### PR TITLE
Fix issue with the standard cc test

### DIFF
--- a/tests/test_wfn_cc_standard_cc.py
+++ b/tests/test_wfn_cc_standard_cc.py
@@ -54,6 +54,17 @@ def check_sign(occ_indices, exops):
         sd = slater.excite(sd, *exop)
     return sign
 
+def scale_sign(sgn):
+    """Convert sign to 1 or -1.
+    
+    Args:
+        sgn (int): Sign of the excitation in exop_comb (-1 is stored as 0).
+    
+    Returns:
+        int: 1 or -1.
+    """
+
+    return sgn * 2 - 1
 
 def test_generate_possible_exops():
     """Test StandardCC.generate_possible_exops."""
@@ -67,31 +78,31 @@ def test_generate_possible_exops():
     test.params = np.random.rand(4)
     test.generate_possible_exops([0, 2], [1, 3])
     assert np.allclose(
-        test.exop_combinations[(0, 2, 1, 3)][0][0], [test.get_ind((0, 1)), test.get_ind((2, 3))]
+        test.exop_combinations[(0, 2, 1, 3)][2][0][0:2], [test.get_ind((0, 1)), test.get_ind((2, 3))]
     )
     assert np.allclose(
-        test.exop_combinations[(0, 2, 1, 3)][1][0], [test.get_ind((0, 3)), test.get_ind((2, 1))]
+        test.exop_combinations[(0, 2, 1, 3)][2][1][0:2], [test.get_ind((0, 3)), test.get_ind((2, 1))]
     )
-    base_sign = slater.sign_excite(0b0101, [0, 2], [1, 3])
-    assert base_sign * test.exop_combinations[(0, 2, 1, 3)][0][1] == check_sign([0, 2], [[0, 1], [2, 3]])
-    assert base_sign * test.exop_combinations[(0, 2, 1, 3)][1][1] == check_sign([0, 2], [[0, 3], [2, 1]])
+    base_sign = slater.sign_excite(0b0101, [0, 2], [1, 3]) # base sign of excitation
+    assert  base_sign * scale_sign(test.exop_combinations[(0, 2, 1, 3)][2][0][-1] ) == check_sign([0, 2], [[0, 1], [2, 3]])
+    assert base_sign * scale_sign(test.exop_combinations[(0, 2, 1, 3)][2][1][-1] ) == check_sign([0, 2], [[0, 3], [2, 1]])
 
     test.assign_ranks([1, 2])
     test.assign_exops()
     test.generate_possible_exops([0, 2], [1, 3])
     assert np.allclose(
-        test.exop_combinations[(0, 2, 1, 3)][0][0], [test.get_ind((0, 1)), test.get_ind((2, 3))]
+        test.exop_combinations[(0, 2, 1, 3)][2][0][0:2], [test.get_ind((0, 1)), test.get_ind((2, 3))]
     )
     assert np.allclose(
-        test.exop_combinations[(0, 2, 1, 3)][1][0], [test.get_ind((0, 3)), test.get_ind((2, 1))]
+        test.exop_combinations[(0, 2, 1, 3)][2][1][0:2], [test.get_ind((0, 3)), test.get_ind((2, 1))]
     )
     assert np.allclose(
-        test.exop_combinations[(0, 2, 1, 3)][2][0], [test.get_ind((0, 2, 1, 3))]
+        test.exop_combinations[(0, 2, 1, 3)][1][0][0:1], [test.get_ind((0, 2, 1, 3))]
     )
     base_sign = slater.sign_excite(0b0101, [0, 2], [1, 3])
-    assert base_sign * test.exop_combinations[(0, 2, 1, 3)][0][1] == check_sign([0, 2], [[0, 1], [2, 3]])
-    assert base_sign * test.exop_combinations[(0, 2, 1, 3)][1][1] == check_sign([0, 2], [[0, 3], [2, 1]])
-    assert base_sign * test.exop_combinations[(0, 2, 1, 3)][2][1] == check_sign([0, 2], [[0, 2, 1, 3]])
+    assert base_sign * scale_sign(test.exop_combinations[(0, 2, 1, 3)][2][0][-1]) == check_sign([0, 2], [[0, 1], [2, 3]])
+    assert base_sign * scale_sign(test.exop_combinations[(0, 2, 1, 3)][2][1][-1]) == check_sign([0, 2], [[0, 3], [2, 1]])
+    assert base_sign * scale_sign(test.exop_combinations[(0, 2, 1, 3)][1][0][-1]) == check_sign([0, 2], [[0, 2, 1, 3]])
 
     test = TempStandardCC()
     test.assign_nelec(4)
@@ -100,61 +111,56 @@ def test_generate_possible_exops():
     test.assign_ranks([1])
     test.assign_exops()
     test.refresh_exops = None
