### PR TITLE
24 bug unable to generate enough determinants for h4

### DIFF
--- a/fanpy/eqn/projected.py
+++ b/fanpy/eqn/projected.py
@@ -71,6 +71,9 @@ class ProjectedSchrodinger(BaseSchrodinger):
     pspace : {tuple/list of int, tuple/list of CIWavefunction, None}
         States onto which the Schrodinger equation is projected.
         By default, the largest space is used.
+    pspace_exc_orders : list/tuple of int
+        Excitation orders of the Slater determinants that will be used in the projection space.
+        By default, if the pspace was not assigned, the first and second-order excitation is used.
     refwfn : {tuple/list of int, CIWavefunction}
         State with respect to which the energy and the norm are computed.
         If a list/tuple of Slater determinants are given, then the reference state is the given
@@ -243,6 +246,7 @@ class ProjectedSchrodinger(BaseSchrodinger):
             step_save=step_save,
             tmpfile=tmpfile,
         )
+        self.pspace_exc_orders = pspace_exc_orders
         self.assign_pspace(pspace)
         self.assign_refwfn(refwfn)
 

--- a/fanpy/eqn/projected.py
+++ b/fanpy/eqn/projected.py
@@ -152,6 +152,7 @@ class ProjectedSchrodinger(BaseSchrodinger):
         step_save=True,
         tmpfile="",
         pspace=None,
+        pspace_exc_orders=None,
         refwfn=None,
         eqn_weights=None,
         energy_type="compute",
@@ -193,6 +194,9 @@ class ProjectedSchrodinger(BaseSchrodinger):
         pspace : {tuple/list of int, tuple/list of CIWavefunction, None}
             States onto which the Schrodinger equation is projected.
             By default, the largest space is used.
+        pspace_exc_orders : list/tuple of int
+            Excitation orders of the Slater determinants that will be used in the projection space.
+            By default, if the pspace was not assigned, the first and second-order excitation is used.
         refwfn : {tuple/list of int, CIWavefunction, None}
             State with respect to which the energy and the norm are computed.
             If a list/tuple of Slater determinants are given, then the reference state is the given
@@ -300,12 +304,15 @@ class ProjectedSchrodinger(BaseSchrodinger):
 
         """
         if pspace is None:
+            if self.pspace_exc_orders is None:
+                self.pspace_exc_orders = [1, 2]
+
             pspace = sd_list.sd_list(
                 self.wfn.nelec,
                 self.wfn.nspin,
                 spin=self.wfn.spin,
                 seniority=self.wfn.seniority,
-                exc_orders=[1, 2],
+                exc_orders=self.pspace_exc_orders,
             )
 
         if __debug__ and not (

--- a/fanpy/interface/fanci/legacy.py
+++ b/fanpy/interface/fanci/legacy.py
@@ -1119,7 +1119,9 @@ class ProjectedSchrodingerFanCI(ProjectedSchrodingerLegacyFanCI):
                 y[i] = self.fanpy_wfn.get_overlap(sd)
         return y
 
-    def compute_overlap_deriv(self, x: np.ndarray, occs_array: Union[np.ndarray, str], chunk_idx=[0, -1]) -> np.ndarray:
+    def compute_overlap_deriv(
+        self, x: np.ndarray, occs_array: Union[np.ndarray, str], chunk_idx=[None, None]
+    ) -> np.ndarray:
         """
         Compute the FanCI overlap derivative matrix.
 

--- a/fanpy/interface/fanci/legacy.py
+++ b/fanpy/interface/fanci/legacy.py
@@ -1,6 +1,6 @@
 """
-    Legacy version of FanCI objective class.
-    Based of the original class from FanCI code.
+Legacy version of FanCI objective class.
+Based of the original class from FanCI code.
 """
 
 from fanpy.tools import slater
@@ -1514,7 +1514,6 @@ class ProjectedSchrodingerFanCI(ProjectedSchrodingerLegacyFanCI):
             opt_kwargs.setdefault("gtol", 1.0e-8)
             opt_kwargs.setdefault("max_nfev", 1000 * self.nactive)
             opt_kwargs.setdefault("verbose", 2)
-            # self.step_print = False
             # opt_kwargs.setdefault("callback", self.print)
             if self.objective_type != "projected":
                 raise ValueError("objective_type must be projected")
