### PR TITLE
Solve issue with scipy > 1.10

### DIFF
--- a/fanpy/solver/ci.py
+++ b/fanpy/solver/ci.py
@@ -67,7 +67,16 @@ def brute(wfn, ham, save_file=""):
             ci_matrix[i, i + j] += ham.integrate_sd_sd(sd1, sd2)
     # ci_matrix += ci_matrix.T - np.diag(np.diag(ci_matrix))
 
-    eigval, eigvec = scipy.linalg.eigh(ci_matrix, lower=False, overwrite_a=True, turbo=False, type=1)
+    # Check Scipy version for compatibility with the 'turbo' argument
+    # Note: The 'turbo' argument was removed in Scipy 1.11.0 and is not available in newer versions.
+    # This check is to ensure compatibility with older versions of Scipy.
+    scipy_version = tuple(map(int, scipy.__version__.split(".")[:2]))
+
+    if scipy_version < (1, 11):
+        eigval, eigvec = scipy.linalg.eigh(ci_matrix, lower=False, overwrite_a=True, turbo=False, type=1)
+    else:
+        eigval, eigvec = scipy.linalg.eigh(ci_matrix, lower=False, overwrite_a=True, type=1)
+
     del ci_matrix
 
     if save_file != "":


### PR DESCRIPTION
Solving the issue with scipy.linalg.eigh's argument 'turbo' has been removed in newer versions of scipy.

The scipy version has been tested to keep usability with older versions, but it can be removed in future updates.