+    test.params = np.random.rand(8)
     test.generate_possible_exops([0, 1], [2, 3])
     assert np.allclose(
-        test.exop_combinations[(0, 1, 2, 3)][0][0], [test.get_ind((0, 2)), test.get_ind((1, 3))]
+        test.exop_combinations[(0, 1, 2, 3)][2][0][0:2], [test.get_ind((0, 2)), test.get_ind((1, 3))]
     )
     assert np.allclose(
-        test.exop_combinations[(0, 1, 2, 3)][1][0], [test.get_ind((0, 3)), test.get_ind((1, 2))]
+        test.exop_combinations[(0, 1, 2, 3)][2][1][0:2], [test.get_ind((0, 3)), test.get_ind((1, 2))]
     )
     base_sign = slater.sign_excite(0b0011, [0, 1], [2, 3])
-    assert base_sign * test.exop_combinations[(0, 1, 2, 3)][0][1] == check_sign([0, 1], [[0, 2], [1, 3]])
-    assert base_sign * test.exop_combinations[(0, 1, 2, 3)][1][1] == check_sign([0, 1], [[0, 3], [1, 2]])
+    assert base_sign * scale_sign(test.exop_combinations[(0, 1, 2, 3)][2][0][-1]) == check_sign([0, 1], [[0, 2], [1, 3]])
+    assert base_sign * scale_sign(test.exop_combinations[(0, 1, 2, 3)][2][1][-1]) == check_sign([0, 1], [[0, 3], [1, 2]])
 
     test.generate_possible_exops([0, 1, 4], [2, 3, 6])
     assert np.allclose(
-        test.exop_combinations[(0, 1, 4, 2, 3, 6)][0][0],
+        test.exop_combinations[(0, 1, 4, 2, 3, 6)][3][0][0:3],
         (test.get_ind((0, 2)), test.get_ind((1, 3)), test.get_ind((4, 6))),
     )
     assert np.allclose(
-        test.exop_combinations[(0, 1, 4, 2, 3, 6)][1][0],
+        test.exop_combinations[(0, 1, 4, 2, 3, 6)][3][1][0:3],
             (test.get_ind((0, 2)), test.get_ind((1, 6)), test.get_ind((4, 3))),
     )
     assert np.allclose(
-        test.exop_combinations[(0, 1, 4, 2, 3, 6)][2][0],
+        test.exop_combinations[(0, 1, 4, 2, 3, 6)][3][2][0:3],
             (test.get_ind((0, 3)), test.get_ind((1, 2)), test.get_ind((4, 6))),
     )
     assert np.allclose(
-        test.exop_combinations[(0, 1, 4, 2, 3, 6)][3][0],
+        test.exop_combinations[(0, 1, 4, 2, 3, 6)][3][3][0:3],
             (test.get_ind((0, 3)), test.get_ind((1, 6)), test.get_ind((4, 2))),
     )
     assert np.allclose(
-        test.exop_combinations[(0, 1, 4, 2, 3, 6)][4][0],
+        test.exop_combinations[(0, 1, 4, 2, 3, 6)][3][4][0:3],
             (test.get_ind((0, 6)), test.get_ind((1, 2)), test.get_ind((4, 3))),
     )
     assert np.allclose(
-        test.exop_combinations[(0, 1, 4, 2, 3, 6)][5][0],
+        test.exop_combinations[(0, 1, 4, 2, 3, 6)][3][5][0:3],
             (test.get_ind((0, 6)), test.get_ind((1, 3)), test.get_ind((4, 2))),
     )
     base_sign = slater.sign_excite(0b10011, [0, 1, 4], [2, 3, 6])
-    assert base_sign * test.exop_combinations[(0, 1, 4, 2, 3, 6)][0][1] == check_sign([0, 1, 4],
-        ((0, 2), (1, 3), (4, 6)),
-                                                                                      )
-    assert base_sign * test.exop_combinations[(0, 1, 4, 2, 3, 6)][1][1] == check_sign([0, 1, 4],
-            ((0, 2), (1, 6), (4, 3)),
-                                                                                      )
-    assert base_sign * test.exop_combinations[(0, 1, 4, 2, 3, 6)][2][1] == check_sign([0, 1, 4],
-            ((0, 3), (1, 2), (4, 6)),
-                                                                                      )
-    assert base_sign * test.exop_combinations[(0, 1, 4, 2, 3, 6)][3][1] == check_sign([0, 1, 4],
-            ((0, 3), (1, 6), (4, 2)),
-                                                                                      )
-    assert base_sign * test.exop_combinations[(0, 1, 4, 2, 3, 6)][4][1] == check_sign([0, 1, 4],
-            ((0, 6), (1, 2), (4, 3)),
-                                                                                      )
-    assert base_sign * test.exop_combinations[(0, 1, 4, 2, 3, 6)][5][1] == check_sign([0, 1, 4],
-            ((0, 6), (1, 3), (4, 2)),
-                                                                                      )
+    assert base_sign * scale_sign(test.exop_combinations[(0, 1, 4, 2, 3, 6)][3][0][-1]) == check_sign([0, 1, 4],
+        ((0, 2), (1, 3), (4, 6)))
+    assert base_sign * scale_sign(test.exop_combinations[(0, 1, 4, 2, 3, 6)][3][1][-1]) == check_sign([0, 1, 4],
+            ((0, 2), (1, 6), (4, 3)),)
+    assert base_sign * scale_sign(test.exop_combinations[(0, 1, 4, 2, 3, 6)][3][2][-1]) == check_sign([0, 1, 4],
+            ((0, 3), (1, 2), (4, 6)),)
+    assert base_sign * scale_sign(test.exop_combinations[(0, 1, 4, 2, 3, 6)][3][3][-1]) == check_sign([0, 1, 4],
+            ((0, 3), (1, 6), (4, 2)),)
+    assert base_sign * scale_sign(test.exop_combinations[(0, 1, 4, 2, 3, 6)][3][4][-1]) == check_sign([0, 1, 4],
+            ((0, 6), (1, 2), (4, 3)),)
+    assert base_sign * scale_sign(test.exop_combinations[(0, 1, 4, 2, 3, 6)][3][5][-1]) == check_sign([0, 1, 4],
+            ((0, 6), (1, 3), (4, 2)),)
 
     test = TempStandardCC()
     test.assign_nelec(4)
