### PR TITLE
Solving Numpy depreciation warnings

### DIFF
--- a/fanpy/ham/restricted_chemical.py
+++ b/fanpy/ham/restricted_chemical.py
@@ -88,7 +88,7 @@ class RestrictedMolecularHamiltonian(GeneralizedMolecularHamiltonian):
 
     # FIXME: remove sign?
     # FIXME: too many branches, too many statements
-    def integrate_sd_sd(self, sd1, sd2, deriv=None, components=False):  # pylint: disable=R0911
+    def integrate_sd_sd_decomposed(self, sd1, sd2, deriv=None):  # pylint: disable=R0911
         r"""Integrate the Hamiltonian with against two Slater determinants.
 
         .. math::
@@ -115,18 +115,11 @@ class RestrictedMolecularHamiltonian(GeneralizedMolecularHamiltonian):
         deriv : np.ndarray
             Indices of the Hamiltonian parameters against which the integral is derivatized.
             Default is no derivatization.
-        components : {bool, False}
-            Option for separating the integrals into the one electron, coulomb, and exchange
-            components.
-            Default adds the three components together.
 
         Returns
         -------
-        integral : {float, np.ndarray(3,)}
-            Values of the integrals.
-            If `components` is False, then the value of the integral is returned.
-            If `components` is True, then the value of the one electron, coulomb, and exchange
-            components are returned.
+        integral : {np.ndarray(3,)}
+            Array containing the values of the one electron, coulomb, and exchange components.
 
         Raises
         ------
@@ -136,7 +129,7 @@ class RestrictedMolecularHamiltonian(GeneralizedMolecularHamiltonian):
         """
         # pylint: disable=C0103,R0912,R0915
         if deriv is not None:
-            return self._integrate_sd_sd_deriv(sd1, sd2, deriv, components=components)
+            return self._integrate_sd_sd_deriv_decomposed(sd1, sd2, deriv)
 
         nspatial = self.nspatial
 
@@ -149,14 +142,10 @@ class RestrictedMolecularHamiltonian(GeneralizedMolecularHamiltonian):
 
         # if two Slater determinants do not have the same number of electrons
         if len(diff_sd1) != len(diff_sd2):
-            if components:
-                return 0.0, 0.0, 0.0
-            return 0.0
+            return 0.0, 0.0, 0.0
         diff_order = len(diff_sd1)
         if diff_order > 2:
-            if components:
-                return 0.0, 0.0, 0.0
-            return 0.0
+            return 0.0, 0.0, 0.0
 
         sign = slater.sign_excite(sd1, diff_sd1, reversed(diff_sd2))
 
@@ -173,9 +162,50 @@ class RestrictedMolecularHamiltonian(GeneralizedMolecularHamiltonian):
         else:
             one_electron, coulomb, exchange = self._integrate_sd_sd_two(diff_sd1, diff_sd2)
 
-        if components:
-            return sign * np.array([one_electron, coulomb, exchange])
-        return sign * (one_electron + coulomb + exchange)
+        return sign * np.array([one_electron, coulomb, exchange])
+
+    def integrate_sd_sd(self, sd1, sd2, deriv=None):  # pylint: disable=R0911
+        r"""Integrate the Hamiltonian with against two Slater determinants.
+
+        .. math::
+
+            H_{\mathbf{m}\mathbf{n}} &=
+            \left< \mathbf{m} \middle| \hat{H} \middle| \mathbf{n} \right>\\
+            &= \sum_{ij}
+               h_{ij} \left< \mathbf{m} \middle| a^\dagger_i a_j \middle| \mathbf{n} \right>
+            + \sum_{i<j, k<l} g_{ijkl}
+            \left< \mathbf{m} \middle| a^\dagger_i a^\dagger_j a_l a_k \middle| \mathbf{n} \right>\\
+
+        In the first summation involving :math:`h_{ij}`, only the terms where :math:`\mathbf{m}` and
+        :math:`\mathbf{n}` are different by at most single excitation will contribute to the
+        integral. In the second summation involving :math:`g_{ijkl}`, only the terms where
+        :math:`\mathbf{m}` and :math:`\mathbf{n}` are different by at most double excitation will
+        contribute to the integral.
+
+        Parameters
+        ----------
+        sd1 : int
+            Slater Determinant against which the Hamiltonian is integrated.
+        sd2 : int
+            Slater Determinant against which the Hamiltonian is integrated.
+        deriv : np.ndarray
+            Indices of the Hamiltonian parameters against which the integral is derivatized.
+            Default is no derivatization.
+
+        Returns
+        -------
+        integral : {np.ndarray(3,)}
+            Array containing the values of the one electron, coulomb, and exchange components.
+
+        Raises
+        ------
+        TypeError
+            If Slater determinant is not an integer.
+
+        """
+        decomposed_integral = self.integrate_sd_sd_decomposed(sd1, sd2, deriv=deriv)
+
+        return np.sum(decomposed_integral, axis=0)
 
     def param_ind_to_rowcol_ind(self, param_ind):
         r"""Return the row and column indices of the antihermitian matrix from the parameter index.
@@ -231,10 +261,10 @@ class RestrictedMolecularHamiltonian(GeneralizedMolecularHamiltonian):
 
         return int(x), int(y)
 
-    # TODO: Much of the following function can be shortened by using impure functions (function with
-    # a side effect) instead
+    # TODO: Much of the following function can be shortened by using impure functions
+    # (function with a side effect) instead
     # FIXME: too many branches, too many statements
-    def _integrate_sd_sd_deriv(self, sd1, sd2, deriv, components=False):
+    def _integrate_sd_sd_deriv_decomposed(self, sd1, sd2, deriv):
         r"""Return derivative of the CI matrix element with respect to the antihermitian elements.
 
         Parameters
@@ -245,18 +275,12 @@ class RestrictedMolecularHamiltonian(GeneralizedMolecularHamiltonian):
             Slater Determinant against which the Hamiltonian is integrated.
         deriv : np.ndarray
             Indices of the Hamiltonian parameter against which the integral is derivatized.
