### PR TITLE
Documentation correction

### DIFF
--- a/fanpy/tools/graphs.py
+++ b/fanpy/tools/graphs.py
@@ -187,7 +187,7 @@ def generate_unordered_partition(collection, bin_size_num):
     ----------
     collection : list
         List of elements that will be partitioned.
-        There should be an ordered list to ensure a correct number of partitions and correct ordering of the bins. 
+        This should be an ordered list to ensure a correct number of partitions and correct ordering of the bins. 
     bin_size_num : list of 2-tuple of int
         List of tuples that describe the size and the number of the bins.
         First element of the tuple is the size of the bin.

--- a/fanpy/tools/graphs.py
+++ b/fanpy/tools/graphs.py
@@ -187,6 +187,7 @@ def generate_unordered_partition(collection, bin_size_num):
     ----------
     collection : list
         List of elements that will be partitioned.
+        There should be an ordered list to ensure a correct number of partitions and correct ordering of the bins. 
     bin_size_num : list of 2-tuple of int
         List of tuples that describe the size and the number of the bins.
         First element of the tuple is the size of the bin.


### PR DESCRIPTION
Update description of generate_unordered_partition in tools/graphs.py
The input list of `collection` should be ordered otherwise it results in an incorrect number of partitions and also affects the order of first elements in different bins of the same size.