@@ -163,128 +169,114 @@ def test_generate_possible_exops():
     test.assign_ranks([1, 2])
     test.assign_exops()
     test.refresh_exops = None
+    test.params = np.random.rand(8)
     test.generate_possible_exops([0, 1], [2, 3])
     assert np.allclose(
-        test.exop_combinations[(0, 1, 2, 3)][0][0], [test.get_ind((0, 2)), test.get_ind((1, 3))]
+        test.exop_combinations[(0, 1, 2, 3)][2][0][0:2], [test.get_ind((0, 2)), test.get_ind((1, 3))]
     )
     assert np.allclose(
-        test.exop_combinations[(0, 1, 2, 3)][1][0], [test.get_ind((0, 3)), test.get_ind((1, 2))]
+        test.exop_combinations[(0, 1, 2, 3)][2][1][0:2], [test.get_ind((0, 3)), test.get_ind((1, 2))]
     )
     assert np.allclose(
-        test.exop_combinations[(0, 1, 2, 3)][2][0], [test.get_ind((0, 1, 2, 3))]
+        test.exop_combinations[(0, 1, 2, 3)][1][0][0:1], [test.get_ind((0, 1, 2, 3))]
     )
     base_sign = slater.sign_excite(0b0011, [0, 1], [2, 3])
-    assert base_sign * test.exop_combinations[(0, 1, 2, 3)][0][1] == check_sign([0, 1], [[0, 2], [1, 3]])
-    assert base_sign * test.exop_combinations[(0, 1, 2, 3)][1][1] == check_sign([0, 1], [[0, 3], [1, 2]])
-    assert base_sign * test.exop_combinations[(0, 1, 2, 3)][2][1] == check_sign([0, 1], [[0, 1, 2, 3]])
+    assert base_sign * scale_sign(test.exop_combinations[(0, 1, 2, 3)][2][0][-1]) == check_sign([0, 1], [[0, 2], [1, 3]])
+    assert base_sign * scale_sign(test.exop_combinations[(0, 1, 2, 3)][2][1][-1]) == check_sign([0, 1], [[0, 3], [1, 2]])
+    assert base_sign * scale_sign(test.exop_combinations[(0, 1, 2, 3)][1][0][-1]) == check_sign([0, 1], [[0, 1, 2, 3]])
 
     test.generate_possible_exops([0, 1, 4], [2, 3, 6])
     assert np.allclose(
-        test.exop_combinations[(0, 1, 4, 2, 3, 6)][0][0],
+        test.exop_combinations[(0, 1, 4, 2, 3, 6)][3][0][0:3],
         (test.get_ind((0, 2)), test.get_ind((1, 3)), test.get_ind((4, 6))),
     )
     assert np.allclose(
-        test.exop_combinations[(0, 1, 4, 2, 3, 6)][1][0],
+        test.exop_combinations[(0, 1, 4, 2, 3, 6)][3][1][0:3],
             (test.get_ind((0, 2)), test.get_ind((1, 6)), test.get_ind((4, 3))),
     )
     assert np.allclose(
-        test.exop_combinations[(0, 1, 4, 2, 3, 6)][2][0],
+        test.exop_combinations[(0, 1, 4, 2, 3, 6)][3][2][0:3],
             (test.get_ind((0, 3)), test.get_ind((1, 2)), test.get_ind((4, 6))),
     )
     assert np.allclose(
-        test.exop_combinations[(0, 1, 4, 2, 3, 6)][3][0],
+        test.exop_combinations[(0, 1, 4, 2, 3, 6)][3][3][0:3],
             (test.get_ind((0, 3)), test.get_ind((1, 6)), test.get_ind((4, 2))),
     )
     assert np.allclose(
-        test.exop_combinations[(0, 1, 4, 2, 3, 6)][4][0],
+        test.exop_combinations[(0, 1, 4, 2, 3, 6)][3][4][0:3],
             (test.get_ind((0, 6)), test.get_ind((1, 2)), test.get_ind((4, 3))),
     )
     assert np.allclose(
-        test.exop_combinations[(0, 1, 4, 2, 3, 6)][5][0],
+        test.exop_combinations[(0, 1, 4, 2, 3, 6)][3][5][0:3],
             (test.get_ind((0, 6)), test.get_ind((1, 3)), test.get_ind((4, 2))),
     )
     assert np.allclose(
-        test.exop_combinations[(0, 1, 4, 2, 3, 6)][6][0],
+        test.exop_combinations[(0, 1, 4, 2, 3, 6)][2][0][0:2],
             (test.get_ind((0, 2)), test.get_ind((1, 4, 3, 6))),
     )
     assert np.allclose(
-        test.exop_combinations[(0, 1, 4, 2, 3, 6)][7][0],
+        test.exop_combinations[(0, 1, 4, 2, 3, 6)][2][1][0:2],
         (test.get_ind((0, 3)), test.get_ind((1, 4, 2, 6))),
     )
     assert np.allclose(
-        test.exop_combinations[(0, 1, 4, 2, 3, 6)][8][0],
+        test.exop_combinations[(0, 1, 4, 2, 3, 6)][2][2][0:2],
         (test.get_ind((0, 6)), test.get_ind((1, 4, 2, 3))),
     )
     assert np.allclose(
-        test.exop_combinations[(0, 1, 4, 2, 3, 6)][9][0],
+        test.exop_combinations[(0, 1, 4, 2, 3, 6)][2][3][0:2],
         (test.get_ind((1, 2)), test.get_ind((0, 4, 3, 6))),
     )
     assert np.allclose(
-        test.exop_combinations[(0, 1, 4, 2, 3, 6)][10][0],
+        test.exop_combinations[(0, 1, 4, 2, 3, 6)][2][4][0:2],
         (test.get_ind((1, 3)), test.get_ind((0, 4, 2, 6))),
     )
     assert np.allclose(
-        test.exop_combinations[(0, 1, 4, 2, 3, 6)][11][0],
+        test.exop_combinations[(0, 1, 4, 2, 3, 6)][2][5][0:2],
         (test.get_ind((1, 6)), test.get_ind((0, 4, 2, 3))),
     )
     assert np.allclose(
-        test.exop_combinations[(0, 1, 4, 2, 3, 6)][12][0],
+        test.exop_combinations[(0, 1, 4, 2, 3, 6)][2][6][0:2],
         (test.get_ind((4, 2)), test.get_ind((0, 1, 3, 6))),
     )
     assert np.allclose(
-        test.exop_combinations[(0, 1, 4, 2, 3, 6)][13][0],
+        test.exop_combinations[(0, 1, 4, 2, 3, 6)][2][7][0:2],
         (test.get_ind((4, 3)), test.get_ind((0, 1, 2, 6))),
     )
     assert np.allclose(
-        test.exop_combinations[(0, 1, 4, 2, 3, 6)][14][0],
+        test.exop_combinations[(0, 1, 4, 2, 3, 6)][2][8][0:2],
         (test.get_ind((4, 6)), test.get_ind((0, 1, 2, 3))),
     )
     base_sign = slater.sign_excite(0b10011, [0, 1, 4], [2, 3, 6])
