### PR TITLE
Factory method for make (fanci) script 

### DIFF
--- a/fanpy/scripts/gaussian/make_fanci_script.py
+++ b/fanpy/scripts/gaussian/make_fanci_script.py
@@ -3,7 +3,7 @@ import os
 import textwrap
 
 from fanpy.scripts.utils import check_inputs, parser
-
+from fanpy.scripts.utils import get_wfn_info
 
 def make_script(  # pylint: disable=R1710,R0912,R0915
     nelec,
@@ -138,176 +138,10 @@ def make_script(  # pylint: disable=R1710,R0912,R0915
     from_imports = [("fanpy.wfn.utils", "convert_to_fanci")]
 
     wfn_type = wfn_type.lower()
-    if wfn_type == "ci_pairs":
-        from_imports.append(("fanpy.wfn.ci.ci_pairs", "CIPairs"))
-        wfn_name = "CIPairs"
-        if wfn_kwargs is None:
-            wfn_kwargs = ""
-    elif wfn_type == "cisd":
-        from_imports.append(("fanpy.wfn.ci.cisd", "CISD"))
-        wfn_name = "CISD"
-        if wfn_kwargs is None:
-            wfn_kwargs = ""
-    elif wfn_type == "fci":
-        from_imports.append(("fanpy.wfn.ci.fci", "FCI"))
-        wfn_name = "FCI"
-        if wfn_kwargs is None:
-            wfn_kwargs = "spin=None"
-    elif wfn_type == "hci":
-        from_imports.append(("fanpy.wfn.ci.hci", "hCI"))
-        wfn_name = "hCI"
-        if wfn_kwargs is None:
-            wfn_kwargs = "alpha1=0.5, alpha2=0.25, hierarchy=1"
-    elif wfn_type == "doci":
-        from_imports.append(("fanpy.wfn.ci.doci", "DOCI"))
-        wfn_name = "DOCI"
-        if wfn_kwargs is None:
-            wfn_kwargs = ""
-    elif wfn_type == "mps":
-        from_imports.append(("fanpy.wfn.network.mps", "MatrixProductState"))
-        wfn_name = "MatrixProductState"
-        if wfn_kwargs is None:
-            wfn_kwargs = "dimension=None"
-    elif wfn_type == "determinant-ratio":
-        from_imports.append(("fanpy.wfn.quasiparticle.det_ratio", "DeterminantRatio"))
-        wfn_name = "DeterminantRatio"
-        if wfn_kwargs is None:
-            wfn_kwargs = "numerator_mask=None"
-    elif wfn_type == "ap1rog":
-        from_imports.append(("fanpy.wfn.geminal.ap1rog", "AP1roG"))
-        wfn_name = "AP1roG"
-        if wfn_kwargs is None:
-            wfn_kwargs = "ref_sd=None, ngem=None"
-    elif wfn_type == "apr2g":
-        from_imports.append(("fanpy.wfn.geminal.apr2g", "APr2G"))
-        wfn_name = "APr2G"
-        if wfn_kwargs is None:
-            wfn_kwargs = "ngem=None"
-    elif wfn_type == "apig":
-        from_imports.append(("fanpy.wfn.geminal.apig", "APIG"))
-        wfn_name = "APIG"
-        if wfn_kwargs is None:
-            wfn_kwargs = "ngem=None"
-    elif wfn_type == "apsetg":
-        from_imports.append(("fanpy.wfn.geminal.apsetg", "BasicAPsetG"))
-        wfn_name = "BasicAPsetG"
-        if wfn_kwargs is None:
-            wfn_kwargs = "ngem=None"
-    elif wfn_type == "apg":  # pragma: no branch
-        from_imports.append(("fanpy.wfn.geminal.apg", "APG"))
-        wfn_name = "APG"
-        if wfn_kwargs is None:
-            wfn_kwargs = "ngem=None"
-    elif wfn_type == "network":
-        from_imports.append(("fanpy.upgrades.numpy_network", "NumpyNetwork"))
-        wfn_name = "NumpyNetwork"
-        if wfn_kwargs is None:
-            wfn_kwargs = "num_layers=2"
-    elif wfn_type == "rbm":
-        from_imports.append(("fanpy.wfn.network.rbm", "RestrictedBoltzmannMachine"))
-        wfn_name = "RestrictedBoltzmannMachine"
-        if wfn_kwargs is None:
-            wfn_kwargs = "nbath=nspin, num_layers=1, orders=(1, 2)"
 
-    elif wfn_type == "basecc":
-        from_imports.append(("fanpy.wfn.cc.base", "BaseCC"))
-        wfn_name = "BaseCC"
-        if wfn_kwargs is None:
-            wfn_kwargs = "ranks=None, indices=None, refwfn=None, exop_combinations=None"
-    elif wfn_type == "standardcc":
-        from_imports.append(("fanpy.wfn.cc.standard_cc", "StandardCC"))
-        wfn_name = "StandardCC"
-        if wfn_kwargs is None:
-            wfn_kwargs = "ranks=None, indices=None, refwfn=None, exop_combinations=None"
-    elif wfn_type == "generalizedcc":
-        from_imports.append(("fanpy.wfn.cc.generalized_cc", "GeneralizedCC"))
-        wfn_name = "GeneralizedCC"
-        if wfn_kwargs is None:
-            wfn_kwargs = "ranks=None, indices=None, refwfn=None, exop_combinations=None"
-    elif wfn_type == "senioritycc":
-        from_imports.append(("fanpy.wfn.cc.seniority", "SeniorityCC"))
-        wfn_name = "SeniorityCC"
-        if wfn_kwargs is None:
-            wfn_kwargs = "ranks=None, indices=None, refwfn=None, exop_combinations=None"
-    elif wfn_type == "pccd":
-        from_imports.append(("fanpy.wfn.cc.pccd_ap1rog", "PCCD"))
-        wfn_name = "PCCD"
-        if wfn_kwargs is None:
-            wfn_kwargs = "ranks=None, indices=None, refwfn=None, exop_combinations=None"
-    elif wfn_type == "ap1rogsd":
-        from_imports.append(("fanpy.wfn.cc.ap1rog_generalized", "AP1roGSDGeneralized"))
-        wfn_name = "AP1roGSDGeneralized"
-        if wfn_kwargs is None:
-            wfn_kwargs = "ranks=None, indices=None, refwfn=None, exop_combinations=None"
-    elif wfn_type == "ap1rogsd_spin":
-        from_imports.append(("fanpy.wfn.cc.ap1rog_spin", "AP1roGSDSpin"))
-        wfn_name = "AP1roGSDSpin"
-        if wfn_kwargs is None:
-            wfn_kwargs = "ranks=None, indices=None, refwfn=None, exop_combinations=None"
-    elif wfn_type == "apsetgd":
-        from_imports.append(("fanpy.wfn.cc.apset1rog_d", "APset1roGD"))
-        wfn_name = "APset1roGD"
-        if wfn_kwargs is None:
-            wfn_kwargs = "ranks=None, indices=None, refwfn=None, exop_combinations=None"
-    elif wfn_type == "apsetgsd":
-        from_imports.append(("fanpy.wfn.cc.apset1rog_sd", "APset1roGSD"))
-        wfn_name = "APset1roGSD"
-        if wfn_kwargs is None:
-            wfn_kwargs = "ranks=None, indices=None, refwfn=None, exop_combinations=None"
-    elif wfn_type == "apg1rod":
-        from_imports.append(("fanpy.wfn.cc.apg1ro_d", "APG1roD"))
-        wfn_name = "APG1roD"
-        if wfn_kwargs is None:
-            wfn_kwargs = "ranks=None, indices=None, refwfn=None, exop_combinations=None"
-    elif wfn_type == "apg1rosd":
-        from_imports.append(("fanpy.wfn.cc.apg1ro_sd", "APG1roSD"))
-        wfn_name = "APG1roSD"
-        if wfn_kwargs is None:
-            wfn_kwargs = "ranks=None, indices=None, refwfn=None, exop_combinations=None"
-    elif wfn_type == "ccsdsen0":
-        from_imports.append(("fanpy.wfn.cc.ccsd_sen0", "CCSDsen0"))
-        wfn_name = "CCSDsen0"
-        if wfn_kwargs is None:
-            wfn_kwargs = "ranks=None, indices=None, refwfn=None, exop_combinations=None"
-    elif wfn_type == "ccsdqsen0":
-        from_imports.append(("fanpy.wfn.cc.ccsdq_sen0", "CCSDQsen0"))
-        wfn_name = "CCSDQsen0"
-        if wfn_kwargs is None:
-            wfn_kwargs = "ranks=None, indices=None, refwfn=None, exop_combinations=None"
-    elif wfn_type == "ccsdtqsen0":
-        from_imports.append(("fanpy.wfn.cc.ccsdtq_sen0", "CCSDTQsen0"))
-        wfn_name = "CCSDTQsen0"
-        if wfn_kwargs is None:
-            wfn_kwargs = "ranks=None, indices=None, refwfn=None, exop_combinations=None"
-    elif wfn_type == "ccsdtsen2qsen0":
-        from_imports.append(("fanpy.wfn.cc.ccsdt_sen2_q_sen0", "CCSDTsen2Qsen0"))
-        wfn_name = "CCSDTsen2Qsen0"
-        if wfn_kwargs is None:
-            wfn_kwargs = "ranks=None, indices=None, refwfn=None, exop_combinations=None"
-    elif wfn_type == "ccs":
-        from_imports.append(("fanpy.wfn.cc.standard_cc", "StandardCC"))
-        wfn_name = "StandardCC"
-        if wfn_kwargs is None:
-            wfn_kwargs = "indices=None, refwfn=None, exop_combinations=None"
-        wfn_kwargs = f"ranks=[1], {wfn_kwargs}"
-    elif wfn_type == "ccsd":
-        from_imports.append(("fanpy.wfn.cc.standard_cc", "StandardCC"))
-        wfn_name = "StandardCC"
-        if wfn_kwargs is None:
-            wfn_kwargs = "indices=None, refwfn=None, exop_combinations=None"
-        wfn_kwargs = f"ranks=[1, 2], {wfn_kwargs}"
-    elif wfn_type == "ccsdt":
-        from_imports.append(("fanpy.wfn.cc.standard_cc", "StandardCC"))
-        wfn_name = "StandardCC"
-        if wfn_kwargs is None:
-            wfn_kwargs = "indices=None, refwfn=None, exop_combinations=None"
-        wfn_kwargs = f"ranks=[1, 2, 3], {wfn_kwargs}"
-    elif wfn_type == "ccsdtq":
-        from_imports.append(("fanpy.wfn.cc.standard_cc", "StandardCC"))
-        wfn_name = "StandardCC"
-        if wfn_kwargs is None:
-            wfn_kwargs = "indices=None, refwfn=None, exop_combinations=None"
-        wfn_kwargs = f"ranks=[1, 2, 3, 4], {wfn_kwargs}"
+    wfn_info = get_wfn_info(wfn_type)
+    import_line, wfn_name, wfn_kwargs = wfn_info(wfn_kwargs)
+    from_imports.append(import_line)
 
     if wfn_name in ["DOCI", "CIPairs"] and not optimize_orbs:
         from_imports.append(("fanpy.ham.senzero", "SeniorityZeroHamiltonian"))

--- a/fanpy/scripts/gaussian/make_fanci_script.py
+++ b/fanpy/scripts/gaussian/make_fanci_script.py
@@ -253,7 +253,10 @@ def make_script(  # pylint: disable=R1710,R0912,R0915
 
     output += "# Initialize wavefunction\n"
     wfn_init1 = "wfn = {}(".format(wfn_name)
-    wfn_init2 = "nelec, nspin, params={}, memory={}, {})\n".format(wfn_params, memory, wfn_kwargs)
+    if len(wfn_kwargs) > 0:
+        wfn_init2 = "nelec, nspin, params={}, memory={}, {})\n".format(wfn_params, memory, wfn_kwargs)
+    else:
+        wfn_init2 = "nelec, nspin, params={}, memory={})\n".format(wfn_params, memory)
     output += "\n".join(
         textwrap.wrap(wfn_init1 + wfn_init2, width=100, subsequent_indent=" " * len(wfn_init1))
     )

--- a/fanpy/scripts/gaussian/make_script.py
+++ b/fanpy/scripts/gaussian/make_script.py
@@ -3,7 +3,7 @@ import os
 import textwrap
 
 from fanpy.scripts.utils import check_inputs, parser
-
+from fanpy.scripts.gaussian.wavefunction_info import get_wfn_info
 
 def make_script(  # pylint: disable=R1710,R0912,R0915
     nelec,
@@ -137,172 +137,10 @@ def make_script(  # pylint: disable=R1710,R0912,R0915
     from_imports = []
 
     wfn_type = wfn_type.lower()
-    if wfn_type == "ci_pairs":
-        from_imports.append(("fanpy.wfn.ci.ci_pairs", "CIPairs"))
-        wfn_name = "CIPairs"
-        if wfn_kwargs is None:
-            wfn_kwargs = ""
-    elif wfn_type == "cisd":
-        from_imports.append(("fanpy.wfn.ci.cisd", "CISD"))
-        wfn_name = "CISD"
-        if wfn_kwargs is None:
-            wfn_kwargs = ""
 
-    elif wfn_type == "hci":
-        from_imports.append(("fanpy.wfn.ci.hci", "hCI"))
-        wfn_name = "hCI"
-        if wfn_kwargs is None:
-            wfn_kwargs = "alpha1=0.5, alpha2=0.25, hierarchy=2.5"
-
-    elif wfn_type == "fci":
-        from_imports.append(("fanpy.wfn.ci.fci", "FCI"))
-        wfn_name = "FCI"
-        if wfn_kwargs is None:
-            wfn_kwargs = "spin=None"
-    elif wfn_type == "doci":
-        from_imports.append(("fanpy.wfn.ci.doci", "DOCI"))
-        wfn_name = "DOCI"
-        if wfn_kwargs is None:
-            wfn_kwargs = ""
-    elif wfn_type == "mps":
-        from_imports.append(("fanpy.wfn.network.mps", "MatrixProductState"))
-        wfn_name = "MatrixProductState"
-        if wfn_kwargs is None:
-            wfn_kwargs = "dimension=None"
-    elif wfn_type == "determinant-ratio":
-        from_imports.append(("fanpy.wfn.quasiparticle.det_ratio", "DeterminantRatio"))
-        wfn_name = "DeterminantRatio"
-        if wfn_kwargs is None:
-            wfn_kwargs = "numerator_mask=None"
-    elif wfn_type == "ap1rog":
-        from_imports.append(("fanpy.wfn.geminal.ap1rog", "AP1roG"))
-        wfn_name = "AP1roG"
-        if wfn_kwargs is None:
-            wfn_kwargs = "ref_sd=None, ngem=None"
-    elif wfn_type == "apr2g":
-        from_imports.append(("fanpy.wfn.geminal.apr2g", "APr2G"))
-        wfn_name = "APr2G"
-        if wfn_kwargs is None:
-            wfn_kwargs = "ngem=None"
-    elif wfn_type == "apig":
-        from_imports.append(("fanpy.wfn.geminal.apig", "APIG"))
-        wfn_name = "APIG"
-        if wfn_kwargs is None:
-            wfn_kwargs = "ngem=None"
-    elif wfn_type == "apsetg":
-        from_imports.append(("fanpy.wfn.geminal.apsetg", "BasicAPsetG"))
-        wfn_name = "BasicAPsetG"
-        if wfn_kwargs is None:
-            wfn_kwargs = "ngem=None"
-    elif wfn_type == "apg":  # pragma: no branch
-        from_imports.append(("fanpy.wfn.geminal.apg", "APG"))
-        wfn_name = "APG"
-        if wfn_kwargs is None:
-            wfn_kwargs = "ngem=None"
-    elif wfn_type == "network":
-        from_imports.append(("fanpy.upgrades.numpy_network", "NumpyNetwork"))
-        wfn_name = "NumpyNetwork"
-        if wfn_kwargs is None:
-            wfn_kwargs = "num_layers=2"
-    elif wfn_type == "rbm":
-        from_imports.append(("fanpy.wfn.network.rbm", "RestrictedBoltzmannMachine"))
-        wfn_name = "RestrictedBoltzmannMachine"
-        if wfn_kwargs is None:
-            wfn_kwargs = "nbath=nspin, num_layers=1, orders=(1, 2)"
-
-    elif wfn_type == "basecc":
-        from_imports.append(("fanpy.wfn.cc.base", "BaseCC"))
-        wfn_name = "BaseCC"
-        if wfn_kwargs is None:
-            wfn_kwargs = "ranks=None, indices=None, refwfn=None, exop_combinations=None"
-    elif wfn_type == "standardcc":
-        from_imports.append(("fanpy.wfn.cc.standard_cc", "StandardCC"))
-        wfn_name = "StandardCC"
-        if wfn_kwargs is None:
-            wfn_kwargs = "ranks=None, indices=None, refwfn=None, exop_combinations=None"
-    elif wfn_type == "generalizedcc":
-        from_imports.append(("fanpy.wfn.cc.generalized_cc", "GeneralizedCC"))
-        wfn_name = "GeneralizedCC"
-        if wfn_kwargs is None:
-            wfn_kwargs = "ranks=None, indices=None, refwfn=None, exop_combinations=None"
-    elif wfn_type == "senioritycc":
-        from_imports.append(("fanpy.wfn.cc.seniority", "SeniorityCC"))
-        wfn_name = "SeniorityCC"
-        if wfn_kwargs is None:
-            wfn_kwargs = "ranks=None, indices=None, refwfn=None, exop_combinations=None"
-    elif wfn_type == "pccd":
-        from_imports.append(("fanpy.wfn.cc.pccd_ap1rog", "PCCD"))
-        wfn_name = "PCCD"
-        if wfn_kwargs is None:
-            wfn_kwargs = "ranks=None, indices=None, refwfn=None, exop_combinations=None"
-    elif wfn_type == "ap1rogsd":
-        from_imports.append(("fanpy.wfn.cc.ap1rog_generalized", "AP1roGSDGeneralized"))
-        wfn_name = "AP1roGSDGeneralized"
-        if wfn_kwargs is None:
-            wfn_kwargs = "ranks=None, indices=None, refwfn=None, exop_combinations=None"
-    elif wfn_type == "ap1rogsd_spin":
-        from_imports.append(("fanpy.wfn.cc.ap1rog_spin", "AP1roGSDSpin"))
-        wfn_name = "AP1roGSDSpin"
-        if wfn_kwargs is None:
-            wfn_kwargs = "ranks=None, indices=None, refwfn=None, exop_combinations=None"
-    elif wfn_type == "apsetgd":
-        from_imports.append(("fanpy.wfn.cc.apset1rog_d", "APset1roGD"))
-        wfn_name = "APset1roGD"
-        if wfn_kwargs is None:
-            wfn_kwargs = "ranks=None, indices=None, refwfn=None, exop_combinations=None"
-    elif wfn_type == "apsetgsd":
-        from_imports.append(("fanpy.wfn.cc.apset1rog_sd", "APset1roGSD"))
-        wfn_name = "APset1roGSD"
-        if wfn_kwargs is None:
-            wfn_kwargs = "ranks=None, indices=None, refwfn=None, exop_combinations=None"
-    elif wfn_type == "apg1rod":
-        from_imports.append(("fanpy.wfn.cc.apg1ro_d", "APG1roD"))
-        wfn_name = "APG1roD"
-        if wfn_kwargs is None:
-            wfn_kwargs = "ranks=None, indices=None, refwfn=None, exop_combinations=None"
-    elif wfn_type == "apg1rosd":
-        from_imports.append(("fanpy.wfn.cc.apg1ro_sd", "APG1roSD"))
-        wfn_name = "APG1roSD"
-        if wfn_kwargs is None:
-            wfn_kwargs = "ranks=None, indices=None, refwfn=None, exop_combinations=None"
-    elif wfn_type == "ccsdsen0":
-        from_imports.append(("fanpy.wfn.cc.ccsd_sen0", "CCSDsen0"))
-        wfn_name = "CCSDsen0"
-        if wfn_kwargs is None:
-            wfn_kwargs = "ranks=None, indices=None, refwfn=None, exop_combinations=None"
-    elif wfn_type == "ccsdqsen0":
-        from_imports.append(("fanpy.wfn.cc.ccsdq_sen0", "CCSDQsen0"))
-        wfn_name = "CCSDQsen0"
-        if wfn_kwargs is None:
-            wfn_kwargs = "ranks=None, indices=None, refwfn=None, exop_combinations=None"
-    elif wfn_type == "ccsdtqsen0":
-        from_imports.append(("fanpy.wfn.cc.ccsdtq_sen0", "CCSDTQsen0"))
-        wfn_name = "CCSDTQsen0"
-        if wfn_kwargs is None:
-            wfn_kwargs = "ranks=None, indices=None, refwfn=None, exop_combinations=None"
-    elif wfn_type == "ccsdtsen2qsen0":
-        from_imports.append(("fanpy.wfn.cc.ccsdt_sen2_q_sen0", "CCSDTsen2Qsen0"))
-        wfn_name = "CCSDTsen2Qsen0"
-        if wfn_kwargs is None:
-            wfn_kwargs = "ranks=None, indices=None, refwfn=None, exop_combinations=None"
-    elif wfn_type == "ccsd":
-        from_imports.append(("fanpy.wfn.cc.standard_cc", "StandardCC"))
-        wfn_name = "StandardCC"
-        if wfn_kwargs is None:
-            wfn_kwargs = "indices=None, refwfn=None, exop_combinations=None"
-        wfn_kwargs = f"ranks=[1, 2], {wfn_kwargs}"
-    elif wfn_type == "ccsdt":
-        from_imports.append(("fanpy.wfn.cc.standard_cc", "StandardCC"))
-        wfn_name = "StandardCC"
-        if wfn_kwargs is None:
-            wfn_kwargs = "indices=None, refwfn=None, exop_combinations=None"
-        wfn_kwargs = f"ranks=[1, 2, 3], {wfn_kwargs}"
-    elif wfn_type == "ccsdtq":
-        from_imports.append(("fanpy.wfn.cc.standard_cc", "StandardCC"))
-        wfn_name = "StandardCC"
-        if wfn_kwargs is None:
-            wfn_kwargs = "indices=None, refwfn=None, exop_combinations=None"
-        wfn_kwargs = f"ranks=[1, 2, 3, 4], {wfn_kwargs}"
+    wfn_info = get_wfn_info(wfn_type)
+    import_line, wfn_name, wfn_kwargs = wfn_info(wfn_kwargs)
+    from_imports.append(import_line)
 
     if wfn_name in ["DOCI", "CIPairs"] and not optimize_orbs:
         from_imports.append(("fanpy.ham.senzero", "SeniorityZeroHamiltonian"))

--- a/fanpy/scripts/gaussian/make_script.py
+++ b/fanpy/scripts/gaussian/make_script.py
@@ -278,7 +278,10 @@ def make_script(  # pylint: disable=R1710,R0912,R0915
 
     output += "# Initialize wavefunction\n"
     wfn_init1 = "wfn = {}(".format(wfn_name)
-    wfn_init2 = "nelec, nspin, params={}, memory={}, {})\n".format(wfn_params, memory, wfn_kwargs)
+    if len(wfn_kwargs) > 0:
+        wfn_init2 = "nelec, nspin, params={}, memory={}, {})\n".format(wfn_params, memory, wfn_kwargs)
+    else:
+        wfn_init2 = "nelec, nspin, params={}, memory={})\n".format(wfn_params, memory)
     output += "\n".join(
         textwrap.wrap(wfn_init1 + wfn_init2, width=100, subsequent_indent=" " * len(wfn_init1))
     )

--- a/fanpy/scripts/gaussian/run_calc.py
+++ b/fanpy/scripts/gaussian/run_calc.py
@@ -1,5 +1,5 @@
 """Script for running calculations."""
-from fanpy.scripts.make_script import make_script
+from fanpy.scripts.gaussian.make_script import make_script
 from fanpy.scripts.utils import parser
 
 

--- a/fanpy/scripts/gaussian/wavefunction_info.py
+++ b/fanpy/scripts/gaussian/wavefunction_info.py
@@ -80,7 +80,9 @@ _get_custom_info(wfn_kwargs)
 
 """
 
-def get_wfn_info(wfn_type):
+from typing import Union
+
+def get_wfn_info(wfn_type: str) -> callable:
     """
     Returns the corresponding wavefunction information function based on the given wavefunction type.
 
@@ -169,10 +171,10 @@ def get_wfn_info(wfn_type):
     elif wfn_type == "custom":
         return _get_custom_info
     else:
-        raise ValueError("Invalid wavefunction type: {}".format(wfn_type))
+        raise ValueError(f"Invalid wavefunction type: {wfn_type}")
 
 
-def _get_ci_pairs_info(wfn_kwargs):
+def _get_ci_pairs_info(wfn_kwargs: Union[str, None]) -> tuple:
     """
     Get the information about the CI pairs.
 
@@ -193,7 +195,7 @@ def _get_ci_pairs_info(wfn_kwargs):
         wfn_kwargs = ""
     return import_line, wfn_name, wfn_kwargs
 
-def _get_cisd_info(wfn_kwargs):
+def _get_cisd_info(wfn_kwargs: Union[str, None]) -> tuple:
     """
     Get the information about CISD.
 
@@ -215,7 +217,7 @@ def _get_cisd_info(wfn_kwargs):
         wfn_kwargs = ""
     return import_line, wfn_name, wfn_kwargs
 
-def _get_hci_info(wfn_kwargs):
+def _get_hci_info(wfn_kwargs: Union[str, None]) -> tuple:
     """
     Get the information about HCI.
 
@@ -236,7 +238,7 @@ def _get_hci_info(wfn_kwargs):
         wfn_kwargs = "alpha1=0.5, alpha2=0.25, hierarchy=2.5"
     return import_line, wfn_name, wfn_kwargs
 
-def _get_fci_info(wfn_kwargs):
+def _get_fci_info(wfn_kwargs: Union[str, None]) -> tuple:
     """
     Get the information about FCI.
 
@@ -257,7 +259,7 @@ def _get_fci_info(wfn_kwargs):
         wfn_kwargs = "spin=None"
     return import_line, wfn_name, wfn_kwargs
 
-def _get_doci_info(wfn_kwargs):
+def _get_doci_info(wfn_kwargs: Union[str, None]) -> tuple:
     """
     Get the information about DOCI.
 
@@ -278,7 +280,7 @@ def _get_doci_info(wfn_kwargs):
         wfn_kwargs = ""
     return import_line, wfn_name, wfn_kwargs
 
-def _get_mps_info(wfn_kwargs):
+def _get_mps_info(wfn_kwargs: Union[str, None]) -> tuple:
     """
     Get the information about MPS.
 
@@ -299,7 +301,7 @@ def _get_mps_info(wfn_kwargs):
         wfn_kwargs = "dimension=None"
     return import_line, wfn_name, wfn_kwargs
 
-def _get_det_ratio_info(wfn_kwargs):
+def _get_det_ratio_info(wfn_kwargs: Union[str, None]) -> tuple:
     """
     Get the information about the DeterminantRatio wavefunction.
 
@@ -320,7 +322,7 @@ def _get_det_ratio_info(wfn_kwargs):
         wfn_kwargs = "numerator_mask=None"
     return import_line, wfn_name, wfn_kwargs
 
-def _get_ap1rog_info(wfn_kwargs):
+def _get_ap1rog_info(wfn_kwargs: Union[str, None]) -> tuple:
     """
     Get the information about the AP1roG wavefunction.
 
@@ -341,7 +343,7 @@ def _get_ap1rog_info(wfn_kwargs):
         wfn_kwargs = "ref_sd=None, ngem=None"
     return import_line, wfn_name, wfn_kwargs
 
-def _get_apr2g_info(wfn_kwargs):
+def _get_apr2g_info(wfn_kwargs: Union[str, None]) -> tuple:
     """
     Get the information about the APr2G wavefunction.
 
@@ -362,7 +364,7 @@ def _get_apr2g_info(wfn_kwargs):
         wfn_kwargs = "ngem=None"
     return import_line, wfn_name, wfn_kwargs
 
-def _get_apig_info(wfn_kwargs):
+def _get_apig_info(wfn_kwargs: Union[str, None]) -> tuple:
     """
     Get the information about the APIG wavefunction.
 
@@ -383,7 +385,7 @@ def _get_apig_info(wfn_kwargs):
         wfn_kwargs = "ngem=None"
     return import_line, wfn_name, wfn_kwargs
 
-def _get_apsetg_info(wfn_kwargs):
+def _get_apsetg_info(wfn_kwargs: Union[str, None]) -> tuple:
     """
     Get the information about the APsetG wavefunction.
 
@@ -404,7 +406,7 @@ def _get_apsetg_info(wfn_kwargs):
         wfn_kwargs = "ngem=None"
     return import_line, wfn_name, wfn_kwargs
 
-def _get_apg_info(wfn_kwargs):
+def _get_apg_info(wfn_kwargs: Union[str, None]) -> tuple:
     """
     Get the information about the APG wavefunction.
 
@@ -425,7 +427,7 @@ def _get_apg_info(wfn_kwargs):
         wfn_kwargs = "ngem=None"
     return import_line, wfn_name, wfn_kwargs
 
-def _get_network_info(wfn_kwargs):
+def _get_network_info(wfn_kwargs: Union[str, None]) -> tuple:
     """
     Get the information about the network wavefunction.
 
@@ -446,7 +448,7 @@ def _get_network_info(wfn_kwargs):
         wfn_kwargs = "num_layers=2"
     return import_line, wfn_name, wfn_kwargs
 
-def _get_rbm_info(wfn_kwargs):
+def _get_rbm_info(wfn_kwargs: Union[str, None]) -> tuple:
     """
     Get the information about the restricted Boltzmann machine wavefunction.
 
@@ -467,7 +469,7 @@ def _get_rbm_info(wfn_kwargs):
         wfn_kwargs = "nbath=nspin, num_layers=1, orders=(1, 2)"
     return import_line, wfn_name, wfn_kwargs
 
-def _get_basecc_info(wfn_kwargs):
+def _get_basecc_info(wfn_kwargs: Union[str, None]) -> tuple:
     """
     Get information about the BaseCC wavefunction.
 
@@ -488,7 +490,7 @@ def _get_basecc_info(wfn_kwargs):
         wfn_kwargs = "ranks=None, indices=None, refwfn=None, exop_combinations=None"
     return import_line, wfn_name, wfn_kwargs
 
-def _get_standardcc_info(wfn_kwargs):
+def _get_standardcc_info(wfn_kwargs: Union[str, None]) -> tuple:
     """
     Get information about the StandardCC wavefunction.
 
@@ -509,7 +511,7 @@ def _get_standardcc_info(wfn_kwargs):
         wfn_kwargs = "ranks=None, indices=None, refwfn=None, exop_combinations=None"
     return import_line, wfn_name, wfn_kwargs
 
-def _get_generalizedcc_info(wfn_kwargs):
+def _get_generalizedcc_info(wfn_kwargs: Union[str, None]) -> tuple:
     """
     Get information about the GeneralizedCC wavefunction.
 
@@ -530,7 +532,7 @@ def _get_generalizedcc_info(wfn_kwargs):
         wfn_kwargs = "ranks=None, indices=None, refwfn=None, exop_combinations=None"
     return import_line, wfn_name, wfn_kwargs
 
-def _get_senioritycc_info(wfn_kwargs):
+def _get_senioritycc_info(wfn_kwargs: Union[str, None]) -> tuple:
     """
     Get information about the SeniorityCC wavefunction.
 
@@ -551,7 +553,7 @@ def _get_senioritycc_info(wfn_kwargs):
         wfn_kwargs = "ranks=None, indices=None, refwfn=None, exop_combinations=None"
     return import_line, wfn_name, wfn_kwargs
 
-def _get_pccd_info(wfn_kwargs):
+def _get_pccd_info(wfn_kwargs: Union[str, None]) -> tuple:
     """
     Get information about the PCCD wavefunction.
 
@@ -572,7 +574,7 @@ def _get_pccd_info(wfn_kwargs):
         wfn_kwargs = "ranks=None, indices=None, refwfn=None, exop_combinations=None"
     return import_line, wfn_name, wfn_kwargs
 
-def _get_ap1rogsd_info(wfn_kwargs):
+def _get_ap1rogsd_info(wfn_kwargs: Union[str, None]) -> tuple:
     """
     Get information about the AP1roGSD wavefunction.
 
@@ -593,7 +595,7 @@ def _get_ap1rogsd_info(wfn_kwargs):
         wfn_kwargs = "ranks=None, indices=None, refwfn=None, exop_combinations=None"
     return import_line, wfn_name, wfn_kwargs
 
-def _get_ap1rogsd_spin_info(wfn_kwargs):
+def _get_ap1rogsd_spin_info(wfn_kwargs: Union[str, None]) -> tuple:
     """
     Get information about the AP1roGSDSpin wavefunction.
 
@@ -614,7 +616,7 @@ def _get_ap1rogsd_spin_info(wfn_kwargs):
         wfn_kwargs = "ranks=None, indices=None, refwfn=None, exop_combinations=None"
     return import_line, wfn_name, wfn_kwargs
 
-def _get_apsetgd_info(wfn_kwargs):
+def _get_apsetgd_info(wfn_kwargs: Union[str, None]) -> tuple:
     """
     Get information about the APset1roGD wavefunction.
 
@@ -635,7 +637,7 @@ def _get_apsetgd_info(wfn_kwargs):
         wfn_kwargs = "ranks=None, indices=None, refwfn=None, exop_combinations=None"
     return import_line, wfn_name, wfn_kwargs
 
-def _get_apsetgsd_info(wfn_kwargs):
+def _get_apsetgsd_info(wfn_kwargs: Union[str, None]) -> tuple:
     """
     Get information about the APset1roGSD wavefunction.
 
@@ -656,7 +658,7 @@ def _get_apsetgsd_info(wfn_kwargs):
         wfn_kwargs = "ranks=None, indices=None, refwfn=None, exop_combinations=None"
     return import_line, wfn_name, wfn_kwargs
 
-def _get_apg1rod_info(wfn_kwargs):
+def _get_apg1rod_info(wfn_kwargs: Union[str, None]) -> tuple:
     """
     Get information about the APG1roD wavefunction.
 
@@ -677,7 +679,7 @@ def _get_apg1rod_info(wfn_kwargs):
         wfn_kwargs = "ranks=None, indices=None, refwfn=None, exop_combinations=None"
     return import_line, wfn_name, wfn_kwargs
 
-def _get_apg1rosd_info(wfn_kwargs):
+def _get_apg1rosd_info(wfn_kwargs: Union[str, None]) -> tuple:
     """
     Get information about the APG1roSD wavefunction.
 
@@ -698,7 +700,7 @@ def _get_apg1rosd_info(wfn_kwargs):
         wfn_kwargs = "ranks=None, indices=None, refwfn=None, exop_combinations=None"
     return import_line, wfn_name, wfn_kwargs
 
-def _get_ccsdsen0_info(wfn_kwargs):
+def _get_ccsdsen0_info(wfn_kwargs: Union[str, None]) -> tuple:
     """
     Get information about the CCSDsen0 wavefunction.
 
@@ -719,7 +721,7 @@ def _get_ccsdsen0_info(wfn_kwargs):
         wfn_kwargs = "ranks=None, indices=None, refwfn=None, exop_combinations=None"
     return import_line, wfn_name, wfn_kwargs
 
-def _get_ccsdqsen0_info(wfn_kwargs):
+def _get_ccsdqsen0_info(wfn_kwargs: Union[str, None]) -> tuple:
     """
     Get information about the CCSDQsen0 wavefunction.
 
@@ -740,7 +742,7 @@ def _get_ccsdqsen0_info(wfn_kwargs):
         wfn_kwargs = "ranks=None, indices=None, refwfn=None, exop_combinations=None"
     return import_line, wfn_name, wfn_kwargs
 
-def _get_ccsdtqsen0_info(wfn_kwargs):
+def _get_ccsdtqsen0_info(wfn_kwargs: Union[str, None]) -> tuple:
     """
     Get information about the CCSDTQsen0 wavefunction.
 
@@ -761,7 +763,7 @@ def _get_ccsdtqsen0_info(wfn_kwargs):
         wfn_kwargs = "ranks=None, indices=None, refwfn=None, exop_combinations=None"
     return import_line, wfn_name, wfn_kwargs
 
-def _get_ccsdtsen2qsen0_info(wfn_kwargs):
+def _get_ccsdtsen2qsen0_info(wfn_kwargs: Union[str, None]) -> tuple:
     """
     Get information about the CCSDTsen2Qsen0 wavefunction.
 
@@ -782,7 +784,7 @@ def _get_ccsdtsen2qsen0_info(wfn_kwargs):
         wfn_kwargs = "ranks=None, indices=None, refwfn=None, exop_combinations=None"
     return import_line, wfn_name, wfn_kwargs
 
-def _get_ccsd_info(wfn_kwargs):
+def _get_ccsd_info(wfn_kwargs: Union[str, None]) -> tuple:
     """
     Get information about the CCSD wavefunction.
 
@@ -804,7 +806,7 @@ def _get_ccsd_info(wfn_kwargs):
     wfn_kwargs = f"ranks=[1, 2], {wfn_kwargs}"
     return import_line, wfn_name, wfn_kwargs
 
-def _get_ccsdt_info(wfn_kwargs):
+def _get_ccsdt_info(wfn_kwargs: Union[str, None]) -> tuple:
     """
     Get information about the CCSDT wavefunction.
 
@@ -826,7 +828,7 @@ def _get_ccsdt_info(wfn_kwargs):
     wfn_kwargs = f"ranks=[1, 2, 3], {wfn_kwargs}"
     return import_line, wfn_name, wfn_kwargs
 
-def _get_ccsdtq_info(wfn_kwargs):
+def _get_ccsdtq_info(wfn_kwargs: Union[str, None]) -> tuple:
     """
     Get information about the CCSDTQ wavefunction.
 
@@ -848,7 +850,7 @@ def _get_ccsdtq_info(wfn_kwargs):
     wfn_kwargs = f"ranks=[1, 2, 3, 4], {wfn_kwargs}"
     return import_line, wfn_name, wfn_kwargs
 
-def _get_ccs_info(wfn_kwargs):
+def _get_ccs_info(wfn_kwargs: Union[str, None]) -> tuple:
     """
     Get information about the CCS wavefunction.
 
@@ -870,14 +872,14 @@ def _get_ccs_info(wfn_kwargs):
     wfn_kwargs = f"ranks=[1], {wfn_kwargs}"
     return import_line, wfn_name, wfn_kwargs
 
-def _get_custom_info(wfn_kwargs):
+def _get_custom_info(wfn_kwargs: Union[str, None]) -> tuple:
     """
     Get information about the custom wavefunction.
 
     Parameters
     ----------
     wfn_kwargs : str
-        Keyword arguments for the custom wavefunction. Must contain "import_line" and "wfn_name".
+        Keyword arguments for the custom wavefunction. Must contain "import_from" and "wfn_name".
 
     Returns
     -------
@@ -887,19 +889,19 @@ def _get_custom_info(wfn_kwargs):
     Raises
     ------
     ValueError
-        If the wfn_kwargs is not a string or does not contain "import_line" and "wfn_name".
+        If the wfn_kwargs is not a string or does not contain "import_from" and "wfn_name".
     """
     if type(wfn_kwargs) is not str:
         raise ValueError("wfn_kwargs for custom wavefunction must be a string.")
-    if "import_line" not in wfn_kwargs:
-        raise ValueError("Custom wavefunction must specify import_line.")
+    if "import_from" not in wfn_kwargs:
+        raise ValueError("import_form not found in wfn_kwargs. Custom wavefunction must specify where to import from.")
     if "wfn_name" not in wfn_kwargs:
-        raise ValueError("Custom wavefunction must specify wfn_name.")
+        raise ValueError("wfn_name not found in wfn_kwargs. Custom wavefunction must specify name of wavefunction.")
     
     wfn_kwarg_list = wfn_kwargs.split(",")
     output_wfn_kwargs = ""
     for kwarg in wfn_kwarg_list:
-        if "import_line" in kwarg:
+        if "import_from" in kwarg:
             import_line = kwarg.split("=")[1]
             import_line = import_line.strip()
         elif "wfn_name" in kwarg:

--- a/fanpy/scripts/gaussian/wavefunction_info.py
+++ b/fanpy/scripts/gaussian/wavefunction_info.py
@@ -1,0 +1,887 @@
+"""Factory for importing and initializing wavefunction classes.
+
+This module provides a factory function `get_wfn_info` that takes a wavefunction type as input and returns the corresponding 
+private function.
+
+Methods
+-------
+get_wfn_info(wfn_type)
+    Returns the private function for the given wavefunction type. All private functions return 
+    the import line, wavefunction name, and wavefunction arguments for their wavefunction type.
+
+Private Functions
+-----------------
+_get_ci_pairs_info(wfn_kwargs)
+    Returns the import line, wavefunction name, and wavefunction arguments for the "ci_pairs" wavefunction type.
+_get_cisd_info(wfn_kwargs)
+    Returns the import line, wavefunction name, and wavefunction arguments for the "cisd" wavefunction type.
+_get_hci_info(wfn_kwargs)
+    Returns the import line, wavefunction name, and wavefunction arguments for the "hci" wavefunction type.
+_get_fci_info(wfn_kwargs)
+    Returns the import line, wavefunction name, and wavefunction arguments for the "fci" wavefunction type.
+_get_doci_info(wfn_kwargs)
+    Returns the import line, wavefunction name, and wavefunction arguments for the "doci" wavefunction type.
+_get_mps_info(wfn_kwargs)
+    Returns the import line, wavefunction name, and wavefunction arguments for the "mps" wavefunction type.
+_get_det_ratio_info(wfn_kwargs)
+    Returns the import line, wavefunction name, and wavefunction arguments for the "determinant-ratio" wavefunction type.
+_get_ap1rog_info(wfn_kwargs)
+    Returns the import line, wavefunction name, and wavefunction arguments for the "ap1rog" wavefunction type.
+_get_apr2g_info(wfn_kwargs)
+    Returns the import line, wavefunction name, and wavefunction arguments for the "apr2g" wavefunction type.
+_get_apig_info(wfn_kwargs)
+    Returns the import line, wavefunction name, and wavefunction arguments for the "apig" wavefunction type.
+_get_apsetg_info(wfn_kwargs)
+    Returns the import line, wavefunction name, and wavefunction arguments for the "apsetg" wavefunction type.
+_get_apg_info(wfn_kwargs)
+    Returns the import line, wavefunction name, and wavefunction arguments for the "apg" wavefunction type.
+_get_network_info(wfn_kwargs)
+    Returns the import line, wavefunction name, and wavefunction arguments for the "network" wavefunction type.
+_get_rbm_info(wfn_kwargs)
+    Returns the import line, wavefunction name, and wavefunction arguments for the "rbm" wavefunction type.
+_get_basecc_info(wfn_kwargs)
+    Returns the import line, wavefunction name, and wavefunction arguments for the "basecc" wavefunction type.
+_get_standardcc_info(wfn_kwargs)
+    Returns the import line, wavefunction name, and wavefunction arguments for the "standardcc" wavefunction type.
+_get_generalizedcc_info(wfn_kwargs)
+    Returns the import line, wavefunction name, and wavefunction arguments for the "generalizedcc" wavefunction type.
+_get_senioritycc_info(wfn_kwargs)
+    Returns the import line, wavefunction name, and wavefunction arguments for the "senioritycc" wavefunction type.
+_get_pccd_info(wfn_kwargs)
+    Returns the import line, wavefunction name, and wavefunction arguments for the "pccd" wavefunction type.
+_get_ap1rogsd_info(wfn_kwargs)
+    Returns the import line, wavefunction name, and wavefunction arguments for the "ap1rogsd" wavefunction type.
+_get_ap1rogsd_spin_info(wfn_kwargs)
+    Returns the import line, wavefunction name, and wavefunction arguments for the "ap1rogsd_spin" wavefunction type.
+_get_apsetgd_info(wfn_kwargs)
+    Returns the import line, wavefunction name, and wavefunction arguments for the "apsetgd" wavefunction type.
+_get_apsetgsd_info(wfn_kwargs)
+    Returns the import line, wavefunction name, and wavefunction arguments for the "apsetgsd" wavefunction type.
+_get_apg1rod_info(wfn_kwargs)
+    Returns the import line, wavefunction name, and wavefunction arguments for the "apg1rod" wavefunction type.
+_get_apg1rosd_info(wfn_kwargs)
+    Returns the import line, wavefunction name, and wavefunction arguments for the "apg1rosd" wavefunction type.
+_get_ccsdsen0_info(wfn_kwargs)
+    Returns the import line, wavefunction name, and wavefunction arguments for the "ccsdsen0" wavefunction type.
+_get_ccsdqsen0_info(wfn_kwargs)
+    Returns the import line, wavefunction name, and wavefunction arguments for the "ccsdqsen0" wavefunction type.
+_get_ccsdtqsen0_info(wfn_kwargs)
+    Returns the import line, wavefunction name, and wavefunction arguments for the "ccsdtqsen0" wavefunction type.
+_get_ccsdtsen2qsen0_info(wfn_kwargs)
+    Returns the import line, wavefunction name, and wavefunction arguments for the "ccsdtsen2qsen0" wavefunction type.
+_get_ccsd_info(wfn_kwargs)
+    Returns the import line, wavefunction name, and wavefunction arguments for the "ccsd" wavefunction type.
+_get_ccsdt_info(wfn_kwargs)
+    Returns the import line, wavefunction name, and wavefunction arguments for the "ccsdt" wavefunction type.
+_get_ccsdtq_info(wfn_kwargs)
+    Returns the import line, wavefunction name, and wavefunction arguments for the "ccsdtq" wavefunction type.
+_get_custom_info(wfn_kwargs)
+    Returns the import line, wavefunction name, and wavefunction arguments for the "custom" wavefunction type.
+
+"""
+
+def get_wfn_info(wfn_type):
+    """
+    Returns the corresponding wavefunction information function based on the given wavefunction type.
+
+    Parameters
+    ----------
+    wfn_type : str
+        The type of wavefunction.
+
+    Returns
+    -------
+    function : function
+        The wavefunction information function corresponding to the given wavefunction type.
+
+    Raises 
+    ------
+    ValueError
+        If the given wavefunction type is invalid.
+    """
+
+    if wfn_type == "ci_pairs":
+        return _get_ci_pairs_info
+    elif wfn_type == "cisd":
+        return _get_cisd_info
+    elif wfn_type == "hci":
+        return _get_hci_info
+    elif wfn_type == "fci":
+        return _get_fci_info
+    elif wfn_type == "doci":
+        return _get_doci_info
+    elif wfn_type == "mps":
+        return _get_mps_info
+    elif wfn_type == "determinant-ratio":
+        return _get_det_ratio_info
+    elif wfn_type == "ap1rog":
+        return _get_ap1rog_info
+    elif wfn_type == "apr2g":
+        return _get_apr2g_info
+    elif wfn_type == "apig":
+        return _get_apig_info
+    elif wfn_type == "apsetg":
+        return _get_apsetg_info
+    elif wfn_type == "apg":
+        return _get_apg_info
+    elif wfn_type == "network": 
+        return _get_network_info
+    elif wfn_type == "rbm":
+        return _get_rbm_info
+    elif wfn_type == "basecc":
+        return _get_basecc_info
+    elif wfn_type == "standardcc":
+        return _get_standardcc_info
+    elif wfn_type == "generalizedcc":
+        return _get_generalizedcc_info
+    elif wfn_type == "senioritycc":
+        return _get_senioritycc_info
+    elif wfn_type == "pccd":
+        return _get_pccd_info
+    elif wfn_type == "ap1rogsd":
+        return _get_ap1rogsd_info
+    elif wfn_type == "ap1rogsd_spin":
+        return _get_ap1rogsd_spin_info
+    elif wfn_type == "apsetgd":
+        return _get_apsetgd_info
+    elif wfn_type == "apsetgsd":
+        return _get_apsetgsd_info
+    elif wfn_type == "apg1rod":
+        return _get_apg1rod_info
+    elif wfn_type == "apg1rosd":
+        return _get_apg1rosd_info
+    elif wfn_type == "ccsdsen0":
+        return _get_ccsdsen0_info
+    elif wfn_type == "ccsdqsen0":
+        return _get_ccsdqsen0_info
+    elif wfn_type == "ccsdtqsen0":
+        return _get_ccsdtqsen0_info
+    elif wfn_type == "ccsdtsen2qsen0":
+        return _get_ccsdtsen2qsen0_info
+    elif wfn_type == "ccsd":
+        return _get_ccsd_info
+    elif wfn_type == "ccsdt":
+        return _get_ccsdt_info
+    elif wfn_type == "ccsdtq":
+        return _get_ccsdtq_info
+    elif wfn_type == "custom":
+        return _get_custom_info
+    else:
+        raise ValueError("Invalid wavefunction type: {}".format(wfn_type))
+
+
+def _get_ci_pairs_info(wfn_kwargs):
+    """
+    Get the information about the CI pairs.
+
+    Parameters
+    ----------
+    wfn_kwargs : str, None
+        Additional keyword arguments for the CI pairs.
+
+    Returns
+    -------
+    results : tuple
+        A tuple containing the import line, the name of the CI pairs class, and the additional keyword arguments.
+    """
+
+    import_line = ("fanpy.wfn.ci.ci_pairs", "CIPairs")
+    wfn_name = "CIPairs"
+    if wfn_kwargs is None:
+        wfn_kwargs = ""
+    return import_line, wfn_name, wfn_kwargs
+
+def _get_cisd_info(wfn_kwargs):
+    """
+    Get the information about CISD.
+
+    Parameters
+    ----------
+    wfn_kwargs : str, None
+        Additional keyword arguments for CISD.
+
+    Returns
+    -------
+    results : tuple
+        A tuple containing the import line, the name of the CISD class, and the additional keyword arguments.
+
+    """
+
+    import_line = ("fanpy.wfn.ci.cisd", "CISD")
+    wfn_name = "CISD"
+    if wfn_kwargs is None:
+        wfn_kwargs = ""
+    return import_line, wfn_name, wfn_kwargs
+
+def _get_hci_info(wfn_kwargs):
+    """
+    Get the information about HCI.
+
+    Parameters
+    ----------
+    wfn_kwargs : str, None
+        Additional keyword arguments for HCI.
+
+    Returns
+    -------
+    results : tuple
+        A tuple containing the import line, the name of the HCI class, and the additional keyword arguments.
+    """
+
+    import_line = ("fanpy.wfn.ci.hci", "hCI")
+    wfn_name = "hCI"
+    if wfn_kwargs is None:
+        wfn_kwargs = "alpha1=0.5, alpha2=0.25, hierarchy=2.5"
+    return import_line, wfn_name, wfn_kwargs
+
+def _get_fci_info(wfn_kwargs):
+    """
+    Get the information about FCI.
+
+    Parameters
+    ----------
+    wfn_kwargs : str, None
+        Additional keyword arguments for FCI.
+    
+    Returns
+    -------
+    results : tuple
+        A tuple containing the import line, the name of the FCI class, and the additional keyword arguments.
+    """
+
+    import_line = ("fanpy.wfn.ci.fci", "FCI")
+    wfn_name = "FCI"
+    if wfn_kwargs is None:
+        wfn_kwargs = "spin=None"
+    return import_line, wfn_name, wfn_kwargs
+
+def _get_doci_info(wfn_kwargs):
+    """
+    Get the information about DOCI.
+
+    Parameters
+    ----------
+    wfn_kwargs : str, None
+        Additional keyword arguments for DOCI.
+    
+    Returns
+    -------
+    results : tuple
+        A tuple containing the import line, the name of the DOCI class, and the additional keyword arguments.
+    """
+
+    import_line = ("fanpy.wfn.ci.doci", "DOCI")
+    wfn_name = "DOCI"
+    if wfn_kwargs is None:
+        wfn_kwargs = ""
+    return import_line, wfn_name, wfn_kwargs
+
+def _get_mps_info(wfn_kwargs):
+    """
+    Get the information about MPS.
+
+    Parameters
+    ----------
+    wfn_kwargs : str, None
+        Additional keyword arguments for MPS.
+
+    Returns
+    -------
+    results : tuple
+        A tuple containing the import line, the name of the MPS class, and the additional keyword arguments.
+    """
+
+    import_line = ("fanpy.wfn.network.mps", "MatrixProductState")
+    wfn_name = "MatrixProductState"
+    if wfn_kwargs is None:
+        wfn_kwargs = "dimension=None"
+    return import_line, wfn_name, wfn_kwargs
+
+def _get_det_ratio_info(wfn_kwargs):
+    """
+    Get the information about the DeterminantRatio wavefunction.
+
+    Parameters
+    ----------
+    wfn_kwargs : str, None
+        Additional keyword arguments for the DeterminantRatio wavefunction.
+
+    Returns
+    -------
+    results : tuple
+        A tuple containing the import line, the name of the DeterminantRatio class, and the additional keyword arguments.
+    """
+
+    import_line = ("fanpy.wfn.quasiparticle.det_ratio", "DeterminantRatio")
+    wfn_name = "DeterminantRatio"
+    if wfn_kwargs is None:
+        wfn_kwargs = "numerator_mask=None"
+    return import_line, wfn_name, wfn_kwargs
+
+def _get_ap1rog_info(wfn_kwargs):
+    """
+    Get the information about the AP1roG wavefunction.
+
+    Parameters
+    ----------
+    wfn_kwargs : str, None
+        Additional keyword arguments for the AP1roG wavefunction.
+
+    Returns
+    -------
+    results : tuple
+        A tuple containing the import line, the name of the AP1roG class, and the additional keyword arguments.
+    """
+
+    import_line = ("fanpy.wfn.geminal.ap1rog", "AP1roG")
+    wfn_name = "AP1roG"
+    if wfn_kwargs is None:
+        wfn_kwargs = "ref_sd=None, ngem=None"
+    return import_line, wfn_name, wfn_kwargs
+
+def _get_apr2g_info(wfn_kwargs):
+    """
+    Get the information about the APr2G wavefunction.
+
+    Parameters
+    ----------
+    wfn_kwargs : str, None
+        Additional keyword arguments for the APr2G wavefunction.
+
+    Returns
+    -------
+    results : tuple
+        A tuple containing the import line, the name of the APr2G class, and the additional keyword arguments.
+    """
+
+    import_line = ("fanpy.wfn.geminal.apr2g", "APr2G")
+    wfn_name = "APr2G"
+    if wfn_kwargs is None:
+        wfn_kwargs = "ngem=None"
+    return import_line, wfn_name, wfn_kwargs
+
+def _get_apig_info(wfn_kwargs):
+    """
+    Get the information about the APIG wavefunction.
+
+    Parameters
+    ----------
+    wfn_kwargs : str, None
+        Additional keyword arguments for the APIG wavefunction.
+
+    Returns
+    -------
+    results : tuple
+        A tuple containing the import line, the name of the APIG class, and the additional keyword arguments.
+    """
+
+    import_line = ("fanpy.wfn.geminal.apig", "APIG")
+    wfn_name = "APIG"
+    if wfn_kwargs is None:
+        wfn_kwargs = "ngem=None"
+    return import_line, wfn_name, wfn_kwargs
+
+def _get_apsetg_info(wfn_kwargs):
+    """
+    Get the information about the APsetG wavefunction.
+
+    Parameters
+    ----------
+    wfn_kwargs : str, None    
+        Additional keyword arguments for the APsetG wavefunction.
+
+    Returns
+    -------
+    results : tuple
+        A tuple containing the import line, the name of the APsetG class, and the additional keyword arguments.
+    """
+
+    import_line = ("fanpy.wfn.geminal.apsetg", "BasicAPsetG")
+    wfn_name = "BasicAPsetG"
+    if wfn_kwargs is None:
+        wfn_kwargs = "ngem=None"
+    return import_line, wfn_name, wfn_kwargs
+
+def _get_apg_info(wfn_kwargs):
+    """
+    Get the information about the APG wavefunction.
+
+    Parameters
+    ----------
+    wfn_kwargs : str, None
+        Additional keyword arguments for the APG wavefunction.
+
+    Returns
+    -------
+    results : tuple
+        A tuple containing the import line, the name of the APG class, and the additional keyword arguments.
+    """
+
+    import_line = ("fanpy.wfn.geminal.apg", "APG")
+    wfn_name = "APG"
+    if wfn_kwargs is None:
+        wfn_kwargs = "ngem=None"
+    return import_line, wfn_name, wfn_kwargs
+
+def _get_network_info(wfn_kwargs):
+    """
+    Get the information about the network wavefunction.
+
+    Parameters
+    ----------
+    wfn_kwargs : str, None
+        Additional keyword arguments for the network wavefunction.
+
+    Returns
+    -------
+    results : tuple
+        A tuple containing the import line, the name of the network class, and the additional keyword arguments.
+    """
+
+    import_line = ("fanpy.upgrades.numpy_network", "NumpyNetwork")
+    wfn_name = "NumpyNetwork"
+    if wfn_kwargs is None:
+        wfn_kwargs = "num_layers=2"
+    return import_line, wfn_name, wfn_kwargs
+
+def _get_rbm_info(wfn_kwargs):
+    """
+    Get the information about the restricted Boltzmann machine wavefunction.
+
+    Parameters
+    ----------
+    wfn_kwargs : str, None
+        Additional keyword arguments for the restricted Boltzmann machine wavefunction.
+
+    Returns
+    -------
+    results : tuple
+        A tuple containing the import line, the name of the restricted Boltzmann machine class, and the additional keyword arguments.
+    """
+
+    import_line = ("fanpy.wfn.network.rbm_standard", "RestrictedBoltzmannMachine")
+    wfn_name = "RestrictedBoltzmannMachine"
+    if wfn_kwargs is None:
+        wfn_kwargs = "nbath=nspin, num_layers=1, orders=(1, 2)"
+    return import_line, wfn_name, wfn_kwargs
+
+def _get_basecc_info(wfn_kwargs):
+    """
+    Get information about the BaseCC wavefunction.
+
+    Parameters
+    ----------
+    wfn_kwargs : str, None 
+        Keyword arguments for the BaseCC wavefunction.
+
+    Returns
+    -------
+    results : tuple
+        A tuple containing the import line, wavefunction name, and keyword arguments.
+    """
+
+    import_line = ("fanpy.wfn.cc.base", "BaseCC")
+    wfn_name = "BaseCC"
+    if wfn_kwargs is None:
+        wfn_kwargs = "ranks=None, indices=None, refwfn=None, exop_combinations=None"
+    return import_line, wfn_name, wfn_kwargs
+
+def _get_standardcc_info(wfn_kwargs):
+    """
+    Get information about the StandardCC wavefunction.
+
+    Parameters
+    ----------
+    wfn_kwargs : str, None
+        Keyword arguments for the StandardCC wavefunction.
+
+    Returns
+    -------
+    results : tuple
+        A tuple containing the import line, wavefunction name, and keyword arguments.
+    """
+
+    import_line = ("fanpy.wfn.cc.standard_cc", "StandardCC")
+    wfn_name = "StandardCC"
+    if wfn_kwargs is None:
+        wfn_kwargs = "ranks=None, indices=None, refwfn=None, exop_combinations=None"
+    return import_line, wfn_name, wfn_kwargs
+
+def _get_generalizedcc_info(wfn_kwargs):
+    """
+    Get information about the GeneralizedCC wavefunction.
+
+    Parameters
+    ----------
+    wfn_kwargs : str, None
+        Keyword arguments for the GeneralizedCC wavefunction.
+
+    Returns
+    -------
+    results : tuple
+        A tuple containing the import line, wavefunction name, and keyword arguments.
+    """
+
+    import_line = ("fanpy.wfn.cc.generalized_cc", "GeneralizedCC")
+    wfn_name = "GeneralizedCC"
+    if wfn_kwargs is None:
+        wfn_kwargs = "ranks=None, indices=None, refwfn=None, exop_combinations=None"
+    return import_line, wfn_name, wfn_kwargs
+
+def _get_senioritycc_info(wfn_kwargs):
+    """
+    Get information about the SeniorityCC wavefunction.
+
+    Parameters
+    ----------
+    wfn_kwargs : str, None
+        Keyword arguments for the SeniorityCC wavefunction.
+
+    Returns
+    -------
+    results : tuple
+        A tuple containing the import line, wavefunction name, and keyword arguments.
+    """
+
+    import_line = ("fanpy.wfn.cc.seniority_cc", "SeniorityCC")
+    wfn_name = "SeniorityCC"
+    if wfn_kwargs is None:
+        wfn_kwargs = "ranks=None, indices=None, refwfn=None, exop_combinations=None"
+    return import_line, wfn_name, wfn_kwargs
+
+def _get_pccd_info(wfn_kwargs):
+    """
+    Get information about the PCCD wavefunction.
+
+    Parameters
+    ----------
+    wfn_kwargs : str, None
+        Keyword arguments for the PCCD wavefunction.
+
+    Returns
+    -------
+    results : tuple
+        A tuple containing the import line, wavefunction name, and keyword arguments.
+    """
+
+    import_line = ("fanpy.wfn.cc.pccd_ap1rog", "PCCD")
+    wfn_name = "PCCD"
+    if wfn_kwargs is None:
+        wfn_kwargs = "ranks=None, indices=None, refwfn=None, exop_combinations=None"
+    return import_line, wfn_name, wfn_kwargs
+
+def _get_ap1rogsd_info(wfn_kwargs):
+    """
+    Get information about the AP1roGSD wavefunction.
+
+    Parameters
+    ----------
+    wfn_kwargs : str, None
+        Keyword arguments for the AP1roGSD wavefunction.
+
+    Returns
+    -------
+    results : tuple
+        A tuple containing the import line, wavefunction name, and keyword arguments.
+    """
+
+    import_line = ("fanpy.wfn.cc.ap1rog_generalized", "AP1roGSDGeneralized")
+    wfn_name = "AP1roGSDGeneralized"
+    if wfn_kwargs is None:
+        wfn_kwargs = "ranks=None, indices=None, refwfn=None, exop_combinations=None"
+    return import_line, wfn_name, wfn_kwargs
+
+def _get_ap1rogsd_spin_info(wfn_kwargs):
+    """
+    Get information about the AP1roGSDSpin wavefunction.
+
+    Parameters
+    ----------
+    wfn_kwargs : str, None
+        Keyword arguments for the AP1roGSDSpin wavefunction.
+
+    Returns
+    -------
+    results : tuple
+        A tuple containing the import line, wavefunction name, and keyword arguments.
+    """
+
+    import_line = ("fanpy.wfn.cc.ap1rog_spin", "AP1roGSDSpin")
+    wfn_name = "AP1roGSDSpin"
+    if wfn_kwargs is None:
+        wfn_kwargs = "ranks=None, indices=None, refwfn=None, exop_combinations=None"
+    return import_line, wfn_name, wfn_kwargs
+
+def _get_apsetgd_info(wfn_kwargs):
+    """
+    Get information about the APset1roGD wavefunction.
+
+    Parameters
+    ----------
+    wfn_kwargs : str, None
+        Keyword arguments for the APset1roGD wavefunction.
+
+    Returns
+    -------
+    results : tuple
+        A tuple containing the import line, wavefunction name, and keyword arguments.
+    """
+
+    import_line = ("fanpy.wfn.cc.apset1rog_d", "APset1roGD")
+    wfn_name = "APset1roGD"
+    if wfn_kwargs is None:
+        wfn_kwargs = "ranks=None, indices=None, refwfn=None, exop_combinations=None"
+    return import_line, wfn_name, wfn_kwargs
+
+def _get_apsetgsd_info(wfn_kwargs):
+    """
+    Get information about the APset1roGSD wavefunction.
+
+    Parameters
+    ----------
+    wfn_kwargs : str, None
+        Keyword arguments for the APset1roGSD wavefunction.
+
+    Returns
+    -------
+    results : tuple
+        A tuple containing the import line, wavefunction name, and keyword arguments.
+    """
+
+    import_line = ("fanpy.wfn.cc.apset1rog_sd", "APset1roGSD")
+    wfn_name = "APset1roGSD"
+    if wfn_kwargs is None:
+        wfn_kwargs = "ranks=None, indices=None, refwfn=None, exop_combinations=None"
+    return import_line, wfn_name, wfn_kwargs
+
+def _get_apg1rod_info(wfn_kwargs):
+    """
+    Get information about the APG1roD wavefunction.
+
+    Parameters
+    ----------
+    wfn_kwargs : str, None
+        Keyword arguments for the APG1roD wavefunction.
+
+    Returns
+    -------
+    results : tuple
+        A tuple containing the import line, wavefunction name, and keyword arguments.
+    """
+
+    import_line = ("fanpy.wfn.cc.apg1ro_d", "APG1roD")
+    wfn_name = "APG1roD"
+    if wfn_kwargs is None:
+        wfn_kwargs = "ranks=None, indices=None, refwfn=None, exop_combinations=None"
+    return import_line, wfn_name, wfn_kwargs
+
+def _get_apg1rosd_info(wfn_kwargs):
+    """
+    Get information about the APG1roSD wavefunction.
+
+    Parameters
+    ----------
+    wfn_kwargs : str, None
+        Keyword arguments for the APG1roSD wavefunction.
+
+    Returns
+    -------
+    results : tuple
+        A tuple containing the import line, wavefunction name, and keyword arguments.
+    """
+
+    import_line = ("fanpy.wfn.cc.apg1ro_sd", "APG1roSD")
+    wfn_name = "APG1roSD"
+    if wfn_kwargs is None:
+        wfn_kwargs = "ranks=None, indices=None, refwfn=None, exop_combinations=None"
+    return import_line, wfn_name, wfn_kwargs
+
+def _get_ccsdsen0_info(wfn_kwargs):
+    """
+    Get information about the CCSDsen0 wavefunction.
+
+    Parameters
+    ----------
+    wfn_kwargs : str, None
+        Keyword arguments for the CCSDsen0 wavefunction.
+
+    Returns
+    -------
+    results : tuple
+        A tuple containing the import line, wavefunction name, and keyword arguments.
+    """
+
+    import_line = ("fanpy.wfn.cc.ccsd_sen0", "CCSDsen0")
+    wfn_name = "CCSDsen0"
+    if wfn_kwargs is None:
+        wfn_kwargs = "ranks=None, indices=None, refwfn=None, exop_combinations=None"
+    return import_line, wfn_name, wfn_kwargs
+
+def _get_ccsdqsen0_info(wfn_kwargs):
+    """
+    Get information about the CCSDQsen0 wavefunction.
+
+    Parameters
+    ----------
+    wfn_kwargs : str, None
+        Keyword arguments for the CCSDQsen0 wavefunction.
+
+    Returns
+    -------
+    results : tuple
+        A tuple containing the import line, wavefunction name, and keyword arguments.
+    """
+
+    import_line = ("fanpy.wfn.cc.ccsdq_sen0", "CCSDQsen0")
+    wfn_name = "CCSDQsen0"
+    if wfn_kwargs is None:
+        wfn_kwargs = "ranks=None, indices=None, refwfn=None, exop_combinations=None"
+    return import_line, wfn_name, wfn_kwargs
+
+def _get_ccsdtqsen0_info(wfn_kwargs):
+    """
+    Get information about the CCSDTQsen0 wavefunction.
+
+    Parameters
+    ----------
+    wfn_kwargs : str, None
+        Keyword arguments for the CCSDTQsen0 wavefunction.
+
+    Returns
+    -------
+    results : tuple
+        A tuple containing the import line, wavefunction name, and keyword arguments.
+    """
+
+    import_line = ("fanpy.wfn.cc.ccsdtq_sen0", "CCSDTQsen0")
+    wfn_name = "CCSDTQsen0"
+    if wfn_kwargs is None:
+        wfn_kwargs = "ranks=None, indices=None, refwfn=None, exop_combinations=None"
+    return import_line, wfn_name, wfn_kwargs
+
+def _get_ccsdtsen2qsen0_info(wfn_kwargs):
+    """
+    Get information about the CCSDTsen2Qsen0 wavefunction.
+
+    Parameters
+    ----------
+    wfn_kwargs : str, None
+        Keyword arguments for the CCSDTsen2Qsen0 wavefunction.
+
+    Returns
+    -------
+    results : tuple
+        A tuple containing the import line, wavefunction name, and keyword arguments.
+    """
+
+    import_line = ("fanpy.wfn.cc.ccsdt_sen2_q_sen0", "CCSDTsen2Qsen0")
+    wfn_name = "CCSDTsen2Qsen0"
+    if wfn_kwargs is None:
+        wfn_kwargs = "ranks=None, indices=None, refwfn=None, exop_combinations=None"
+    return import_line, wfn_name, wfn_kwargs
+
+def _get_ccsd_info(wfn_kwargs):
+    """
+    Get information about the CCSD wavefunction.
+
+    Parameters
+    ----------
+    wfn_kwargs : str, None
+        Keyword arguments for the CCSD wavefunction.
+
+    Returns
+    -------
+    results : tuple
+        A tuple containing the import line, wavefunction name, and keyword arguments.
+    """
+
+    import_line = ("fanpy.wfn.cc.standard_cc", "StandardCC")
+    wfn_name = "StandardCC"
+    if wfn_kwargs is None:
+        wfn_kwargs = "indices=None, refwfn=None, exop_combinations=None"
+    wfn_kwargs = f"ranks=[1, 2], {wfn_kwargs}"
+    return import_line, wfn_name, wfn_kwargs
+
+def _get_ccsdt_info(wfn_kwargs):
+    """
+    Get information about the CCSDT wavefunction.
+
+    Parameters
+    ----------
+    wfn_kwargs : str, None
+        Keyword arguments for the CCSDT wavefunction.
+
+    Returns
+    -------
+    results : tuple
+        A tuple containing the import line, wavefunction name, and keyword arguments.
+    """
+
+    import_line = ("fanpy.wfn.cc.standard_cc", "StandardCC")
+    wfn_name = "StandardCC"
+    if wfn_kwargs is None:
+        wfn_kwargs = "indices=None, refwfn=None, exop_combinations=None"
+    wfn_kwargs = f"ranks=[1, 2, 3], {wfn_kwargs}"
+    return import_line, wfn_name, wfn_kwargs
+
+def _get_ccsdtq_info(wfn_kwargs):
+    """
+    Get information about the CCSDTQ wavefunction.
+
+    Parameters
+    ----------
+    wfn_kwargs : str, None
+        Keyword arguments for the CCSDTQ wavefunction.
+
+    Returns
+    -------
+    results : tuple
+        A tuple containing the import line, wavefunction name, and keyword arguments.
+    """
+
+    import_line = ("fanpy.wfn.cc.standard_cc", "StandardCC")
+    wfn_name = "StandardCC"
+    if wfn_kwargs is None:
+        wfn_kwargs = "indices=None, refwfn=None, exop_combinations=None"
+    wfn_kwargs = f"ranks=[1, 2, 3, 4], {wfn_kwargs}"
+    return import_line, wfn_name, wfn_kwargs
+
+def _get_custom_info(wfn_kwargs):
+    """
+    Get information about the custom wavefunction.
+
+    Parameters
+    ----------
+    wfn_kwargs : str
+        Keyword arguments for the custom wavefunction. Must contain "import_line" and "wfn_name".
+
+    Returns
+    -------
+    results : tuple
+        A tuple containing the import line, wavefunction name, and keyword arguments.
+
+    Raises
+    ------
+    ValueError
+        If the wfn_kwargs is not a string or does not contain "import_line" and "wfn_name".
+    """
+    if type(wfn_kwargs) is not str:
+        raise ValueError("wfn_kwargs for custom wavefunction must be a string.")
+    if "import_line" not in wfn_kwargs:
+        raise ValueError("Custom wavefunction must specify import_line.")
+    if "wfn_name" not in wfn_kwargs:
+        raise ValueError("Custom wavefunction must specify wfn_name.")
+    
+    wfn_kwarg_list = wfn_kwargs.split(",")
+    output_wfn_kwargs = ""
+    for kwarg in wfn_kwarg_list:
+        if "import_line" in kwarg:
+            import_line = kwarg.split("=")[1]
+            import_line = import_line.strip()
+        elif "wfn_name" in kwarg:
+            wfn_name = kwarg.split("=")[1]
+            wfn_name = wfn_name.strip()
+        else:
+            output_wfn_kwargs += kwarg + ","
+    import_line = (import_line, wfn_name)
+    return import_line, wfn_name, output_wfn_kwargs[:-1]

--- a/fanpy/scripts/gaussian/wavefunction_info.py
+++ b/fanpy/scripts/gaussian/wavefunction_info.py
@@ -158,6 +158,8 @@ def get_wfn_info(wfn_type):
         return _get_ccsdtqsen0_info
     elif wfn_type == "ccsdtsen2qsen0":
         return _get_ccsdtsen2qsen0_info
+    elif wfn_type == "ccs":
+        return _get_ccs_info
     elif wfn_type == "ccsd":
         return _get_ccsd_info
     elif wfn_type == "ccsdt":
@@ -844,6 +846,28 @@ def _get_ccsdtq_info(wfn_kwargs):
     if wfn_kwargs is None:
         wfn_kwargs = "indices=None, refwfn=None, exop_combinations=None"
     wfn_kwargs = f"ranks=[1, 2, 3, 4], {wfn_kwargs}"
+    return import_line, wfn_name, wfn_kwargs
+
+def _get_ccs_info(wfn_kwargs):
+    """
+    Get information about the CCS wavefunction.
+
+    Parameters
+    ----------
+    wfn_kwargs : str, None
+        Keyword arguments for the CCS wavefunction.
+
+    Returns
+    -------
+    results : tuple
+        A tuple containing the import line, wavefunction name, and keyword arguments.
+    """
+
+    import_line = ("fanpy.wfn.cc.standard_cc", "StandardCC")
+    wfn_name = "StandardCC"
+    if wfn_kwargs is None:
+        wfn_kwargs = "indices=None, refwfn=None, exop_combinations=None"
+    wfn_kwargs = f"ranks=[1], {wfn_kwargs}"
     return import_line, wfn_name, wfn_kwargs
 
 def _get_custom_info(wfn_kwargs):

--- a/fanpy/scripts/gaussian/wavefunction_info.py
+++ b/fanpy/scripts/gaussian/wavefunction_info.py
@@ -102,74 +102,45 @@ def get_wfn_info(wfn_type: str) -> callable:
         If the given wavefunction type is invalid.
     """
 
-    if wfn_type == "ci_pairs":
-        return _get_ci_pairs_info
-    elif wfn_type == "cisd":
-        return _get_cisd_info
-    elif wfn_type == "hci":
-        return _get_hci_info
-    elif wfn_type == "fci":
-        return _get_fci_info
-    elif wfn_type == "doci":
-        return _get_doci_info
-    elif wfn_type == "mps":
-        return _get_mps_info
-    elif wfn_type == "determinant-ratio":
-        return _get_det_ratio_info
-    elif wfn_type == "ap1rog":
-        return _get_ap1rog_info
-    elif wfn_type == "apr2g":
-        return _get_apr2g_info
-    elif wfn_type == "apig":
-        return _get_apig_info
-    elif wfn_type == "apsetg":
-        return _get_apsetg_info
-    elif wfn_type == "apg":
-        return _get_apg_info
-    elif wfn_type == "network": 
-        return _get_network_info
-    elif wfn_type == "rbm":
-        return _get_rbm_info
-    elif wfn_type == "basecc":
-        return _get_basecc_info
-    elif wfn_type == "standardcc":
-        return _get_standardcc_info
-    elif wfn_type == "generalizedcc":
-        return _get_generalizedcc_info
-    elif wfn_type == "senioritycc":
-        return _get_senioritycc_info
-    elif wfn_type == "pccd":
-        return _get_pccd_info
-    elif wfn_type == "ap1rogsd":
-        return _get_ap1rogsd_info
-    elif wfn_type == "ap1rogsd_spin":
-        return _get_ap1rogsd_spin_info
-    elif wfn_type == "apsetgd":
-        return _get_apsetgd_info
-    elif wfn_type == "apsetgsd":
-        return _get_apsetgsd_info
-    elif wfn_type == "apg1rod":
-        return _get_apg1rod_info
-    elif wfn_type == "apg1rosd":
-        return _get_apg1rosd_info
-    elif wfn_type == "ccsdsen0":
-        return _get_ccsdsen0_info
-    elif wfn_type == "ccsdqsen0":
-        return _get_ccsdqsen0_info
-    elif wfn_type == "ccsdtqsen0":
-        return _get_ccsdtqsen0_info
-    elif wfn_type == "ccsdtsen2qsen0":
-        return _get_ccsdtsen2qsen0_info
-    elif wfn_type == "ccs":
-        return _get_ccs_info
-    elif wfn_type == "ccsd":
-        return _get_ccsd_info
-    elif wfn_type == "ccsdt":
-        return _get_ccsdt_info
-    elif wfn_type == "ccsdtq":
-        return _get_ccsdtq_info
-    elif wfn_type == "custom":
-        return _get_custom_info
+    wfn_info_dict = {
+        "ci_pairs": _get_ci_pairs_info,
+        "cisd": _get_cisd_info,
+        "hci": _get_hci_info,
+        "fci": _get_fci_info,
+        "doci": _get_doci_info,
+        "mps": _get_mps_info,
+        "determinant-ratio": _get_det_ratio_info,
+        "ap1rog": _get_ap1rog_info,
+        "apr2g": _get_apr2g_info,
+        "apig": _get_apig_info,
+        "apsetg": _get_apsetg_info,
+        "apg": _get_apg_info,
+        "network": _get_network_info,
+        "rbm": _get_rbm_info,
+        "basecc": _get_basecc_info,
+        "standardcc": _get_standardcc_info,
+        "generalizedcc": _get_generalizedcc_info,
+        "senioritycc": _get_senioritycc_info,
+        "pccd": _get_pccd_info,
+        "ap1rogsd": _get_ap1rogsd_info,
+        "ap1rogsd_spin": _get_ap1rogsd_spin_info,
+        "apsetgd": _get_apsetgd_info,
+        "apsetgsd": _get_apsetgsd_info,
+        "apg1rod": _get_apg1rod_info,
+        "apg1rosd": _get_apg1rosd_info,
+        "ccsdsen0": _get_ccsdsen0_info,
+        "ccsdqsen0": _get_ccsdqsen0_info,
+        "ccsdtqsen0": _get_ccsdtqsen0_info,
+        "ccsdtsen2qsen0": _get_ccsdtsen2qsen0_info,
+        "ccs": _get_ccs_info,
+        "ccsd": _get_ccsd_info,
+        "ccsdt": _get_ccsdt_info,
+        "ccsdtq": _get_ccsdtq_info,
+        "custom": _get_custom_info
+    }
+    
+    if wfn_type in wfn_info_dict:
+        return wfn_info_dict[wfn_type]
     else:
         raise ValueError(f"Invalid wavefunction type: {wfn_type}")
 

--- a/fanpy/scripts/utils.py
+++ b/fanpy/scripts/utils.py
@@ -16,7 +16,7 @@ parser : argparse.ArgumentParser
 
 """
 import argparse
-
+from fanpy.scripts.gaussian.wavefunction_info import get_wfn_info
 
 def check_inputs(  # pylint: disable=R0912,R0915
     nelec,
@@ -155,43 +155,44 @@ def check_inputs(  # pylint: disable=R0912,R0915
             )
 
     # check wavefunction type
-    wfn_list = [
-        "ci_pairs",
-        "cisd",
-        "fci",
-        "hci",
-        "doci",
-        "mps",
-        "determinant-ratio",
-        "ap1rog",
-        "apr2g",
-        "apig",
-        "apsetg",
-        "apg",
-        "network",
-        "rbm",
+    # wfn_list = [
+    #     "ci_pairs",
+    #     "cisd",
+    #     "fci",
+    #     "hci",
+    #     "doci",
+    #     "mps",
+    #     "determinant-ratio",
+    #     "ap1rog",
+    #     "apr2g",
+    #     "apig",
+    #     "apsetg",
+    #     "apg",
+    #     "network",
+    #     "rbm",
 
-        "basecc",
-        "standardcc",
-        "generalizedcc",
-        "senioritycc",
-        "pccd",
-        "ap1rogsd",
-        "ap1rogsd_spin",
-        "apsetgd",
-        "apsetgsd",
-        "apg1rod",
-        "apg1rosd",
-        "ccsdsen0",
-        "ccsdqsen0",
-        "ccsdtqsen0",
-        "ccsdtsen2qsen0",
-        "ccsd",
-        "ccsdt",
-        "ccsdtq",
-    ]
-    if wfn_type not in wfn_list:
-        raise ValueError("Wavefunction type, {}, must be one of {}.".format(wfn_type, ", ".join(wfn_list)))
+    #     "basecc",
+    #     "standardcc",
+    #     "generalizedcc",
+    #     "senioritycc",
+    #     "pccd",
+    #     "ap1rogsd",
+    #     "ap1rogsd_spin",
+    #     "apsetgd",
+    #     "apsetgsd",
+    #     "apg1rod",
+    #     "apg1rosd",
+    #     "ccsdsen0",
+    #     "ccsdqsen0",
+    #     "ccsdtqsen0",
+    #     "ccsdtsen2qsen0",
+    #     "ccsd",
+    #     "ccsdt",
+    #     "ccsdtq",
+    # ]
+    # this is probably not needed because make_script uses get_wfn_info
+    # so it will be raised there
+    _ = get_wfn_info(wfn_type) # raises error if wfn_type is not valid
 
     # check projection space
     if not (isinstance(pspace_exc, (list, tuple)) and all(isinstance(i, int) for i in pspace_exc)):

--- a/tests/test_scripts_make_script_factoring.py
+++ b/tests/test_scripts_make_script_factoring.py
@@ -260,3 +260,8 @@ def test_import_line():
             exec(command)
         except ModuleNotFoundError:
             pytest.fail(f"ModuleNotFoundError: {import_line[0]}")
+
+@pytest.mark.parametrize("wfn_type", ["42 is the answer to everything", 41, None, 3.14])
+def test_invalid_wfn_type(wfn_type):
+    with pytest.raises(ValueError):
+        get_wfn_info(wfn_type)

--- a/tests/test_scripts_make_script_factoring.py
+++ b/tests/test_scripts_make_script_factoring.py
@@ -153,6 +153,12 @@ def old_input(wfn_type, wfn_kwargs=None):
         wfn_name = "CCSDTsen2Qsen0"
         if wfn_kwargs is None:
             wfn_kwargs = "ranks=None, indices=None, refwfn=None, exop_combinations=None"
+    elif wfn_type == "ccs":
+        from_imports.append(("fanpy.wfn.cc.standard_cc", "StandardCC"))
+        wfn_name = "StandardCC"
+        if wfn_kwargs is None:
+            wfn_kwargs = "indices=None, refwfn=None, exop_combinations=None"
+        wfn_kwargs = f"ranks=[1], {wfn_kwargs}"
     elif wfn_type == "ccsd":
         from_imports.append(("fanpy.wfn.cc.standard_cc", "StandardCC"))
         wfn_name = "StandardCC"
@@ -205,6 +211,7 @@ def test_make_script():
         "ccsdqsen0",
         "ccsdtqsen0",
         "ccsdtsen2qsen0",
+        "ccs",
         "ccsd",
         "ccsdt",
         "ccsdtq"

--- a/tests/test_scripts_make_script_factoring.py
+++ b/tests/test_scripts_make_script_factoring.py
@@ -1,0 +1,262 @@
+"""Test fanpy.script.make_script."""
+
+import pytest
+from fanpy.scripts.gaussian.wavefunction_info import get_wfn_info
+
+def old_input(wfn_type, wfn_kwargs=None):
+    from_imports = []
+    if wfn_type == "ci_pairs":
+        from_imports.append(("fanpy.wfn.ci.ci_pairs", "CIPairs"))
+        wfn_name = "CIPairs"
+        if wfn_kwargs is None:
+            wfn_kwargs = ""
+    elif wfn_type == "cisd":
+        from_imports.append(("fanpy.wfn.ci.cisd", "CISD"))
+        wfn_name = "CISD"
+        if wfn_kwargs is None:
+            wfn_kwargs = ""
+
+    elif wfn_type == "hci":
+        from_imports.append(("fanpy.wfn.ci.hci", "hCI"))
+        wfn_name = "hCI"
+        if wfn_kwargs is None:
+            wfn_kwargs = "alpha1=0.5, alpha2=0.25, hierarchy=2.5"
+
+    elif wfn_type == "fci":
+        from_imports.append(("fanpy.wfn.ci.fci", "FCI"))
+        wfn_name = "FCI"
+        if wfn_kwargs is None:
+            wfn_kwargs = "spin=None"
+    elif wfn_type == "doci":
+        from_imports.append(("fanpy.wfn.ci.doci", "DOCI"))
+        wfn_name = "DOCI"
+        if wfn_kwargs is None:
+            wfn_kwargs = ""
+    elif wfn_type == "mps":
+        from_imports.append(("fanpy.wfn.network.mps", "MatrixProductState"))
+        wfn_name = "MatrixProductState"
+        if wfn_kwargs is None:
+            wfn_kwargs = "dimension=None"
+    elif wfn_type == "determinant-ratio":
+        from_imports.append(("fanpy.wfn.quasiparticle.det_ratio", "DeterminantRatio"))
+        wfn_name = "DeterminantRatio"
+        if wfn_kwargs is None:
+            wfn_kwargs = "numerator_mask=None"
+    elif wfn_type == "ap1rog":
+        from_imports.append(("fanpy.wfn.geminal.ap1rog", "AP1roG"))
+        wfn_name = "AP1roG"
+        if wfn_kwargs is None:
+            wfn_kwargs = "ref_sd=None, ngem=None"
+    elif wfn_type == "apr2g":
+        from_imports.append(("fanpy.wfn.geminal.apr2g", "APr2G"))
+        wfn_name = "APr2G"
+        if wfn_kwargs is None:
+            wfn_kwargs = "ngem=None"
+    elif wfn_type == "apig":
+        from_imports.append(("fanpy.wfn.geminal.apig", "APIG"))
+        wfn_name = "APIG"
+        if wfn_kwargs is None:
+            wfn_kwargs = "ngem=None"
+    elif wfn_type == "apsetg":
+        from_imports.append(("fanpy.wfn.geminal.apsetg", "BasicAPsetG"))
+        wfn_name = "BasicAPsetG"
+        if wfn_kwargs is None:
+            wfn_kwargs = "ngem=None"
+    elif wfn_type == "apg":  # pragma: no branch
+        from_imports.append(("fanpy.wfn.geminal.apg", "APG"))
+        wfn_name = "APG"
+        if wfn_kwargs is None:
+            wfn_kwargs = "ngem=None"
+    elif wfn_type == "network":
+        from_imports.append(("fanpy.upgrades.numpy_network", "NumpyNetwork"))
+        wfn_name = "NumpyNetwork"
+        if wfn_kwargs is None:
+            wfn_kwargs = "num_layers=2"
+    elif wfn_type == "rbm":
+        from_imports.append(("fanpy.wfn.network.rbm_standard", "RestrictedBoltzmannMachine"))
+        wfn_name = "RestrictedBoltzmannMachine"
+        if wfn_kwargs is None:
+            wfn_kwargs = "nbath=nspin, num_layers=1, orders=(1, 2)"
+
+    elif wfn_type == "basecc":
+        from_imports.append(("fanpy.wfn.cc.base", "BaseCC"))
+        wfn_name = "BaseCC"
+        if wfn_kwargs is None:
+            wfn_kwargs = "ranks=None, indices=None, refwfn=None, exop_combinations=None"
+    elif wfn_type == "standardcc":
+        from_imports.append(("fanpy.wfn.cc.standard_cc", "StandardCC"))
+        wfn_name = "StandardCC"
+        if wfn_kwargs is None:
+            wfn_kwargs = "ranks=None, indices=None, refwfn=None, exop_combinations=None"
+    elif wfn_type == "generalizedcc":
+        from_imports.append(("fanpy.wfn.cc.generalized_cc", "GeneralizedCC"))
+        wfn_name = "GeneralizedCC"
+        if wfn_kwargs is None:
+            wfn_kwargs = "ranks=None, indices=None, refwfn=None, exop_combinations=None"
+    elif wfn_type == "senioritycc":
+        from_imports.append(("fanpy.wfn.cc.seniority_cc", "SeniorityCC"))
+        wfn_name = "SeniorityCC"
+        if wfn_kwargs is None:
+            wfn_kwargs = "ranks=None, indices=None, refwfn=None, exop_combinations=None"
+    elif wfn_type == "pccd":
+        from_imports.append(("fanpy.wfn.cc.pccd_ap1rog", "PCCD"))
+        wfn_name = "PCCD"
+        if wfn_kwargs is None:
+            wfn_kwargs = "ranks=None, indices=None, refwfn=None, exop_combinations=None"
+    elif wfn_type == "ap1rogsd":
+        from_imports.append(("fanpy.wfn.cc.ap1rog_generalized", "AP1roGSDGeneralized"))
+        wfn_name = "AP1roGSDGeneralized"
+        if wfn_kwargs is None:
+            wfn_kwargs = "ranks=None, indices=None, refwfn=None, exop_combinations=None"
+    elif wfn_type == "ap1rogsd_spin":
+        from_imports.append(("fanpy.wfn.cc.ap1rog_spin", "AP1roGSDSpin"))
+        wfn_name = "AP1roGSDSpin"
+        if wfn_kwargs is None:
+            wfn_kwargs = "ranks=None, indices=None, refwfn=None, exop_combinations=None"
+    elif wfn_type == "apsetgd":
+        from_imports.append(("fanpy.wfn.cc.apset1rog_d", "APset1roGD"))
+        wfn_name = "APset1roGD"
+        if wfn_kwargs is None:
+            wfn_kwargs = "ranks=None, indices=None, refwfn=None, exop_combinations=None"
+    elif wfn_type == "apsetgsd":
+        from_imports.append(("fanpy.wfn.cc.apset1rog_sd", "APset1roGSD"))
+        wfn_name = "APset1roGSD"
+        if wfn_kwargs is None:
+            wfn_kwargs = "ranks=None, indices=None, refwfn=None, exop_combinations=None"
+    elif wfn_type == "apg1rod":
+        from_imports.append(("fanpy.wfn.cc.apg1ro_d", "APG1roD"))
+        wfn_name = "APG1roD"
+        if wfn_kwargs is None:
+            wfn_kwargs = "ranks=None, indices=None, refwfn=None, exop_combinations=None"
+    elif wfn_type == "apg1rosd":
+        from_imports.append(("fanpy.wfn.cc.apg1ro_sd", "APG1roSD"))
+        wfn_name = "APG1roSD"
+        if wfn_kwargs is None:
+            wfn_kwargs = "ranks=None, indices=None, refwfn=None, exop_combinations=None"
+    elif wfn_type == "ccsdsen0":
+        from_imports.append(("fanpy.wfn.cc.ccsd_sen0", "CCSDsen0"))
+        wfn_name = "CCSDsen0"
+        if wfn_kwargs is None:
+            wfn_kwargs = "ranks=None, indices=None, refwfn=None, exop_combinations=None"
+    elif wfn_type == "ccsdqsen0":
+        from_imports.append(("fanpy.wfn.cc.ccsdq_sen0", "CCSDQsen0"))
+        wfn_name = "CCSDQsen0"
+        if wfn_kwargs is None:
+            wfn_kwargs = "ranks=None, indices=None, refwfn=None, exop_combinations=None"
+    elif wfn_type == "ccsdtqsen0":
+        from_imports.append(("fanpy.wfn.cc.ccsdtq_sen0", "CCSDTQsen0"))
+        wfn_name = "CCSDTQsen0"
+        if wfn_kwargs is None:
+            wfn_kwargs = "ranks=None, indices=None, refwfn=None, exop_combinations=None"
+    elif wfn_type == "ccsdtsen2qsen0":
+        from_imports.append(("fanpy.wfn.cc.ccsdt_sen2_q_sen0", "CCSDTsen2Qsen0"))
+        wfn_name = "CCSDTsen2Qsen0"
+        if wfn_kwargs is None:
+            wfn_kwargs = "ranks=None, indices=None, refwfn=None, exop_combinations=None"
+    elif wfn_type == "ccsd":
+        from_imports.append(("fanpy.wfn.cc.standard_cc", "StandardCC"))
+        wfn_name = "StandardCC"
+        if wfn_kwargs is None:
+            wfn_kwargs = "indices=None, refwfn=None, exop_combinations=None"
+        print(wfn_kwargs)
+        wfn_kwargs = f"ranks=[1, 2], {wfn_kwargs}"
+    elif wfn_type == "ccsdt":
+        from_imports.append(("fanpy.wfn.cc.standard_cc", "StandardCC"))
+        wfn_name = "StandardCC"
+        if wfn_kwargs is None:
+            wfn_kwargs = "indices=None, refwfn=None, exop_combinations=None"
+        wfn_kwargs = f"ranks=[1, 2, 3], {wfn_kwargs}"
+    elif wfn_type == "ccsdtq":
+        from_imports.append(("fanpy.wfn.cc.standard_cc", "StandardCC"))
+        wfn_name = "StandardCC"
+        if wfn_kwargs is None:
+            wfn_kwargs = "indices=None, refwfn=None, exop_combinations=None"
+        wfn_kwargs = f"ranks=[1, 2, 3, 4], {wfn_kwargs}"
+    return from_imports, wfn_name, wfn_kwargs
+
+def test_make_script():
+    wfn_list = [
+        "ci_pairs",
+        "cisd",
+        "hci", # "hci" is missing in the original test
+        "fci",
+        "doci",
+        "mps",
+        "determinant-ratio",
+        "ap1rog",
+        "apr2g",
+        "apig",
+        "apsetg",
+        "apg",
+        "network",
+        "rbm",
+        "basecc",
+        "standardcc",
+        "generalizedcc",
+        "senioritycc",
+        "pccd",
+        "ap1rogsd",
+        "ap1rogsd_spin",
+        "apsetgd",
+        "apsetgsd",
+        "apg1rod",
+        "apg1rosd",
+        "ccsdsen0",
+        "ccsdqsen0",
+        "ccsdtqsen0",
+        "ccsdtsen2qsen0",
+        "ccsd",
+        "ccsdt",
+        "ccsdtq"
+    ]
+    for wfn in wfn_list:
+        wfn_info = get_wfn_info(wfn)
+        import_line, wfn_name, wfn_kwargs = wfn_info(wfn_kwargs=None)
+        old_import_line, old_wfn_name, old_wfn_kwargs = old_input(wfn)
+        assert import_line == old_import_line[0]
+        assert wfn_name == old_wfn_name
+        assert wfn_kwargs == old_wfn_kwargs
+
+def test_import_line():
+    wfn_list = [
+        "ci_pairs",
+        "cisd",
+        "hci", # "hci" is missing in the original test
+        "fci",
+        "doci",
+        "mps",
+        "determinant-ratio",
+        "ap1rog",
+        "apr2g",
+        "apig",
+        "apsetg",
+        "apg",
+        "network",
+        "rbm",
+        "basecc",
+        "standardcc",
+        "generalizedcc",
+        "senioritycc",
+        "pccd",
+        "ap1rogsd",
+        "ap1rogsd_spin",
+        "apsetgd",
+        "apsetgsd",
+        "apg1rod",
+        "apg1rosd",
+        "ccsdsen0",
+        "ccsdqsen0",
+        "ccsdtqsen0",
+        "ccsdtsen2qsen0",
+        "ccsd",
+        "ccsdt",
+        "ccsdtq"
+    ]
+    for wfn in wfn_list:
+        wfn_info = get_wfn_info(wfn)
+        import_line, wfn_name, wfn_kwargs = wfn_info(wfn_kwargs=None)
+        command = f"from {import_line[0]} import {import_line[1]}"
+        try:
+            exec(command)
+        except ModuleNotFoundError:
+            pytest.fail(f"ModuleNotFoundError: {import_line[0]}")


### PR DESCRIPTION
### What changed
Created a factory method for wfn_type in make_script and make_fanci_script. Added option for custom wave function type. 

### Why 
Previously one had to edit the output of make_script if the wave function was not in make_script. 

### How
make_script gets a method for a given wfn_type from get_wfn_info. These wfn_type dependent methods return the import_line, wfn_name, and wfn_kwargs, which make_scripts uses later. The custom wave function method looks for wfn_name and import_from in wfn_kwargs. For example, wfn_kwarg for the CISD wave function would be `wfn_kwargs = "wfn_name = CISD, import_from = fanpy.wfn.ci.cisd"`  

###  Testing
- comparison of old wfn information and information from factory 
- test to see if the from import line still works 
- test for raising ValueError for incorrect wfn_type
- used the write_wfn_py method of run_calc to generate calculate.py for custom and cisd wfn_type