@@ -1525,7 +1524,6 @@ class ProjectedSchrodingerFanCI(ProjectedSchrodingerLegacyFanCI):
             opt_kwargs.setdefault("method", "hybr")
             opt_kwargs.setdefault("options", {})
             opt_kwargs["options"].setdefault("xtol", 1.0e-9)
-            self.step_print = False
             opt_kwargs.setdefault("callback", self.print)
         elif mode == "cma":
             optimizer = cma.fmin
@@ -1535,7 +1533,6 @@ class ProjectedSchrodingerFanCI(ProjectedSchrodingerLegacyFanCI):
             opt_kwargs["options"].setdefault("timeout", np.inf)
             opt_kwargs["options"].setdefault("tolfun", 1e-11)
             opt_kwargs["options"].setdefault("verb_log", 0)
-            self.step_print = False
             if self.objective_type != "energy":
                 raise ValueError("objective_type must be energy")
         elif mode == "bfgs":
@@ -1545,7 +1542,6 @@ class ProjectedSchrodingerFanCI(ProjectedSchrodingerLegacyFanCI):
             opt_kwargs["method"] = "bfgs"
             opt_kwargs.setdefault("options", {"gtol": 1e-8})
             # opt_kwargs["options"]['schrodinger'] = objective
-            self.step_print = False
             opt_kwargs.setdefault("callback", self.print)
         elif mode == "trustregion":
             raise NotImplementedError

--- a/fanpy/interface/fanci/legacy.py
+++ b/fanpy/interface/fanci/legacy.py
@@ -1182,13 +1182,18 @@ class ProjectedSchrodingerFanCI(ProjectedSchrodingerLegacyFanCI):
             component.assign_params(new_params)
 
         # Shape of y is (no. determinants, no. active parameters excluding energy)
-        y = np.zeros(
-            (occs_array.shape[0], self.nactive - self.mask[-1]),
-            dtype=pyci.c_double,
-        )
+        if (s_chunk is None) and (f_chunk is None):
+            y = np.zeros(
+                (occs_array.shape[0], self.nactive - self.mask[-1]),
+                dtype=pyci.c_double,
+            )
 
-        # Select parameters according to selected chunks
-        y = y[s_chunk:f_chunk]
+        else:
+            # Select parameters according to selected chunks
+            y = np.zeros(
+                (f_chunk - s_chunk, self.nactive - self.mask[-1]),
+                dtype=pyci.c_double,
+            )
 
         # Compute derivatives of overlaps
         deriv_indices = self.param_selection[self.fanpy_wfn]

--- a/fanpy/interface/fanci/pyci.py
+++ b/fanpy/interface/fanci/pyci.py
@@ -335,7 +335,9 @@ class ProjectedSchrodingerPyCI(FanCI):
                 y[i] = self.fanpy_wfn.get_overlap(sd)
         return y
 
-    def compute_overlap_deriv(self, x: np.ndarray, occs_array: Union[np.ndarray, str], chunk_idx=[0, -1]) -> np.ndarray:
+    def compute_overlap_deriv(
+        self, x: np.ndarray, occs_array: Union[np.ndarray, str], chunk_idx=[None, None]
+    ) -> np.ndarray:
         """
         Compute the FanCI overlap derivative matrix.
 

--- a/fanpy/interface/fanci/pyci.py
+++ b/fanpy/interface/fanci/pyci.py
@@ -1,6 +1,6 @@
 """