-    assert base_sign * test.exop_combinations[(0, 1, 4, 2, 3, 6)][0][1] == check_sign([0, 1, 4],
-        ((0, 2), (1, 3), (4, 6)),
-                                                                                      )
-    assert base_sign * test.exop_combinations[(0, 1, 4, 2, 3, 6)][1][1] == check_sign([0, 1, 4],
-            ((0, 2), (1, 6), (4, 3)),
-                                                                                      )
-    assert base_sign * test.exop_combinations[(0, 1, 4, 2, 3, 6)][2][1] == check_sign([0, 1, 4],
-            ((0, 3), (1, 2), (4, 6)),
-                                                                                      )
-    assert base_sign * test.exop_combinations[(0, 1, 4, 2, 3, 6)][3][1] == check_sign([0, 1, 4],
-            ((0, 3), (1, 6), (4, 2)),
-                                                                                      )
-    assert base_sign * test.exop_combinations[(0, 1, 4, 2, 3, 6)][4][1] == check_sign([0, 1, 4],
-            ((0, 6), (1, 2), (4, 3)),
-                                                                                      )
-    assert base_sign * test.exop_combinations[(0, 1, 4, 2, 3, 6)][5][1] == check_sign([0, 1, 4],
-            ((0, 6), (1, 3), (4, 2)),
-                                                                                      )
-    assert base_sign * test.exop_combinations[(0, 1, 4, 2, 3, 6)][6][1] == check_sign([0, 1, 4],
-            ((0, 2), (1, 4, 3, 6)),
-                                                                                      )
-    assert base_sign * test.exop_combinations[(0, 1, 4, 2, 3, 6)][7][1] == check_sign([0, 1, 4],
-            ((0, 3), (1, 4, 2, 6)),
-                                                                                      )
-    assert base_sign * test.exop_combinations[(0, 1, 4, 2, 3, 6)][8][1] == check_sign([0, 1, 4],
-            ((0, 6), (1, 4, 2, 3)),
-                                                                                      )
-    assert base_sign * test.exop_combinations[(0, 1, 4, 2, 3, 6)][9][1] == check_sign([0, 1, 4],
-            ((1, 2), (0, 4, 3, 6)),
-                                                                                      )
-    assert base_sign * test.exop_combinations[(0, 1, 4, 2, 3, 6)][10][1] == check_sign([0, 1, 4],
-            ((1, 3), (0, 4, 2, 6)),
-                                                                                      )
-    assert base_sign * test.exop_combinations[(0, 1, 4, 2, 3, 6)][11][1] == check_sign([0, 1, 4],
-            ((1, 6), (0, 4, 2, 3)),
-                                                                                      )
-    assert base_sign * test.exop_combinations[(0, 1, 4, 2, 3, 6)][12][1] == check_sign([0, 1, 4],
-            ((4, 2), (0, 1, 3, 6)),
-                                                                                      )
-    assert base_sign * test.exop_combinations[(0, 1, 4, 2, 3, 6)][13][1] == check_sign([0, 1, 4],
-            ((4, 3), (0, 1, 2, 6)),
-                                                                                       )
-    assert base_sign * test.exop_combinations[(0, 1, 4, 2, 3, 6)][14][1] == check_sign([0, 1, 4],
-            ((4, 6), (0, 1, 2, 3)),
-                                                                                       )
+    assert base_sign * scale_sign(test.exop_combinations[(0, 1, 4, 2, 3, 6)][3][0][-1]) == check_sign([0, 1, 4],
+        ((0, 2), (1, 3), (4, 6)),)
+    assert base_sign * scale_sign(test.exop_combinations[(0, 1, 4, 2, 3, 6)][3][1][-1]) == check_sign([0, 1, 4],
+            ((0, 2), (1, 6), (4, 3)),)
+    assert base_sign * scale_sign(test.exop_combinations[(0, 1, 4, 2, 3, 6)][3][2][-1]) == check_sign([0, 1, 4],
+            ((0, 3), (1, 2), (4, 6)),)
+    assert base_sign * scale_sign(test.exop_combinations[(0, 1, 4, 2, 3, 6)][3][3][-1]) == check_sign([0, 1, 4],
+            ((0, 3), (1, 6), (4, 2)),)
+    assert base_sign * scale_sign(test.exop_combinations[(0, 1, 4, 2, 3, 6)][3][4][-1]) == check_sign([0, 1, 4],
+            ((0, 6), (1, 2), (4, 3)),)
+    assert base_sign * scale_sign(test.exop_combinations[(0, 1, 4, 2, 3, 6)][3][5][-1]) == check_sign([0, 1, 4],
+            ((0, 6), (1, 3), (4, 2)),)
+    assert base_sign * scale_sign(test.exop_combinations[(0, 1, 4, 2, 3, 6)][2][0][-1]) == check_sign([0, 1, 4],
+            ((0, 2), (1, 4, 3, 6)),)
+    assert base_sign * scale_sign(test.exop_combinations[(0, 1, 4, 2, 3, 6)][2][1][-1]) == check_sign([0, 1, 4],
+            ((0, 3), (1, 4, 2, 6)),)
+    assert base_sign * scale_sign(test.exop_combinations[(0, 1, 4, 2, 3, 6)][2][2][-1]) == check_sign([0, 1, 4],
+            ((0, 6), (1, 4, 2, 3)),)
+    assert base_sign * scale_sign(test.exop_combinations[(0, 1, 4, 2, 3, 6)][2][3][-1]) == check_sign([0, 1, 4],
+            ((1, 2), (0, 4, 3, 6)),)
+    assert base_sign * scale_sign(test.exop_combinations[(0, 1, 4, 2, 3, 6)][2][4][-1]) == check_sign([0, 1, 4],
+            ((1, 3), (0, 4, 2, 6)),)
+    assert base_sign * scale_sign(test.exop_combinations[(0, 1, 4, 2, 3, 6)][2][5][-1]) == check_sign([0, 1, 4],
+            ((1, 6), (0, 4, 2, 3)),)
+    assert base_sign * scale_sign(test.exop_combinations[(0, 1, 4, 2, 3, 6)][2][6][-1]) == check_sign([0, 1, 4],
+            ((4, 2), (0, 1, 3, 6)),)
+    assert base_sign * scale_sign(test.exop_combinations[(0, 1, 4, 2, 3, 6)][2][7][-1]) == check_sign([0, 1, 4],
+            ((4, 3), (0, 1, 2, 6)),)
+    assert base_sign * scale_sign(test.exop_combinations[(0, 1, 4, 2, 3, 6)][2][8][-1]) == check_sign([0, 1, 4],
+            ((4, 6), (0, 1, 2, 3)),)
 
     test = TempStandardCC()
     test.assign_nelec(4)