-        components : {bool, False}
-            Option for separating the integrals into the one electron, coulomb, and exchange
-            components.
-            Default adds the three components together.
 
         Returns
         -------
-        d_integral : {np.ndarray(3, len(deriv)), np.ndarray(len(deriv))}
-            Derivatives of the integral with respect to the given parameters.
-            If `components` is False, then the derivative of the integral is returned.
-            If `components` is True, then the derivative of the one electron, coulomb, and exchange
-            components are returned.
+        d_integral : np.ndarray(3, len(deriv))
+            Derivatives of the one electron, coulomb, and exchange integrals with respect
+            to the given parameters.
 
         Raises
         ------
@@ -287,14 +311,10 @@ class RestrictedMolecularHamiltonian(GeneralizedMolecularHamiltonian):
 
         # if two Slater determinants do not have the same number of electrons
         if len(diff_sd1) != len(diff_sd2):
-            if components:
-                return np.zeros((3, len(deriv)))
-            return np.zeros(len(deriv))
+            return np.zeros((3, len(deriv)))
         diff_order = len(diff_sd1)
         if diff_order > 2:
-            if components:
-                return np.zeros((3, len(deriv)))
-            return np.zeros(len(deriv))
+            return np.zeros((3, len(deriv)))
 
         # get sign
         sign = slater.sign_excite(sd1, diff_sd1, reversed(diff_sd2))
@@ -324,9 +344,44 @@ class RestrictedMolecularHamiltonian(GeneralizedMolecularHamiltonian):
             else:
                 output[i] = self._integrate_sd_sd_deriv_two(diff_sd1, diff_sd2, x, y)
 