-    Legacy version of FanCI objective class.
-    Based of the original class from FanCI code.
+Legacy version of FanCI objective class.
+Based of the original class from FanCI code.
 """
 
 from fanpy.tools import slater
@@ -730,7 +730,6 @@ class ProjectedSchrodingerPyCI(FanCI):
             opt_kwargs.setdefault("gtol", 1.0e-8)
             opt_kwargs.setdefault("max_nfev", 1000 * self.nactive)
             opt_kwargs.setdefault("verbose", 2)
-            self._step_print = False
             # opt_kwargs.setdefault("callback", self.print)
             if self.objective_type != "projected":
                 raise ValueError("objective_type must be projected")
@@ -741,7 +740,6 @@ class ProjectedSchrodingerPyCI(FanCI):
             opt_kwargs.setdefault("method", "hybr")
             opt_kwargs.setdefault("options", {})
             opt_kwargs["options"].setdefault("xtol", 1.0e-9)
-            self._step_print = False
             opt_kwargs.setdefault("callback", self.print)
         elif mode == "cma":
             optimizer = cma.fmin
@@ -751,7 +749,6 @@ class ProjectedSchrodingerPyCI(FanCI):
             opt_kwargs["options"].setdefault("timeout", np.inf)
             opt_kwargs["options"].setdefault("tolfun", 1e-11)
             opt_kwargs["options"].setdefault("verb_log", 0)
-            self._step_print = False
             if self.objective_type != "energy":
                 raise ValueError("objective_type must be energy")
         elif mode == "bfgs":
@@ -761,7 +758,6 @@ class ProjectedSchrodingerPyCI(FanCI):
             opt_kwargs["method"] = "bfgs"
             opt_kwargs.setdefault("options", {"gtol": 1e-8})
             # opt_kwargs["options"]['schrodinger'] = objective
-            self._step_print = False
             opt_kwargs.setdefault("callback", self.print)
         elif mode == "trustregion":
             raise NotImplementedError

--- a/fanpy/interface/fanci/pyci.py
+++ b/fanpy/interface/fanci/pyci.py
@@ -398,13 +398,18 @@ class ProjectedSchrodingerPyCI(FanCI):
             component.assign_params(new_params)
 
         # Shape of y is (no. determinants, no. active parameters excluding energy)
-        y = np.zeros(
-            (occs_array.shape[0], self.nactive - self.mask[-1]),
-            dtype=pyci.c_double,
-        )
+        if (s_chunk is None) and (f_chunk is None):
+            y = np.zeros(
+                (occs_array.shape[0], self.nactive - self.mask[-1]),
+                dtype=pyci.c_double,
+            )
 
-        # Select parameters according to selected chunks
-        y = y[s_chunk:f_chunk]
+        else:
+            # Select parameters according to selected chunks
+            y = np.zeros(
+                (f_chunk - s_chunk, self.nactive - self.mask[-1]),
+                dtype=pyci.c_double,
+            )
 
         # Compute derivatives of overlaps
         deriv_indices = self.param_selection[self.fanpy_wfn]

--- a/fanpy/interface/pyci.py
+++ b/fanpy/interface/pyci.py
@@ -1,6 +1,7 @@
 from fanpy.eqn.projected import ProjectedSchrodinger
 
 import numpy as np
+from scipy.special import comb
 from typing import Any
 
 # Log Levels
@@ -77,7 +78,6 @@ class PYCI:
         self.fanpy_ham = fanpy_objective.ham
 
         self.legacy_fanci = legacy_fanci
-        self.nproj = fanpy_objective.nproj
         self.step_print = fanpy_objective.step_print
         self.step_save = fanpy_objective.step_save
         self.tmpfile = fanpy_objective.tmpfile
@@ -122,6 +122,22 @@ class PYCI:
         else:
             self.fill = "excitation"
             self.pspace_wfn = pyci.fullci_wfn(self.pyci_ham.nbasis, self.fanpy_wfn.nelec - self.nocc, self.nocc)
+
+        # Check if the number of projections is valid for PyCI
+        self.nproj = fanpy_objective.nproj
+
+        max_pyci_nproj = int(
+            comb(self.fanpy_wfn.nspin // 2, self.fanpy_wfn.nelec - self.fanpy_wfn.nelec // 2)
+            * comb(self.fanpy_wfn.nspin // 2, self.fanpy_wfn.nelec // 2)
+        )
+
+        if self.nproj > max_pyci_nproj:
+            print(
+                f"WARNING: Invalid number of projections ({self.nproj} > {max_pyci_nproj}). "
+                f"PyCI only supports projections with Sz = 0.\n"
+                f"Reassigning 'nproj' to {max_pyci_nproj}..."
+            )
+            self.nproj = max_pyci_nproj
 
         self.build_pyci_objective(legacy=legacy_fanci)
 

--- a/fanpy/interface/pyci.py
+++ b/fanpy/interface/pyci.py
@@ -125,30 +125,35 @@ class PYCI:
             self.fill = "excitation"
             self.pspace_wfn = pyci.fullci_wfn(self.pyci_ham.nbasis, self.fanpy_wfn.nelec - self.nocc, self.nocc)
 
-            # Check if the number of projections is valid for PyCI
-            if self.objective.pspace_exc_orders is None:
+        # Check if the number of projections is valid for PyCI
+        if self.fanpy_objective.pspace_exc_orders is None:
+            if self.fill == "seniority":
+                max_pyci_nproj = int(comb(self.fanpy_wfn.nspin // 2, self.fanpy_wfn.nelec // 2))
+
+            elif self.fill == "excitation":
                 max_pyci_nproj = int(
                     comb(self.fanpy_wfn.nspin // 2, self.fanpy_wfn.nelec - self.fanpy_wfn.nelec // 2)
                     * comb(self.fanpy_wfn.nspin // 2, self.fanpy_wfn.nelec // 2)
                 )
-            else:
-                max_pyci_nproj = len(
-                    sd_list(
-                        self.fanpy_wfn.nelec,
-                        self.fanpy_wfn.nspin,
-                        spin=0,
-                        seniority=self.seniority,
-                        exc_orders=self.fanpy_objective.pspace_exc_orders,
-                    )
-                )
 
-            if self.nproj > max_pyci_nproj:
-                print(
-                    f"WARNING: Invalid number of projections ({self.nproj} > {max_pyci_nproj}). "
-                    f"PyCI only supports projections with Sz = 0.\n"
-                    f"Reassigning 'nproj' to {max_pyci_nproj}..."
+        else:
+            max_pyci_nproj = len(
+                sd_list(
+                    self.fanpy_wfn.nelec,
+                    self.fanpy_wfn.nspin,
+                    spin=0,
+                    seniority=self.seniority,
+                    exc_orders=self.fanpy_objective.pspace_exc_orders,
                 )
-                self.nproj = max_pyci_nproj
+            )
+
+        if self.nproj > max_pyci_nproj:
+            print(
+                f"WARNING: Invalid number of projections ({self.nproj} > {max_pyci_nproj}). "
+                f"PyCI only supports projections with Sz = 0.\n"
+                f"Reassigning 'nproj' to {max_pyci_nproj}..."
+            )
+            self.nproj = max_pyci_nproj
 
         self.build_pyci_objective(legacy=legacy_fanci)
 


### PR DESCRIPTION
This issue arises from a current limitation in PyCI. Specifically, the Full Configuration Interaction (Full-CI) wavefunctions used in PyCI (triggered when the "fill" method is set to 'excitation') are restricted to Slater determinants with total spin projection $$S_z = 0$$.

Since the goal of this interface is to provide a seamless user experience, the initial implementation retrieves the number of projections (nproj) from Fanpy’s Objective object. However, if the user does not explicitly set the spin in the Wavefunction object, Fanpy assumes all spin cases are valid. This assumption creates a mismatch with PyCI, which only supports $$S_z = 0$$, leading to a conflict.

This issue has been addressed in [this commit]. Now, if the user specifies an nproj value larger than PyCI’s maximum allowable number of projections, a warning is issued and nproj is automatically adjusted to this upper limit.

Unfortunately, PyCI does not offer the same level of flexibility as Fanpy when defining the projection space (pspace). This is due to PyCI’s internal approach for generating Slater determinants via excitations: it constructs the Full-CI wavefunction by sequentially adding single, double, and higher excitations, all constrained to $$S_z = 0$$. This fixed structure limits the seamless integration originally intended.

To work around this, users have three options:

1. Manually build pspace using sd_list with $$S_z = 0$$:

This method gives full control over the Slater determinants included in pspace.
```
pspace = sd_list(nelec, nspinorb, num_limit=None, exc_orders=[1, 2], spin=0)
objective = ProjectedSchrodinger(wfn, ham, energy_type='compute', pspace=pspace)
```

2. Specify the excitation orders directly using pspace_exc_orders:

This will instruct the interface to follow PyCI’s excitation-based filling logic. The list should include consecutive excitation orders (e.g., [1, 2]), as PyCI does not support skipping excitation ranks.
```
objective = ProjectedSchrodinger(wfn, ham, energy_type='compute', pspace_exc_orders=[1, 2])
```

3. Limit the number of projections manually by slicing the pspace:

You can define an arbitrary number of projections by generating pspace manually and slicing it.
```
my_nproj = 1000
pspace = sd_list(nelec, nspinorb, num_limit=None, exc_orders=[1, 2], spin=0)
objective = ProjectedSchrodinger(wfn, ham, energy_type='compute', pspace=pspace[:my_nproj])
```