@@ -292,133 +284,118 @@ def test_generate_possible_exops():
     test.assign_refwfn(0b00110011)
     test.assign_ranks([1, 2, 3])
     test.assign_exops()
+    test.assign_params(np.random.rand(68))
     test.refresh_exops = None
     test.generate_possible_exops([0, 1], [2, 3])
     assert np.allclose(
-        test.exop_combinations[(0, 1, 2, 3)][0][0], [test.get_ind((0, 2)), test.get_ind((1, 3))]
+        test.exop_combinations[(0, 1, 2, 3)][2][0][0:2], [test.get_ind((0, 2)), test.get_ind((1, 3))]
     )
     assert np.allclose(
-        test.exop_combinations[(0, 1, 2, 3)][1][0], [test.get_ind((0, 3)), test.get_ind((1, 2))]
+        test.exop_combinations[(0, 1, 2, 3)][2][1][0:2], [test.get_ind((0, 3)), test.get_ind((1, 2))]
     )
     assert np.allclose(
-        test.exop_combinations[(0, 1, 2, 3)][2][0], [test.get_ind((0, 1, 2, 3))]
+        test.exop_combinations[(0, 1, 2, 3)][1][0][0:1], [test.get_ind((0, 1, 2, 3))]
     )
     base_sign = slater.sign_excite(0b0011, [0, 1], [2, 3])
