### PR TITLE
Correcting the number of projections in PyCI interface

### DIFF
--- a/fanpy/interface/pyci.py
+++ b/fanpy/interface/pyci.py
@@ -151,7 +151,7 @@ class PYCI:
             print(
                 f"WARNING: Invalid number of projections ({self.nproj} > {max_pyci_nproj}). "
                 f"PyCI only supports projections with Sz = 0.\n"
-                f"Reassigning 'nproj' to {max_pyci_nproj}..."
+                f"Reassigning 'nproj' to {max_pyci_nproj} in PyCI interface..."
             )
             self.nproj = max_pyci_nproj
 


### PR DESCRIPTION
This issue arises from a current limitation in PyCI. Specifically, the Full Configuration Interaction (Full-CI) wavefunctions used in PyCI (triggered when the "fill" method is set to 'excitation') are restricted to Slater determinants with total spin projection $$S_z = 0$$.

Since the goal of this interface is to provide a seamless user experience, the initial implementation retrieves the number of projections (nproj) from Fanpy’s Objective object. However, if the user does not explicitly set the spin in the Wavefunction object, Fanpy assumes all spin cases are valid. This assumption creates a mismatch with PyCI, which only supports $$S_z = 0$$, leading to a conflict.

This issue has been addressed in [this commit]. Now, if the user specifies an nproj value larger than PyCI’s maximum allowable number of projections, a warning is issued and nproj is automatically adjusted to this upper limit.

Unfortunately, PyCI does not offer the same level of flexibility as Fanpy when defining the projection space (pspace). This is due to PyCI’s internal approach for generating Slater determinants via excitations: it constructs the Full-CI wavefunction by sequentially adding single, double, and higher excitations, all constrained to $$S_z = 0$$. This fixed structure limits the seamless integration originally intended.

To work around this, users have three options:

1. Manually build pspace using sd_list with $$S_z = 0$$:

This method gives full control over the Slater determinants included in pspace.
```
pspace = sd_list(nelec, nspinorb, num_limit=None, exc_orders=[1, 2], spin=0)
objective = ProjectedSchrodinger(wfn, ham, energy_type='compute', pspace=pspace)
```

2. Specify the excitation orders directly using pspace_exc_orders:

This will instruct the interface to follow PyCI’s excitation-based filling logic. The list should include consecutive excitation orders (e.g., [1, 2]), as PyCI does not support skipping excitation ranks.
```
objective = ProjectedSchrodinger(wfn, ham, energy_type='compute', pspace_exc_orders=[1, 2])
```

3. Limit the number of projections manually by slicing the pspace:

You can define an arbitrary number of projections by generating pspace manually and slicing it.
```
my_nproj = 1000
pspace = sd_list(nelec, nspinorb, num_limit=None, exc_orders=[1, 2], spin=0)
objective = ProjectedSchrodinger(wfn, ham, energy_type='compute', pspace=pspace[:my_nproj])
```

---- 

The warning message was updated to make clear that `nproj` is only updated on PyCI interface and it doesn't affect Fanpy objective object, as suggested by @kzsigmond. We could update the Fanpy objective with this new parameter, but I am not sure if it is the best approach.