### PR TITLE
Create issue templates for GitHub.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,38 @@
+name: Bug report
+description: "Report a bug."
+labels: "bug"
+title: "BUG: "
+
+body:
+- type: textarea
+  attributes: 
+    label: "Describe the problem:"
+  validations:
+    required: true
+      
+- type: textarea
+  attributes:
+    label: "Code that reproduces the bug:"
+  validations:
+    required: true
+    
+- type: textarea
+  attributes:
+    label: "Traceback error:"
+    description: "Please paste the generated error here."
+  validations:
+    required: true
+    
+- type: textarea
+  attributes:
+    label: "Package versions:"
+    value: |
+      python: 
+      fanpy: 
+      numpy:
+  validations:
+    required: true
+      
+- type: textarea
+  attributes: 
+    label: "Additonal comments"

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,23 @@
+name: Feature Request
+description: "Suggest a feature."
+labels: "enhancement"
+title: "ENH: "
+
+body:
+- type: textarea
+  attributes:
+    label: "Describe the new feature:"
+  validations:
+    required: true
+
+- type: textarea
+  attributes:
+    label: "How would you implement this feature?"
+  validations:
+    required: true
+
+- type: textarea
+  attributes:
+    label: "Additional comments:"
+  validations:
+    required: false


### PR DESCRIPTION
# What changed?
I created templates for feature requests and bug reports. These are specifically  for GitHub. It should help with keeping track of issues/new features, and who is working on them.

# Implementation
I used yaml files for both templates, since they can have required fields, unlike markdown templates. Currently, the template assigns a label automatically for both issues (enhancement for feature requests, and bug for bugs). The title starts either with BUG or ENH. Also, for the bug template, there is a field with package versions that is pre-populated with python, fanpy and numpy. 