-    assert base_sign * test.exop_combinations[(0, 1, 2, 3)][0][1] == check_sign([0, 1], [[0, 2], [1, 3]])
-    assert base_sign * test.exop_combinations[(0, 1, 2, 3)][1][1] == check_sign([0, 1], [[0, 3], [1, 2]])
-    assert base_sign * test.exop_combinations[(0, 1, 2, 3)][2][1] == check_sign([0, 1], [[0, 1, 2, 3]])
+    assert base_sign * scale_sign(test.exop_combinations[(0, 1, 2, 3)][2][0][-1]) == check_sign([0, 1], [[0, 2], [1, 3]])
+    assert base_sign * scale_sign(test.exop_combinations[(0, 1, 2, 3)][2][1][-1]) == check_sign([0, 1], [[0, 3], [1, 2]])
+    assert base_sign * scale_sign(test.exop_combinations[(0, 1, 2, 3)][1][0][-1]) == check_sign([0, 1], [[0, 1, 2, 3]])
 
     test.generate_possible_exops([0, 1, 4], [2, 3, 6])
     assert np.allclose(
-        test.exop_combinations[(0, 1, 4, 2, 3, 6)][0][0],
+        test.exop_combinations[(0, 1, 4, 2, 3, 6)][3][0][0:3],
         (test.get_ind((0, 2)), test.get_ind((1, 3)), test.get_ind((4, 6))),
     )
     assert np.allclose(
-        test.exop_combinations[(0, 1, 4, 2, 3, 6)][1][0],
+        test.exop_combinations[(0, 1, 4, 2, 3, 6)][3][1][0:3],
             (test.get_ind((0, 2)), test.get_ind((1, 6)), test.get_ind((4, 3))),
     )
     assert np.allclose(
-        test.exop_combinations[(0, 1, 4, 2, 3, 6)][2][0],
+        test.exop_combinations[(0, 1, 4, 2, 3, 6)][3][2][0:3],
             (test.get_ind((0, 3)), test.get_ind((1, 2)), test.get_ind((4, 6))),
     )
     assert np.allclose(
-        test.exop_combinations[(0, 1, 4, 2, 3, 6)][3][0],
+        test.exop_combinations[(0, 1, 4, 2, 3, 6)][3][3][0:3],
             (test.get_ind((0, 3)), test.get_ind((1, 6)), test.get_ind((4, 2))),
     )
     assert np.allclose(
-        test.exop_combinations[(0, 1, 4, 2, 3, 6)][4][0],
+        test.exop_combinations[(0, 1, 4, 2, 3, 6)][3][4][0:3],
             (test.get_ind((0, 6)), test.get_ind((1, 2)), test.get_ind((4, 3))),
     )
     assert np.allclose(
-        test.exop_combinations[(0, 1, 4, 2, 3, 6)][5][0],
+        test.exop_combinations[(0, 1, 4, 2, 3, 6)][3][5][0:3],
             (test.get_ind((0, 6)), test.get_ind((1, 3)), test.get_ind((4, 2))),
     )
     assert np.allclose(
-        test.exop_combinations[(0, 1, 4, 2, 3, 6)][6][0],
+        test.exop_combinations[(0, 1, 4, 2, 3, 6)][2][0][0:2],
             (test.get_ind((0, 2)), test.get_ind((1, 4, 3, 6))),
     )
     assert np.allclose(
-        test.exop_combinations[(0, 1, 4, 2, 3, 6)][7][0],
+        test.exop_combinations[(0, 1, 4, 2, 3, 6)][2][1][0:2],
         (test.get_ind((0, 3)), test.get_ind((1, 4, 2, 6))),
     )
     assert np.allclose(
-        test.exop_combinations[(0, 1, 4, 2, 3, 6)][8][0],
+        test.exop_combinations[(0, 1, 4, 2, 3, 6)][2][2][0:2],
         (test.get_ind((0, 6)), test.get_ind((1, 4, 2, 3))),
     )
     assert np.allclose(
-        test.exop_combinations[(0, 1, 4, 2, 3, 6)][9][0],
+        test.exop_combinations[(0, 1, 4, 2, 3, 6)][2][3][0:2],
         (test.get_ind((1, 2)), test.get_ind((0, 4, 3, 6))),
     )
     assert np.allclose(
-        test.exop_combinations[(0, 1, 4, 2, 3, 6)][10][0],
+        test.exop_combinations[(0, 1, 4, 2, 3, 6)][2][4][0:2],
         (test.get_ind((1, 3)), test.get_ind((0, 4, 2, 6))),
     )
     assert np.allclose(
-        test.exop_combinations[(0, 1, 4, 2, 3, 6)][11][0],
+        test.exop_combinations[(0, 1, 4, 2, 3, 6)][2][5][0:2],
         (test.get_ind((1, 6)), test.get_ind((0, 4, 2, 3))),
     )
     assert np.allclose(
-        test.exop_combinations[(0, 1, 4, 2, 3, 6)][12][0],
+        test.exop_combinations[(0, 1, 4, 2, 3, 6)][2][6][0:2],
         (test.get_ind((4, 2)), test.get_ind((0, 1, 3, 6))),
     )
     assert np.allclose(
-        test.exop_combinations[(0, 1, 4, 2, 3, 6)][13][0],
+        test.exop_combinations[(0, 1, 4, 2, 3, 6)][2][7][0:2],
         (test.get_ind((4, 3)), test.get_ind((0, 1, 2, 6))),
     )
     assert np.allclose(
-        test.exop_combinations[(0, 1, 4, 2, 3, 6)][14][0],
+        test.exop_combinations[(0, 1, 4, 2, 3, 6)][2][8][0:2],
         (test.get_ind((4, 6)), test.get_ind((0, 1, 2, 3))),
     )
     assert np.allclose(
-        test.exop_combinations[(0, 1, 4, 2, 3, 6)][15][0],
+        test.exop_combinations[(0, 1, 4, 2, 3, 6)][1][0][0],
         (test.get_ind((0, 1, 4, 2, 3, 6)), ),
     )
     base_sign = slater.sign_excite(0b10011, [0, 1, 4], [2, 3, 6])