-        if components:
-            return sign * output.T
-        return sign * np.sum(output, axis=1)
+        return sign * output.T
+
+    def _integrate_sd_sd_deriv(self, sd1, sd2, deriv):
+        r"""Return derivative of the CI matrix element with respect to the antihermitian elements.
+
+        Parameters
+        ----------
+        sd1 : int
+            Slater Determinant against which the Hamiltonian is integrated.
+        sd2 : int
+            Slater Determinant against which the Hamiltonian is integrated.
+        deriv : np.ndarray
+            Indices of the Hamiltonian parameter against which the integral is derivatized.
+
+        Returns
+        -------
+        d_integral : np.ndarray(len(deriv))
+            Derivatives of the one electron, coulomb, and exchange integrals with respect
+            to the given parameters.
+
+        Raises
+        ------
+        TypeError
+            If Slater determinant is not an integer.
+        ValueError
+            If the given `deriv` is not an integer greater than or equal to 0 and less than the
+            number of parameters.
+
+        Notes
+        -----
+        Integrals are not assumed to be real. The performance benefit (at the moment) for assuming
+        real orbitals is not much.
+
+        """
+        # pylint: disable=C0103
+
+        derivatives = self._integrate_sd_sd_deriv_decomposed(sd1, sd2, deriv)
+        return np.sum(derivatives)
 
     def _integrate_sd_sd_zero(self, shared_alpha, shared_beta):
         """Return integrals of the given Slater determinant with itself.

--- a/fanpy/ham/restricted_chemical.py
+++ b/fanpy/ham/restricted_chemical.py
@@ -614,7 +614,7 @@ class RestrictedMolecularHamiltonian(GeneralizedMolecularHamiltonian):
         spin_a, spin_b = map(lambda i: int(not slater.is_alpha(i, nspatial)), [a, b])
 
         if spin_a == 0 and spin_b == 0:
-            shared_alpha_no_ab = shared_alpha[~np.in1d(shared_alpha, [a, b])]
+            shared_alpha_no_ab = shared_alpha[~np.isin(shared_alpha, [a, b])]
             shared_beta_no_ab = shared_beta
         elif spin_a == 0 and spin_b == 1:
             shared_alpha_no_ab = shared_alpha[shared_alpha != a]
@@ -624,7 +624,7 @@ class RestrictedMolecularHamiltonian(GeneralizedMolecularHamiltonian):
             shared_beta_no_ab = shared_beta[shared_beta != a]
         else:
             shared_alpha_no_ab = shared_alpha
-            shared_beta_no_ab = shared_beta[~np.in1d(shared_beta, [a, b])]
+            shared_beta_no_ab = shared_beta[~np.isin(shared_beta, [a, b])]
 
         # selected (spin orbital) x = a
         if x == spatial_a and spin_a == spin_b:

--- a/fanpy/solver/ci.py
+++ b/fanpy/solver/ci.py
@@ -64,7 +64,7 @@ def brute(wfn, ham, save_file=""):
     ci_matrix = np.zeros((wfn.nsd, wfn.nsd))
     for i, sd1 in enumerate(wfn.sds):
         for j, sd2 in enumerate(wfn.sds[i:]):
-            ci_matrix[i, i + j] += ham.integrate_sd_sd(sd1, sd2)
+            ci_matrix[i, i + j] += ham.integrate_sd_sd(sd1, sd2).item()
     # ci_matrix += ci_matrix.T - np.diag(np.diag(ci_matrix))
 
     eigval, eigvec = scipy.linalg.eigh(ci_matrix, lower=False, overwrite_a=True, turbo=False, type=1)

--- a/fanpy/solver/ci.py
+++ b/fanpy/solver/ci.py
@@ -64,7 +64,7 @@ def brute(wfn, ham, save_file=""):
     ci_matrix = np.zeros((wfn.nsd, wfn.nsd))
     for i, sd1 in enumerate(wfn.sds):
         for j, sd2 in enumerate(wfn.sds[i:]):
-            ci_matrix[i, i + j] += ham.integrate_sd_sd(sd1, sd2).item()
+            ci_matrix[i, i + j] += ham.integrate_sd_sd(sd1, sd2)
     # ci_matrix += ci_matrix.T - np.diag(np.diag(ci_matrix))
 
     eigval, eigvec = scipy.linalg.eigh(ci_matrix, lower=False, overwrite_a=True, turbo=False, type=1)

--- a/fanpy/tools/math_tools.py
+++ b/fanpy/tools/math_tools.py
@@ -19,6 +19,7 @@ permanent_borchardt(matrix)
 from itertools import combinations, permutations
 
 import numpy as np
+import math
 
 from scipy.linalg import expm
 from scipy.special import comb
@@ -181,7 +182,7 @@ def permanent_ryser(matrix):
             matrix = matrix.transpose()
             nrow, ncol = ncol, nrow
         matrix = np.pad(matrix, ((0, ncol - nrow), (0, 0)), mode="constant", constant_values=((0, 1.0), (0, 0)))
-        factor /= np.math.factorial(ncol - nrow)
+        factor /= math.factorial(ncol - nrow)
 
     # Initialize rowsum array.
     rowsums = np.zeros(ncol, dtype=matrix.dtype)

--- a/fanpy/tools/math_tools.py
+++ b/fanpy/tools/math_tools.py
@@ -290,7 +290,7 @@ def permanent_borchardt(lambdas, epsilons, zetas, etas=None):
     for indices in combinations(range(num_col), num_row):
         indices = np.array(indices)
         submatrix = cauchy_matrix[:, indices]
-        perm_zetas = np.product(zetas[indices])
+        perm_zetas = np.prod(zetas[indices])
         perm_cauchy += np.linalg.det(submatrix**2) / np.linalg.det(submatrix) * perm_zetas
 
     perm_etas = np.prod(etas)

--- a/fanpy/wfn/cc/base.py
+++ b/fanpy/wfn/cc/base.py
@@ -547,7 +547,7 @@ class BaseCC(BaseWavefunction):
             for indices_sign in indices_multi.values():
                 indices, signs = indices_sign[:, :-1], indices_sign[:, -1]
                 signs = signs.astype(np.int8)
-                signs[signs > 1] = -1
+                signs[signs < 1] = -1
                 output += np.sum(np.prod(self.params[indices], axis=1) * signs)
             return output
 
@@ -555,7 +555,7 @@ class BaseCC(BaseWavefunction):
         for indices_sign in indices_multi.values():
             indices, signs = indices_sign[:, :-1], indices_sign[:, -1]
             signs = signs.astype(np.int8)
-            signs[signs > 1] = -1
+            signs[signs < 1] = -1
             for ind in set(indices.ravel()):
                 bool_indices = ind == indices
                 row_inds = np.sum(bool_indices, axis=1, dtype=bool)
@@ -875,6 +875,10 @@ class BaseCC(BaseWavefunction):
                         sign *= slater.sign_perm(jumbled_a_inds, a_inds)
                         # unjumble the creators
                         sign *= slater.sign_perm(jumbled_c_inds, c_inds)
+
+                        # convert negative integer to zero to keep using np.uint dtypes
+                        if sign == -1:
+                            sign = 0
 
                         inds = [self.get_ind(exop) for exop in combs] + [sign]
                         if len(inds) - 1 in inds_multi:

--- a/tests/test_ham_base.py
+++ b/tests/test_ham_base.py
@@ -1,4 +1,5 @@
 """Test fanpy.ham.base."""
+
 from fanpy.ham.base import BaseHamiltonian
 from fanpy.wfn.ci.base import CIWavefunction
 
@@ -18,7 +19,7 @@ class TempBaseHamiltonian(BaseHamiltonian):
         """Return number of spin orbitals."""
         return 10
 
-    def integrate_sd_sd(self, sd1, sd2, deriv=None, components=True):
+    def integrate_sd_sd(self, sd1, sd2, deriv=None):
         """Integrate slater determinants."""
         return 1
 

--- a/tests/test_ham_generalized_chemical.py
+++ b/tests/test_ham_generalized_chemical.py
@@ -1,4 +1,5 @@
 """Test fanpy.ham.generalized_chemical."""
+
 import itertools as it
 
 from fanpy.ham.base import BaseHamiltonian
@@ -123,15 +124,7 @@ def test_integrate_sd_wfn():
     test_wfn = type(
         "Temporary wavefunction.",
         (object,),
-        {
-            "get_overlap": lambda sd, deriv=None: 1
-            if sd == 0b0101
-            else 2
-            if sd == 0b1010
-            else 3
-            if sd == 0b1100
-            else 0
-        },
+        {"get_overlap": lambda sd, deriv=None: 1 if sd == 0b0101 else 2 if sd == 0b1010 else 3 if sd == 0b1100 else 0},
     )
 
     one_energy, coulomb, exchange = test_ham.integrate_sd_wfn(0b0101, test_wfn, components=True)
@@ -175,26 +168,24 @@ def test_integrate_sd_wfn():
         test_ham.integrate_sd_wfn("1", test_wfn)
 
 
-def test_integrate_sd_sd_trivial():
+def test_integrate_sd_sd_decomposed_trivial():
     """Test GeneralizedMolecularHamiltonian.integrate_sd_sd for trivial cases."""
     one_int = np.random.rand(6, 6)
     two_int = np.random.rand(6, 6, 6, 6)
     test = GeneralizedMolecularHamiltonian(one_int, two_int)
 
-    assert np.allclose((0, 0, 0), test.integrate_sd_sd(0b000111, 0b001001, components=True))
-    assert np.allclose((0, 0, 0), test.integrate_sd_sd(0b000111, 0b111000, components=True))
+    assert np.allclose((0, 0, 0), test.integrate_sd_sd_decomposed(0b000111, 0b001001))
+    assert np.allclose((0, 0, 0), test.integrate_sd_sd_decomposed(0b000111, 0b111000))
     assert np.allclose(
         (0, two_int[0, 1, 2, 3], -two_int[0, 1, 3, 2]),
-        test.integrate_sd_sd(0b100011, 0b101100, components=True),
+        test.integrate_sd_sd_decomposed(0b100011, 0b101100),
     )
-    assert two_int[0, 1, 2, 3] - two_int[0, 1, 3, 2] == test.integrate_sd_sd(
-        0b100011, 0b101100, components=False
-    )
-    assert np.allclose((one_int[0, 0], 0, 0), test.integrate_sd_sd(0b1, 0b1, components=True))
-    assert np.allclose((one_int[0, 1], 0, 0), test.integrate_sd_sd(0b1, 0b10, components=True))
+    assert two_int[0, 1, 2, 3] - two_int[0, 1, 3, 2] == test.integrate_sd_sd(0b100011, 0b101100)
+    assert np.allclose((one_int[0, 0], 0, 0), test.integrate_sd_sd_decomposed(0b1, 0b1))
+    assert np.allclose((one_int[0, 1], 0, 0), test.integrate_sd_sd_decomposed(0b1, 0b10))
     assert np.allclose(
         (0, -two_int[1, 4, 1, 3] + two_int[0, 4, 0, 3], two_int[1, 4, 3, 1] - two_int[0, 4, 3, 0]),
-        test.integrate_sd_sd(0b110001, 0b101010, deriv=np.array([0]), components=True).ravel(),
+        test.integrate_sd_sd_decomposed(0b110001, 0b101010, deriv=np.array([0])).ravel(),
     )
 
     with pytest.raises(TypeError):
@@ -352,7 +343,7 @@ def test_integrate_sd_sd_particlenum():
     # \braket{12 | h_{11} + h_{22} + g_{1212} - g_{1221} | 12}
     assert np.allclose(ham.integrate_sd_sd(civec[1], civec[1]), 4)
 
-    assert np.allclose(ham.integrate_sd_sd(civec[0], civec[1], components=True), 0)
+    assert np.allclose(ham.integrate_sd_sd_decomposed(civec[0], civec[1]), 0)
 
 
 def test_param_ind_to_rowcol_ind():
@@ -378,9 +369,7 @@ def test_integrate_sd_sd_deriv():
     with pytest.raises(ValueError):
         test_ham._integrate_sd_sd_deriv(0b0101, 0b0101, 2)
     assert test_ham._integrate_sd_sd_deriv(0b0101, 0b0001, np.array([0])) == 0
-    assert np.allclose(
-        test_ham._integrate_sd_sd_deriv(0b0101, 0b0001, np.array([0]), components=True), 0
-    )
+    assert np.allclose(test_ham._integrate_sd_sd_deriv_decomposed(0b0101, 0b0001, np.array([0])), 0)
     assert test_ham._integrate_sd_sd_deriv(0b000111, 0b111000, np.array([0])) == 0
 
     with pytest.raises(TypeError):
@@ -417,12 +406,10 @@ def test_integrate_sd_sd_deriv_fdiff_h2_sto6g():
                 test_ham2 = GeneralizedMolecularHamiltonian(one_int, two_int, params=addition)
 
                 finite_diff = (
-                    np.array(test_ham2.integrate_sd_sd(sd1, sd2, components=True))
-                    - np.array(test_ham.integrate_sd_sd(sd1, sd2, components=True))
+                    np.array(test_ham2.integrate_sd_sd_decomposed(sd1, sd2))
+                    - np.array(test_ham.integrate_sd_sd_decomposed(sd1, sd2))
                 ) / epsilon
-                derivative = test_ham._integrate_sd_sd_deriv(
-                    sd1, sd2, np.array([i]), components=True
-                ).ravel()
+                derivative = test_ham._integrate_sd_sd_deriv_decomposed(sd1, sd2, np.array([i])).ravel()
                 assert np.allclose(finite_diff, derivative, atol=20 * epsilon)
 
 
@@ -456,12 +443,10 @@ def test_integrate_sd_sd_deriv_fdiff_h4_sto6g_trial_slow():
                 test_ham2 = GeneralizedMolecularHamiltonian(one_int, two_int, params=addition)
 
                 finite_diff = (
-                    np.array(test_ham2.integrate_sd_sd(sd1, sd2, components=True))
-                    - np.array(test_ham.integrate_sd_sd(sd1, sd2, components=True))
+                    np.array(test_ham2.integrate_sd_sd_decomposed(sd1, sd2))
+                    - np.array(test_ham.integrate_sd_sd_decomposed(sd1, sd2))
                 ) / epsilon
-                derivative = test_ham._integrate_sd_sd_deriv(
-                    sd1, sd2, np.array([i]), components=True
-                ).ravel()
+                derivative = test_ham._integrate_sd_sd_deriv_decomposed(sd1, sd2, np.array([i])).ravel()
                 assert np.allclose(finite_diff, derivative, atol=20 * epsilon)
 
 
@@ -494,21 +479,16 @@ def test_integrate_sd_sd_deriv_fdiff_random():
                 test_ham2 = GeneralizedMolecularHamiltonian(one_int, two_int, params=addition)
 
                 finite_diff = (
-                    np.array(test_ham2.integrate_sd_sd(sd1, sd2, components=True))
-                    - np.array(test_ham.integrate_sd_sd(sd1, sd2, components=True))
+                    np.array(test_ham2.integrate_sd_sd_decomposed(sd1, sd2))
+                    - np.array(test_ham.integrate_sd_sd_decomposed(sd1, sd2))
                 ) / epsilon
-                derivative = test_ham._integrate_sd_sd_deriv(
-                    sd1, sd2, np.array([i]), components=True
-                ).ravel()
+                derivative = test_ham._integrate_sd_sd_deriv_decomposed(sd1, sd2, np.array([i])).ravel()
                 assert np.allclose(finite_diff, derivative, atol=20 * epsilon)
 
                 finite_diff = (
-                    np.array(test_ham2.integrate_sd_sd(sd1, sd2, components=False))
-                    - np.array(test_ham.integrate_sd_sd(sd1, sd2, components=False))
+                    np.array(test_ham2.integrate_sd_sd(sd1, sd2)) - np.array(test_ham.integrate_sd_sd(sd1, sd2))
                 ) / epsilon
-                derivative = test_ham._integrate_sd_sd_deriv(
-                    sd1, sd2, np.array([i]), components=False
-                ).ravel()
+                derivative = test_ham._integrate_sd_sd_deriv(sd1, sd2, np.array([i])).ravel()
                 assert np.allclose(finite_diff, derivative, atol=60 * epsilon)
 
 
@@ -541,12 +521,10 @@ def test_integrate_sd_sd_deriv_fdiff_random_small():
                 test_ham2 = GeneralizedMolecularHamiltonian(one_int, two_int, params=addition)
 
                 finite_diff = (
-                    np.array(test_ham2.integrate_sd_sd(sd1, sd2, components=True))
-                    - np.array(test_ham.integrate_sd_sd(sd1, sd2, components=True))
+                    np.array(test_ham2.integrate_sd_sd_decomposed(sd1, sd2))
+                    - np.array(test_ham.integrate_sd_sd_decomposed(sd1, sd2))
                 ) / epsilon
-                derivative = test_ham._integrate_sd_sd_deriv(
-                    sd1, sd2, np.array([i]), components=True
-                ).ravel()
+                derivative = test_ham._integrate_sd_sd_deriv_decomposed(sd1, sd2, np.array([i])).ravel()
                 assert np.allclose(finite_diff, derivative, atol=20 * epsilon)
 
 
@@ -628,13 +606,7 @@ def test_integrate_sd_sds_deriv_zero():
     assert np.allclose(
         test_ham._integrate_sd_sds_deriv_zero(occ_indices, vir_indices),
         np.array(
-            [
-                [
-                    test_ham._integrate_sd_sd_deriv_zero(i, j, occ_indices)
-                    for i in range(7)
-                    for j in range(i + 1, 8)
-                ]
-            ]
+            [[test_ham._integrate_sd_sd_deriv_zero(i, j, occ_indices) for i in range(7) for j in range(i + 1, 8)]]
         ).T,
     )
 
@@ -656,11 +628,7 @@ def test_integrate_sd_sds_deriv_one():
             np.array(
                 [
                     [
-                        np.array(
-                            test_ham._integrate_sd_sd_deriv_one(
-                                (i,), (j,), x, y, occ_indices[occ_indices != i]
-                            )
-                        )
+                        np.array(test_ham._integrate_sd_sd_deriv_one((i,), (j,), x, y, occ_indices[occ_indices != i]))
                         * slater.sign_excite(0b11011, [i], [j])
                         for x in range(8)
                         for y in range(x + 1, 8)
@@ -724,20 +692,12 @@ def test_integrate_sd_wfn_compare_basehamiltonian():
                 test_ham2.integrate_sd_wfn(slater.create(0, *occ_indices), wfn),
             )
             assert np.allclose(
-                test_ham.integrate_sd_wfn(
-                    slater.create(0, *occ_indices), wfn, wfn_deriv=np.arange(wfn.nparams)
-                ),
-                test_ham.integrate_sd_wfn(
-                    slater.create(0, *occ_indices), wfn, wfn_deriv=np.arange(wfn.nparams)
-                ),
+                test_ham.integrate_sd_wfn(slater.create(0, *occ_indices), wfn, wfn_deriv=np.arange(wfn.nparams)),
+                test_ham.integrate_sd_wfn(slater.create(0, *occ_indices), wfn, wfn_deriv=np.arange(wfn.nparams)),
             )
             assert np.allclose(
-                test_ham.integrate_sd_wfn(
-                    slater.create(0, *occ_indices), wfn, ham_deriv=np.arange(test_ham.nparams)
-                ),
-                test_ham.integrate_sd_wfn(
-                    slater.create(0, *occ_indices), wfn, ham_deriv=np.arange(test_ham2.nparams)
-                ),
+                test_ham.integrate_sd_wfn(slater.create(0, *occ_indices), wfn, ham_deriv=np.arange(test_ham.nparams)),
+                test_ham.integrate_sd_wfn(slater.create(0, *occ_indices), wfn, ham_deriv=np.arange(test_ham2.nparams)),
             )
 
 
@@ -763,17 +723,13 @@ def test_integrate_sd_wfn_deriv_fdiff():
     ham.assign_params(original + step1 + step2)
 
     temp_ham = GeneralizedMolecularHamiltonian(one_int, two_int)
-    temp_ham.orb_rotate_matrix(
-        unitary_matrix(original).dot(unitary_matrix(step1)).dot(unitary_matrix(step2))
-    )
+    temp_ham.orb_rotate_matrix(unitary_matrix(original).dot(unitary_matrix(step1)).dot(unitary_matrix(step2)))
     assert np.allclose(ham.one_int, temp_ham.one_int)
     assert np.allclose(ham.two_int, temp_ham.two_int)
 
     def objective(params):
         temp_ham = GeneralizedMolecularHamiltonian(one_int, two_int)
-        temp_ham.orb_rotate_matrix(
-            unitary_matrix(original).dot(unitary_matrix(step1)).dot(unitary_matrix(step2))
-        )
+        temp_ham.orb_rotate_matrix(unitary_matrix(original).dot(unitary_matrix(step1)).dot(unitary_matrix(step2)))
         temp_ham.set_ref_ints()
         temp_ham._prev_params = ham.params.copy()
         temp_ham.assign_params(params.copy())
@@ -798,9 +754,7 @@ def test_integrate_sd_wfn_deriv_fdiff():
 
     assert np.allclose(
         nd.Gradient(objective)(wfn.wfns[0].params),
-        ham.integrate_sd_wfn(
-            0b001011, wfn, wfn_deriv=(wfn.wfns[0], np.arange(wfn.wfns[0].nparams))
-        ),
+        ham.integrate_sd_wfn(0b001011, wfn, wfn_deriv=(wfn.wfns[0], np.arange(wfn.wfns[0].nparams))),
     )
 
 

--- a/tests/test_ham_senzero.py
+++ b/tests/test_ham_senzero.py
@@ -1,4 +1,5 @@
 """Test fanpy.ham.senzero."""
+
 from fanpy.ham.restricted_chemical import RestrictedMolecularHamiltonian
 from fanpy.ham.senzero import SeniorityZeroHamiltonian
 from fanpy.tools.math_tools import unitary_matrix
@@ -12,7 +13,7 @@ import pytest
 from utils import find_datafile
 
 
-def test_integrate_sd_sd_trivial():
+def test_integrate_sd_sd_decomposed_trivial():
     """Test SeniorityZeroHamiltonian.integrate_sd_sd for trivial cases."""
     one_int = np.random.rand(4, 4)
     two_int = np.random.rand(4, 4, 4, 4)
@@ -21,15 +22,13 @@ def test_integrate_sd_sd_trivial():
     with pytest.raises(NotImplementedError):
         test.integrate_sd_sd(0b00010001, 0b01000100, deriv=0)
 
-    assert np.allclose((0, 0, 0), test.integrate_sd_sd(0b00010001, 0b00100001, components=True))
-    assert np.allclose(0, test.integrate_sd_sd(0b00010001, 0b00100001, components=False))
-    assert np.allclose((0, 0, 0), test.integrate_sd_sd(0b00100001, 0b00010001, components=True))
-    assert np.allclose((0, 0, 0), test.integrate_sd_sd(0b01010101, 0b00010001, components=True))
-    assert np.allclose(0, test.integrate_sd_sd(0b01010101, 0b00010001, components=False))
-    assert np.allclose((0, 0, 0), test.integrate_sd_sd(0b11001100, 0b00110011, components=True))
-    assert np.allclose(
-        (0, two_int[0, 0, 1, 1], 0), test.integrate_sd_sd(0b00010001, 0b00100010, components=True)
-    )
+    assert np.allclose((0, 0, 0), test.integrate_sd_sd_decomposed(0b00010001, 0b00100001))
+    assert np.allclose(0, test.integrate_sd_sd(0b00010001, 0b00100001))
+    assert np.allclose((0, 0, 0), test.integrate_sd_sd_decomposed(0b00100001, 0b00010001))
+    assert np.allclose((0, 0, 0), test.integrate_sd_sd_decomposed(0b01010101, 0b00010001))
+    assert np.allclose(0, test.integrate_sd_sd(0b01010101, 0b00010001))
+    assert np.allclose((0, 0, 0), test.integrate_sd_sd_decomposed(0b11001100, 0b00110011))
+    assert np.allclose((0, two_int[0, 0, 1, 1], 0), test.integrate_sd_sd_decomposed(0b00010001, 0b00100010))
 
     with pytest.raises(TypeError):
         test.integrate_sd_sd(0b110001, "1")
@@ -58,9 +57,7 @@ def test_integrate_sd_sd_h2_631gdp():
             sd2 = int(sd2)
             if get_seniority(sd2, one_int.shape[0]) != 0:
                 continue
-            assert np.allclose(
-                full_ham.integrate_sd_sd(sd1, sd2), test_ham.integrate_sd_sd(sd1, sd2)
-            )
+            assert np.allclose(full_ham.integrate_sd_sd(sd1, sd2), test_ham.integrate_sd_sd(sd1, sd2))
 
 
 def test_integrate_sd_sd_lih_631g_full():
@@ -84,9 +81,7 @@ def test_integrate_sd_sd_lih_631g_full():
             sd2 = int(sd2)
             if get_seniority(sd2, one_int.shape[0]) != 0:
                 continue
-            assert np.allclose(
-                full_ham.integrate_sd_sd(sd1, sd2), test_ham.integrate_sd_sd(sd1, sd2)
-            )
+            assert np.allclose(full_ham.integrate_sd_sd(sd1, sd2), test_ham.integrate_sd_sd(sd1, sd2))
 
 
 def test_integrate_sd_wfn_2e():
@@ -133,17 +128,11 @@ def test_integrate_sd_wfn_4e():
         },
     )
 
-    assert np.allclose(
-        ham.integrate_sd_wfn(0b011011, test_wfn), ham_full.integrate_sd_wfn(0b011011, test_wfn)
-    )
+    assert np.allclose(ham.integrate_sd_wfn(0b011011, test_wfn), ham_full.integrate_sd_wfn(0b011011, test_wfn))
 
-    assert np.allclose(
-        ham.integrate_sd_wfn(0b101101, test_wfn), ham_full.integrate_sd_wfn(0b101101, test_wfn)
-    )
+    assert np.allclose(ham.integrate_sd_wfn(0b101101, test_wfn), ham_full.integrate_sd_wfn(0b101101, test_wfn))
 
-    assert np.allclose(
-        ham.integrate_sd_wfn(0b110110, test_wfn), ham_full.integrate_sd_wfn(0b110110, test_wfn)
-    )
+    assert np.allclose(ham.integrate_sd_wfn(0b110110, test_wfn), ham_full.integrate_sd_wfn(0b110110, test_wfn))
 
     with pytest.raises(ValueError):
         ham.integrate_sd_wfn(0b0101, test_wfn, wfn_deriv=0, ham_deriv=0)
@@ -189,17 +178,13 @@ def test_integrate_sd_wfn_deriv_fdiff():
     ham.assign_params(original + step1 + step2)
 
     temp_ham = SeniorityZeroHamiltonian(one_int, two_int)
-    temp_ham.orb_rotate_matrix(
-        unitary_matrix(original).dot(unitary_matrix(step1)).dot(unitary_matrix(step2))
-    )
+    temp_ham.orb_rotate_matrix(unitary_matrix(original).dot(unitary_matrix(step1)).dot(unitary_matrix(step2)))
     assert np.allclose(ham.one_int, temp_ham.one_int)
     assert np.allclose(ham.two_int, temp_ham.two_int)
 
     def objective(params):
         temp_ham = SeniorityZeroHamiltonian(one_int, two_int)
-        temp_ham.orb_rotate_matrix(
-            unitary_matrix(original).dot(unitary_matrix(step1)).dot(unitary_matrix(step2))
-        )
+        temp_ham.orb_rotate_matrix(unitary_matrix(original).dot(unitary_matrix(step1)).dot(unitary_matrix(step2)))
         temp_ham.set_ref_ints()
         temp_ham._prev_params = ham.params.copy()
         temp_ham.assign_params(params.copy())

--- a/tests/test_solver_ci.py
+++ b/tests/test_solver_ci.py
@@ -1,4 +1,5 @@
 """Test wfn.solver.ci."""
+
 from fanpy.ham.restricted_chemical import RestrictedMolecularHamiltonian
 from fanpy.solver import ci
 from fanpy.wfn.ci.base import CIWavefunction
@@ -16,35 +17,29 @@ class TempMolecularHamiltonian(RestrictedMolecularHamiltonian):
         if sd1 > sd2:
             sd1, sd2 = sd2, sd1
         if [sd1, sd2] == [0b0011, 0b0011]:
-            return [1]
+            return 1
         elif [sd1, sd2] == [0b0011, 0b1100]:
-            return [3]
+            return 3
         elif [sd1, sd2] == [0b1100, 0b1100]:
-            return [8]
+            return 8
 
 
 def test_brute(tmp_path):
     """Test wfn.solver.ci.brute."""
     test_wfn = CIWavefunction(2, 4, sds=[0b0011, 0b1100])
-    test_ham = TempMolecularHamiltonian(
-        np.ones((2, 2), dtype=float), np.ones((2, 2, 2, 2), dtype=float)
-    )
+    test_ham = TempMolecularHamiltonian(np.ones((2, 2), dtype=float), np.ones((2, 2, 2, 2), dtype=float))
     # check type
     with pytest.raises(TypeError):
         ci.brute(None, test_ham, 0)
     with pytest.raises(TypeError):
         ci.brute(test_wfn, None, 0)
 
-    test_ham = TempMolecularHamiltonian(
-        np.ones((3, 3), dtype=float), np.ones((3, 3, 3, 3), dtype=float)
-    )
+    test_ham = TempMolecularHamiltonian(np.ones((3, 3), dtype=float), np.ones((3, 3, 3, 3), dtype=float))
     with pytest.raises(ValueError):
         ci.brute(test_wfn, test_ham, 0)
 
     test_wfn = CIWavefunction(2, 4, sds=[0b0011, 0b1100])
-    test_ham = TempMolecularHamiltonian(
-        np.ones((2, 2), dtype=float), np.ones((2, 2, 2, 2), dtype=float)
-    )
+    test_ham = TempMolecularHamiltonian(np.ones((2, 2), dtype=float), np.ones((2, 2, 2, 2), dtype=float))
     with pytest.raises(TypeError):
         ci.brute(test_wfn, test_ham, None)
     with pytest.raises(TypeError):
@@ -61,10 +56,10 @@ def test_brute(tmp_path):
     results = ci.brute(test_wfn, test_ham)
     energies = results["eigval"]
     coeffs = results["eigvec"]
-    assert np.allclose(energies[0], (9 - 85 ** 0.5) / 2)
+    assert np.allclose(energies[0], (9 - 85**0.5) / 2)
     matrix = np.array([[1 - energies[0], 3], [3, 8 - energies[0]]])
     assert np.allclose(matrix.dot(coeffs[:, 0]), np.zeros(2))
-    assert np.allclose(energies[1], (9 + 85 ** 0.5) / 2)
+    assert np.allclose(energies[1], (9 + 85**0.5) / 2)
     matrix = np.array([[1 - energies[1], 3], [3, 8 - energies[1]]])
     assert np.allclose(matrix.dot(coeffs[:, 1]), np.zeros(2))
 

--- a/tests/test_wfn_cc_base.py
+++ b/tests/test_wfn_cc_base.py
@@ -1,4 +1,5 @@
 """Test fanpy.wavefunction.cc.cc_wavefunction."""
+
 import itertools as it
 import numdifftools as nd
 
@@ -14,6 +15,7 @@ from fanpy.wfn.cc.base import BaseCC
 
 class TempBaseCC(BaseCC):
     """CC wavefunction that skips initialization."""
+
     def __init__(self):
         self._cache_fns = {}
         self.exop_combinations = {}
@@ -61,13 +63,29 @@ def test_assign_exops():
     test.assign_ranks()
     test.assign_exops()
     exops = [
-        [0, 1], [0, 2], [0, 3], [1, 0], [1, 2], [1, 3], [2, 0], [2, 1], [2, 3], [3, 0], [3, 1],
-        [3, 2], [0, 1, 2, 3], [0, 2, 1, 3], [0, 3, 1, 2], [1, 2, 0, 3], [1, 3, 0, 2], [2, 3, 0, 1],
+        [0, 1],
+        [0, 2],
+        [0, 3],
+        [1, 0],
+        [1, 2],
+        [1, 3],
+        [2, 0],
+        [2, 1],
+        [2, 3],
+        [3, 0],
+        [3, 1],
+        [3, 2],
+        [0, 1, 2, 3],
+        [0, 2, 1, 3],
+        [0, 3, 1, 2],
+        [1, 2, 0, 3],
+        [1, 3, 0, 2],
+        [2, 3, 0, 1],
     ]
-    assert test.exops == {tuple(exop) : ind for ind, exop in enumerate(exops)}
+    assert test.exops == {tuple(exop): ind for ind, exop in enumerate(exops)}
     test.assign_exops([[0, 2], [1, 3]])
     exops = [[0, 1], [0, 3], [2, 1], [2, 3], [0, 2, 1, 3]]
-    assert test.exops == {tuple(exop) : ind for ind, exop in enumerate(exops)}
+    assert test.exops == {tuple(exop): ind for ind, exop in enumerate(exops)}
 
 
 def test_assign_refwfn():
@@ -200,9 +218,9 @@ def test_product_amplitudes_multi():
 
     indices = np.array([[0, 1, 2, -1]])
     answer = np.zeros(18)
-    answer[0] = - 2 * 3
-    answer[1] = - 1 * 3
-    answer[2] = - 1 * 2
+    answer[0] = -2 * 3
+    answer[1] = -1 * 3
+    answer[2] = -1 * 2
     assert np.allclose(test.product_amplitudes_multi({3: indices}, True), answer)
 
     indices = np.array([[0, 1, 2, 1], [3, 4, 5, -1]])
@@ -241,10 +259,14 @@ def test_product_amplitudes_multi():
 
 def test_olp_deriv():
     """Test BaseCC._olp_deriv."""
-    test = BaseCC(4, 10, )
+    test = BaseCC(
+        4,
+        10,
+    )
     test.assign_params(np.random.rand(test.nparams))
     test.assign_refwfn(slater.ground(4, 10))
     for sd in np.random.choice(sd_list(4, 10), 5):
+
         def func(x):
             test.assign_params(x)
             return test._olp(sd)
@@ -268,7 +290,7 @@ def test_get_overlap():
     # FIXME: WRONG NUMBERS
     # assert test.get_overlap(0b1010) == 1*4 + 2*3 + 5
     # assert test.get_overlap(0b1010, 4) == 1*4 + 2*3
-    assert test.get_overlap(0b1010) == 1*9 - 3*8 - 14
+    assert test.get_overlap(0b1010) == 1 * 9 - 3 * 8 - 14
     assert np.allclose(
         test.get_overlap(0b1010, True),
         np.array([9, 0, -8, 0, 0, 0, 0, -3, 1, 0, 0, 0, 0, -1, 0, 0, 0, 0]),
@@ -279,7 +301,7 @@ def check_sign(occ_indices, exops):
     sd = slater.create(0, *occ_indices)
     sign = 1
     for exop in exops:
-        sign *= slater.sign_excite(sd, exop[:len(exop) // 2], exop[len(exop) // 2:])
+        sign *= slater.sign_excite(sd, exop[: len(exop) // 2], exop[len(exop) // 2 :])
         sd = slater.excite(sd, *exop)
     return sign
 
@@ -298,15 +320,15 @@ def test_generate_possible_exops():
     sign = check_sign([0, 2], [[0, 1], [2, 3]]) / base_sign
     assert np.allclose(
         test.exop_combinations[(0, 2, 1, 3)][2][0],
-        [test.get_ind((0, 1)), test.get_ind((2, 3)), sign if sign == 1 else 255]
+        [test.get_ind((0, 1)), test.get_ind((2, 3)), sign if sign == 1 else 0],
     )
     assert np.allclose(
         test.exop_combinations[(0, 2, 1, 3)][2][1],
-        [test.get_ind((0, 3)), test.get_ind((2, 1)), check_sign([0, 2], [[0, 3], [2, 1]]) / base_sign]
+        [test.get_ind((0, 3)), test.get_ind((2, 1)), check_sign([0, 2], [[0, 3], [2, 1]]) / base_sign],
     )
     assert np.allclose(
         test.exop_combinations[(0, 2, 1, 3)][1][0],
-        [test.get_ind((0, 2, 1, 3)), check_sign([0, 2], [[0, 2, 1, 3]]) / base_sign]
+        [test.get_ind((0, 2, 1, 3)), check_sign([0, 2], [[0, 2, 1, 3]]) / base_sign],
     )
 
     test = TempBaseCC()
@@ -321,12 +343,11 @@ def test_generate_possible_exops():
     sign = check_sign([0, 1, 2], [[2, 5], [0, 1, 4, 6]]) / base_sign
     assert np.allclose(
         test.exop_combinations[(0, 1, 2, 4, 5, 6)][2][0],
-        [test.get_ind((2, 5)), test.get_ind((0, 1, 4, 6)), sign if sign == 1 else 255],
+        [test.get_ind((2, 5)), test.get_ind((0, 1, 4, 6)), sign if sign == 1 else 0],
     )
     assert np.allclose(
         test.exop_combinations[(0, 1, 2, 4, 5, 6)][2][1],
-        [test.get_ind((2, 6)), test.get_ind((0, 1, 4, 5)),
-         check_sign([0, 1, 2], [[2, 6], [0, 1, 4, 5]]) / base_sign],
+        [test.get_ind((2, 6)), test.get_ind((0, 1, 4, 5)), check_sign([0, 1, 2], [[2, 6], [0, 1, 4, 5]]) / base_sign],
     )
     assert np.allclose(
         test.exop_combinations[(0, 1, 2, 4, 5, 6)][1][0],
@@ -344,6 +365,10 @@ def test_generate_possible_exops():
     base_sign = slater.sign_excite(0b00000111, [0, 1, 2], [4, 5, 6])
     assert np.allclose(
         test.exop_combinations[(0, 1, 2, 4, 5, 6)][3][0],
-        [test.get_ind((0, 4)), test.get_ind((1, 6)), test.get_ind((2, 5)),
-         check_sign([0, 1, 2], [[2, 5], [0, 4], [1, 6]]) / base_sign],
+        [
+            test.get_ind((0, 4)),
+            test.get_ind((1, 6)),
+            test.get_ind((2, 5)),
+            check_sign([0, 1, 2], [[2, 5], [0, 4], [1, 6]]) / base_sign,
+        ],
     )


### PR DESCRIPTION
This pull request aims to address the  `numpy` deprecation warnings raised when running the tests. 

## Use `np.prod` instead of `np.product`

In the past, `np.product` was an independent function that relied on `np.prod`. 
In more recent versions, they have become essentially the same function, and the recommendation is to use `np.prod` since `np.product` will be deprecated.

## Math alias is deprecated

`np.math` served as a wrapper for the standard `math` module and has been replaced by `math`.

## Conversion of out-of-bound Python integers to integer arrays

This solution is a bit more complex. The issue arises from the sign value, which can be either 1 or -1. When it is -1, redefining the NumPy array with the dtype set to `np.uint*` converts negative numbers to the maximum value available for this dtype. It was previously used to convert this number back to -1 when needed. 

Now, as this "convert" feature is no longer available, the negative value is replaced by zero and converted back to -1 when required.

## Conversion of scalar to array

NumPy now requires you to extract a single element from your array instead of using it directly as a scalar. This was resolved using the method `.item()`.