-    assert base_sign * test.exop_combinations[(0, 1, 4, 2, 3, 6)][0][1] == check_sign([0, 1, 4],
-        ((0, 2), (1, 3), (4, 6)),
-                                                                                      )
-    assert base_sign * test.exop_combinations[(0, 1, 4, 2, 3, 6)][1][1] == check_sign([0, 1, 4],
-            ((0, 2), (1, 6), (4, 3)),
-                                                                                      )
-    assert base_sign * test.exop_combinations[(0, 1, 4, 2, 3, 6)][2][1] == check_sign([0, 1, 4],
-            ((0, 3), (1, 2), (4, 6)),
-                                                                                      )
-    assert base_sign * test.exop_combinations[(0, 1, 4, 2, 3, 6)][3][1] == check_sign([0, 1, 4],
-            ((0, 3), (1, 6), (4, 2)),
-                                                                                      )
-    assert base_sign * test.exop_combinations[(0, 1, 4, 2, 3, 6)][4][1] == check_sign([0, 1, 4],
-            ((0, 6), (1, 2), (4, 3)),
-                                                                                      )
-    assert base_sign * test.exop_combinations[(0, 1, 4, 2, 3, 6)][5][1] == check_sign([0, 1, 4],
-            ((0, 6), (1, 3), (4, 2)),
-                                                                                      )
-    assert base_sign * test.exop_combinations[(0, 1, 4, 2, 3, 6)][6][1] == check_sign([0, 1, 4],
-            ((0, 2), (1, 4, 3, 6)),
-                                                                                      )
-    assert base_sign * test.exop_combinations[(0, 1, 4, 2, 3, 6)][7][1] == check_sign([0, 1, 4],
-            ((0, 3), (1, 4, 2, 6)),
-                                                                                      )
-    assert base_sign * test.exop_combinations[(0, 1, 4, 2, 3, 6)][8][1] == check_sign([0, 1, 4],
-            ((0, 6), (1, 4, 2, 3)),
-                                                                                      )
-    assert base_sign * test.exop_combinations[(0, 1, 4, 2, 3, 6)][9][1] == check_sign([0, 1, 4],
-            ((1, 2), (0, 4, 3, 6)),
-                                                                                      )
-    assert base_sign * test.exop_combinations[(0, 1, 4, 2, 3, 6)][10][1] == check_sign([0, 1, 4],
-            ((1, 3), (0, 4, 2, 6)),
-                                                                                      )
-    assert base_sign * test.exop_combinations[(0, 1, 4, 2, 3, 6)][11][1] == check_sign([0, 1, 4],
-            ((1, 6), (0, 4, 2, 3)),
-                                                                                      )
-    assert base_sign * test.exop_combinations[(0, 1, 4, 2, 3, 6)][12][1] == check_sign([0, 1, 4],
-            ((4, 2), (0, 1, 3, 6)),
-                                                                                      )
-    assert base_sign * test.exop_combinations[(0, 1, 4, 2, 3, 6)][13][1] == check_sign([0, 1, 4],
-            ((4, 3), (0, 1, 2, 6)),
-                                                                                       )
-    assert base_sign * test.exop_combinations[(0, 1, 4, 2, 3, 6)][14][1] == check_sign([0, 1, 4],
-            ((4, 6), (0, 1, 2, 3)),
-                                                                                       )
-    assert base_sign * test.exop_combinations[(0, 1, 4, 2, 3, 6)][14][1] == check_sign([0, 1, 4],
-            ((0, 1, 4, 2, 3, 6), ),
-                                                                                       )
+    assert base_sign * scale_sign(test.exop_combinations[(0, 1, 4, 2, 3, 6)][3][0][-1]) == check_sign([0, 1, 4],
+        ((0, 2), (1, 3), (4, 6)),)
+    assert base_sign * scale_sign(test.exop_combinations[(0, 1, 4, 2, 3, 6)][3][1][-1]) == check_sign([0, 1, 4],
+            ((0, 2), (1, 6), (4, 3)),)
+    assert base_sign * scale_sign(test.exop_combinations[(0, 1, 4, 2, 3, 6)][3][2][-1]) == check_sign([0, 1, 4],
+            ((0, 3), (1, 2), (4, 6)),)
+    assert base_sign * scale_sign(test.exop_combinations[(0, 1, 4, 2, 3, 6)][3][3][-1]) == check_sign([0, 1, 4],
+            ((0, 3), (1, 6), (4, 2)),)
+    assert base_sign * scale_sign(test.exop_combinations[(0, 1, 4, 2, 3, 6)][3][4][-1]) == check_sign([0, 1, 4],
+            ((0, 6), (1, 2), (4, 3)),)
+    assert base_sign * scale_sign(test.exop_combinations[(0, 1, 4, 2, 3, 6)][3][5][-1]) == check_sign([0, 1, 4],
+            ((0, 6), (1, 3), (4, 2)),)
+    assert base_sign * scale_sign(test.exop_combinations[(0, 1, 4, 2, 3, 6)][2][0][-1]) == check_sign([0, 1, 4],
+            ((0, 2), (1, 4, 3, 6)),)
+    assert base_sign * scale_sign(test.exop_combinations[(0, 1, 4, 2, 3, 6)][2][1][-1]) == check_sign([0, 1, 4],
+            ((0, 3), (1, 4, 2, 6)),)
+    assert base_sign * scale_sign(test.exop_combinations[(0, 1, 4, 2, 3, 6)][2][2][-1]) == check_sign([0, 1, 4],
+            ((0, 6), (1, 4, 2, 3)),)
+    assert base_sign * scale_sign(test.exop_combinations[(0, 1, 4, 2, 3, 6)][2][3][-1]) == check_sign([0, 1, 4],
+            ((1, 2), (0, 4, 3, 6)),)
+    assert base_sign * scale_sign(test.exop_combinations[(0, 1, 4, 2, 3, 6)][2][4][-1]) == check_sign([0, 1, 4],
+            ((1, 3), (0, 4, 2, 6)),)
+    assert base_sign * scale_sign(test.exop_combinations[(0, 1, 4, 2, 3, 6)][2][5][-1]) == check_sign([0, 1, 4],
+            ((1, 6), (0, 4, 2, 3)),)
+    assert base_sign * scale_sign(test.exop_combinations[(0, 1, 4, 2, 3, 6)][2][6][-1]) == check_sign([0, 1, 4],
+            ((4, 2), (0, 1, 3, 6)),)
+    assert base_sign * scale_sign(test.exop_combinations[(0, 1, 4, 2, 3, 6)][2][7][-1]) == check_sign([0, 1, 4],
+            ((4, 3), (0, 1, 2, 6)),)
+    assert base_sign * scale_sign(test.exop_combinations[(0, 1, 4, 2, 3, 6)][2][8][-1]) == check_sign([0, 1, 4],
+            ((4, 6), (0, 1, 2, 3)),)
+    assert base_sign * scale_sign(test.exop_combinations[(0, 1, 4, 2, 3, 6)][1][0][1]) == check_sign([0, 1, 4],
+            ((0, 1, 4, 2, 3, 6), ),)


### PR DESCRIPTION
## Change in the structure of `exop_combs`
The structure of `exop_combs` changed in the base CC class. The previous structure, which this test expected was:
```
exop_combs = {
     (idx of anihillation and creation operators) : [[[idx excitation operator 1, idx excitation operator 2], sign],
                                                     [[idx excitation operator], sign], ...]
     ......
}
```
For every excitation we store the different ways we can generate it with excitation operators. In addition, we also store the sign of the excitation operator string.

In the newer structure, have a dictionary for all excitations,  where we group the excitation operator combinations based on how many excitation operators they contain. 
```
exop_combs = {
     (idx of anihillation and creation operators) : { 2 : [[idx excitation operator 1, idx excitation operator 2, sign], ...],
                                                  1 : [[idx excitation operator, sign], ...], ...
                                                   }
     ......
}
```
I adjusted the indexing of `exop_combs` in the generate possible exops test.

## Storing -1 sign

In order to use the uint datatype, we assign 0 to -1 in #42. Therefore, the tests for the signs had to be updated.  I am rescaling the sign from [0, 1] to [-1, 1] with a function `scale_sign`. Note: the base class in this branch does not have the updated code, since the aforementioned PR has not been merged yet.

## Other changes
Some of the test wavefunctions did not have assigned parameters, because the initialization was modified. I had to assign some parameters, so that the test would run. 