### PR TITLE
Improved importing CSV Dataframe for Geminals

### DIFF
--- a/fanpy/analysis/dataframe/base.py
+++ b/fanpy/analysis/dataframe/base.py
@@ -14,7 +14,7 @@ class DataFrameFanpy:
         else:
             self.dataframe = pd.DataFrame({wfn_label: wfn_params}, index=wfn_index)
 
-        self.metadata = None
+        self._metadata = None
 
     def __getattr__(self, attr):
         """Delegate attribute access to the underlying DataFrame."""
@@ -74,7 +74,7 @@ class DataFrameFanpy:
 
         # Save metadata
         with open(metadata_filename, "w") as f:
-            json.dump(self.metadata, f)
+            json.dump(self._metadata, f)
 
     def read_csv(self, filename, **kwargs):
         """Import dataframe from a CSV file and a metadata JSON files."""
@@ -93,7 +93,7 @@ class DataFrameFanpy:
 
         # Import metadata from JSON file
         with open(metadata_filename) as f:
-            self.metadata = json.load(f)
+            self._metadata = json.load(f)
 
     @abc.abstractmethod
     def add_wfn_to_dataframe(self, wfn, wfn_label=None):

--- a/fanpy/analysis/dataframe/cc.py
+++ b/fanpy/analysis/dataframe/cc.py
@@ -104,6 +104,12 @@ class DataFrameCC(DataFrameFanpy):
         # Add the new column while ensuring alignment
         self.dataframe[wfn_label] = param_series.reindex(self.index)
 
+        # Check if the Dataframe metadata is empty
+        if (self.wfn_nspatial is None) or (self.wfn_reference is None):
+            self.wfn_nspatial = wfn.nspatial
+            self.wfn_reference = wfn.refwfn
+            print(f"DataFrame metadata imported from {wfn_label}.")
+
     def set_sds_as_index(self):
         """Convert DataFrame index to the default format of binary numbers which represents SDs in Fanpy convention."""
 

--- a/fanpy/analysis/dataframe/cc.py
+++ b/fanpy/analysis/dataframe/cc.py
@@ -48,7 +48,7 @@ class DataFrameCC(DataFrameFanpy):
         """Import dataframe as a CSV file, including metadata as JSON file."""
 
         # Prepare metadata
-        self.metadata = {
+        self._metadata = {
             "wfn_nspatial": self.wfn_nspatial,
             "wfn_reference": self.wfn_reference,
             "index_view": self.index_view,
@@ -64,9 +64,9 @@ class DataFrameCC(DataFrameFanpy):
         DataFrameFanpy.read_csv(self, filename, **kwargs)
 
         # Import wavefunction information from metadata
-        self.wfn_nspatial = self.metadata["wfn_nspatial"]
-        self.wfn_reference = self.metadata["wfn_reference"]
-        self._index_view = self.metadata["index_view"]
+        self.wfn_nspatial = self._metadata["wfn_nspatial"]
+        self.wfn_reference = self._metadata["wfn_reference"]
+        self._index_view = self._metadata["index_view"]
 
     def add_wfn_to_dataframe(self, wfn, wfn_label=None):
         """Add column to dataframe containing excitation operators and CC parameters.
@@ -114,6 +114,9 @@ class DataFrameCC(DataFrameFanpy):
         """Convert DataFrame index to the default format of binary numbers which represents SDs in Fanpy convention."""
 
         if self.index_view == "operators":
+            if (self.wfn_reference is None) or (self.wfn_nspatial is None):
+                raise ValueError("Wavefunction information is not available. Index format cannot be changed.")
+
             operators = self.index
 
             # Prepare the list to store formatted excitation operators
@@ -154,6 +157,12 @@ class DataFrameCC(DataFrameFanpy):
             # Update index_view flag
             self._index_view = "determinants"
 
+        elif self.index_view == "determinants":
+            pass
+
+        else:
+            raise ValueError("Invalid index format. Index format cannot be changed.")
+
     def set_formatted_sds_as_index(self):
         """Convert DataFrame index to the human-readable notation of excited Slater Determinants of occupied (1) and unoccupied (0) MOs."""
 
@@ -163,6 +172,9 @@ class DataFrameCC(DataFrameFanpy):
             self.set_sds_as_index()
 
         if self.index_view == "determinants":
+            if self.wfn_nspatial is None:
+                raise ValueError("Wavefunction information is not available. Index format cannot be changed.")
+
             sds_index = self.index
 
             formatted_sds = [
@@ -181,6 +193,12 @@ class DataFrameCC(DataFrameFanpy):
             # Update index_view flag
             self._index_view = "formatted determinants"
 
+        elif self.index_view == "formatted determinants":
+            pass
+
+        else:
+            raise ValueError("Invalid index format. Index format cannot be changed.")
+
     def set_operators_as_index(self):
         """Convert DataFrame index to coupled cluster operator indices."""
 
@@ -190,6 +208,9 @@ class DataFrameCC(DataFrameFanpy):
             self.set_sds_as_index()
 
         if self.index_view == "determinants":
+            if self.wfn_reference is None:
+                raise ValueError("Wavefunction information is not available. Index format cannot be changed.")
+
             sds_index = self.index
 
             operators = [" ".join(map(str, slater.occ_indices(self.wfn_reference ^ sd))) for sd in sds_index]
@@ -199,3 +220,9 @@ class DataFrameCC(DataFrameFanpy):
 
             # Update index_view flag
             self._index_view = "operators"
+
+        elif self.index_view == "operators":
+            pass
+
+        else:
+            raise ValueError("Invalid index format. Index format cannot be changed.")

--- a/fanpy/analysis/dataframe/ci.py
+++ b/fanpy/analysis/dataframe/ci.py
@@ -90,6 +90,11 @@ class DataFrameCI(DataFrameFanpy):
         # Add the new column while ensuring alignment
         self.dataframe[wfn_label] = param_series.reindex(self.index)
 
+        # Check if the Dataframe metadata is empty
+        if self.wfn_nspatial is None:
+            self.wfn_nspatial = wfn.nspatial
+            print(f"DataFrame metadata imported from {wfn_label}.")
+
     def set_formatted_sds_as_index(self):
         """Convert DataFrame index to the human-readable format of occupied (1) and unoccupied (0) MOs."""
 

--- a/fanpy/analysis/dataframe/ci.py
+++ b/fanpy/analysis/dataframe/ci.py
@@ -41,7 +41,7 @@ class DataFrameCI(DataFrameFanpy):
         """Import dataframe as a CSV file, including metadata as JSON file."""
 
         # Prepare metadata
-        self.metadata = {
+        self._metadata = {
             "wfn_nspatial": self.wfn_nspatial,
             "index_view": self.index_view,
         }
@@ -56,8 +56,8 @@ class DataFrameCI(DataFrameFanpy):
         DataFrameFanpy.read_csv(self, filename, **kwargs)
 
         # Import wavefunction information from metadata
-        self.wfn_nspatial = self.metadata["wfn_nspatial"]
-        self._index_view = self.metadata["index_view"]
+        self.wfn_nspatial = self._metadata["wfn_nspatial"]
+        self._index_view = self._metadata["index_view"]
 
     def add_wfn_to_dataframe(self, wfn, wfn_label=None):
         """Add column to dataframe containing Slater determinants and CI parameters.
@@ -101,6 +101,9 @@ class DataFrameCI(DataFrameFanpy):
         from fanpy.tools import slater
 
         if self.index_view == "determinants":
+            if self.wfn_nspatial is None:
+                raise ValueError("Wavefunction information is not available. Index format cannot be changed.")
+
             sds_index = self.index
 
             formatted_sds = [
@@ -119,6 +122,12 @@ class DataFrameCI(DataFrameFanpy):
             # Update index_view flag
             self._index_view = "formatted determinants"
 
+        elif self.index_view == "formatted determinants":
+            pass
+
+        else:
+            raise ValueError("Invalid index format. Index format cannot be changed.")
+
     def set_sds_as_index(self):
         """Convert DataFrame index to the default format of binary numbers which represents SDs in Fanpy convention."""
 
@@ -135,3 +144,9 @@ class DataFrameCI(DataFrameFanpy):
 
             # Update index_view flag
             self._index_view = "determinants"
+
+        elif self.index_view == "determinants":
+            pass
+
+        else:
+            raise ValueError("Invalid index format. Index format cannot be changed.")

--- a/fanpy/analysis/dataframe/geminal.py
+++ b/fanpy/analysis/dataframe/geminal.py
@@ -115,7 +115,7 @@ class DataFrameGeminal(DataFrameFanpy):
         wfn_params = wfn.params
         wfn_ngem = wfn.ngem
 
-        if hasattr(wfn, "ref_sd") and (wfn.ref_sd == None):
+        if hasattr(wfn, "ref_sd") and (wfn.ref_sd is None):
             self.wfn_ref_sd = wfn.ref_sd
 
         # Convert operators from tuple to strings
@@ -151,6 +151,15 @@ class DataFrameGeminal(DataFrameFanpy):
 
         # Add the new column while ensuring alignment
         self.dataframe[wfn_label] = param_series.reindex(self.index)
+
+        # Check if the Dataframe metadata is empty
+        if (self.wfn_nspatial is None) or (self.wfn_nspin is None):
+            self.wfn_nspatial = wfn.nspatial
+            self.wfn_nspin = wfn.nspin
+
+            if (self.wfn_ref_sd is None) and (hasattr(wfn, "ref_sd") and (wfn.ref_sd is not None)):
+                self.wfn_ref_sd = wfn.ref_sd
+            print(f"DataFrame metadata imported from {wfn_label}.")
 
     def set_sds_as_index(self):
         """Convert DataFrame index to the default format of binary numbers which represents pairs in Fanpy convention."""

--- a/fanpy/analysis/dataframe/geminal.py
+++ b/fanpy/analysis/dataframe/geminal.py
@@ -91,6 +91,9 @@ class DataFrameGeminal(DataFrameFanpy):
         self.wfn_ref_sd = self.metadata["wfn_ref_sd"]
         self._index_view = self.metadata["index_view"]
 
+        self.dataframe = self.dataframe.reset_index()
+        self.dataframe = self.dataframe.set_index(["geminal", "pair"])
+
     def add_wfn_to_dataframe(self, wfn, wfn_label=None):
         """Add column to dataframe containing excitation operators and Geminal parameters.
 

--- a/fanpy/analysis/dataframe/geminal.py
+++ b/fanpy/analysis/dataframe/geminal.py
@@ -155,7 +155,6 @@ class DataFrameGeminal(DataFrameFanpy):
             wfn_orbital_pairs = self.index.get_level_values("pair")
 
             # Prepare the list to store Slater Determinants
-            geminals = []
             sds = []
 
             for geminal, orbital_pair in zip(wfn_geminals, wfn_orbital_pairs):
@@ -176,33 +175,30 @@ class DataFrameGeminal(DataFrameFanpy):
                 # Add Slater Determinant and parameter to the list
                 wfn_pair = int("".join(wfn_pair[::-1]), 2)
 
-                geminals.append(geminal)
                 sds.append(wfn_pair)
 
             # Update index notation of the DataFrame
-            self.dataframe.index = MultiIndex.from_arrays([geminals, sds], names=["geminal", "pair"])
+            self.dataframe.index = MultiIndex.from_arrays([wfn_geminals, sds], names=["geminal", "determinants"])
 
             # Update index_view flag
             self._index_view = "determinants"
 
         elif self.index_view == "formatted determinants":
             wfn_geminals = self.index.get_level_values("geminal")
-            wfn_formatted_sds_pairs = self.index.get_level_values("pair")
+            wfn_formatted_sds = self.index.get_level_values("formatted determinants")
 
             # Prepare the list to store Slater Determinants
-            geminals = []
             sds = []
 
-            for geminal, formatted_sd_pair in zip(wfn_geminals, wfn_formatted_sds_pairs):
+            for formatted_sd_pair in wfn_formatted_sds:
 
                 sd_alpha, sd_beta = formatted_sd_pair.split()
                 sd_pair = int(sd_beta[::-1] + sd_alpha[::-1], 2)
 
-                geminals.append(geminal)
                 sds.append(sd_pair)
 
             # Update index notation of the DataFrame
-            self.dataframe.index = MultiIndex.from_arrays([geminals, sds], names=["geminal", "pair"])
+            self.dataframe.index = MultiIndex.from_arrays([wfn_geminals, sds], names=["geminal", "determinants"])
 
             # Update index_view flag
             self._index_view = "determinants"
@@ -217,13 +213,12 @@ class DataFrameGeminal(DataFrameFanpy):
 
         if self.index_view == "determinants":
             wfn_geminals = self.index.get_level_values("geminal")
-            wfn_sds_pairs = self.index.get_level_values("pair")
+            wfn_sds = self.index.get_level_values("determinants")
 
             # Prepare the list to store formatted Slater Determinants
-            geminals = []
             formatted_sds = []
 
-            for geminal, sd_pair in zip(wfn_geminals, wfn_sds_pairs):
+            for sd_pair in wfn_sds:
 
                 formatted_sd = " ".join(
                     [
@@ -232,11 +227,12 @@ class DataFrameGeminal(DataFrameFanpy):
                     ]
                 )
 
-                geminals.append(geminal)
                 formatted_sds.append(formatted_sd)
 
             # Update index notation of the DataFrame
-            self.dataframe.index = MultiIndex.from_arrays([geminals, formatted_sds], names=["geminal", "pair"])
+            self.dataframe.index = MultiIndex.from_arrays(
+                [wfn_geminals, formatted_sds], names=["geminal", "formatted determinants"]
+            )
 
             # Update index_view flag
             self._index_view = "formatted determinants"
@@ -254,7 +250,6 @@ class DataFrameGeminal(DataFrameFanpy):
             wfn_sds_pairs = self.index.get_level_values("pair")
 
             # Prepare the list to store formatted Slater Determinants
-            geminals = []
             operators = []
 
             for geminal, sd_pair in zip(wfn_geminals, wfn_sds_pairs):
@@ -272,11 +267,10 @@ class DataFrameGeminal(DataFrameFanpy):
                 else:
                     operator = " ".join(map(str, slater.occ_indices(sd_pair)))
 
-                geminals.append(geminal)
                 operators.append(operator)
 
             # Update index notation of the DataFrame
-            self.dataframe.index = MultiIndex.from_arrays([geminals, operators], names=["geminal", "pair"])
+            self.dataframe.index = MultiIndex.from_arrays([wfn_geminals, operators], names=["geminal", "pair"])
 
             # Update index_view flag
             self._index_view = "geminals"

--- a/fanpy/analysis/dataframe/geminal.py
+++ b/fanpy/analysis/dataframe/geminal.py
@@ -281,7 +281,7 @@ class DataFrameGeminal(DataFrameFanpy):
 
         if self.index_view == "determinants":
             wfn_geminals = self.index.get_level_values("geminal")
-            wfn_sds_pairs = self.index.get_level_values("pair")
+            wfn_sds_pairs = self.index.get_level_values("determinants")
 
             # Prepare the list to store formatted Slater Determinants
             operators = []

--- a/fanpy/analysis/dataframe/geminal.py
+++ b/fanpy/analysis/dataframe/geminal.py
@@ -92,7 +92,12 @@ class DataFrameGeminal(DataFrameFanpy):
         self._index_view = self.metadata["index_view"]
 
         self.dataframe = self.dataframe.reset_index()
-        self.dataframe = self.dataframe.set_index(["geminal", "pair"])
+        if self.metadata["index_view"] == "geminals":
+            self.dataframe = self.dataframe.set_index(["geminal", "pair"])
+        elif self.metadata["index_view"] == "determinants":
+            self.dataframe = self.dataframe.set_index(["geminal", "determinants"])
+        elif self.metadata["index_view"] == "formatted determinants":
+            self.dataframe = self.dataframe.set_index(["geminal", "formatted determinants"])
 
     def add_wfn_to_dataframe(self, wfn, wfn_label=None):
         """Add column to dataframe containing excitation operators and Geminal parameters.

--- a/tests/test_analysis_dataframe.py
+++ b/tests/test_analysis_dataframe.py
@@ -1,0 +1,407 @@
+"""Test fanpy.analysis.dataframe."""
+
+from fanpy.wfn.base import BaseWavefunction
+from fanpy.wfn.ci.base import CIWavefunction
+from fanpy.wfn.cc.base import BaseCC
+from fanpy.wfn.cc.standard_cc import StandardCC
+from fanpy.wfn.geminal.base import BaseGeminal
+from fanpy.wfn.geminal.ap1rog import AP1roG
+from fanpy.tools import slater, sd_list
+
+from fanpy.analysis.dataframe.base import DataFrameFanpy
+from fanpy.analysis.dataframe.ci import DataFrameCI
+from fanpy.analysis.dataframe.cc import DataFrameCC
+from fanpy.analysis.dataframe.geminal import DataFrameGeminal
+
+import numpy as np
+import pandas as pd
+from itertools import combinations, product
+
+import pytest
+
+
+def test_empty_dataframe():
+    """Test creating an empty analysis.dataframe.base.DataFrameFanpy object."""
+
+    # Create an empty DataFrameFanpy object
+    df = DataFrameFanpy()
+
+    assert isinstance(df.dataframe, pd.DataFrame)
+    assert df.empty
+
+
+def test_base_dataframe():
+    """Test creating an analysis.dataframe.base.DataFrameFanpy object."""
+
+    # Create a custom DataFrameFanpy object
+    index = [1, 2, 3, 4]
+    params = [1.0, 0.75, 0.5, 0.25]
+
+    df = DataFrameFanpy(wfn_label="params", wfn_params=params, wfn_index=index)
+
+    assert df.shape == (len(params), 1)
+    assert df.index.tolist() == index
+    assert df["params"].tolist() == params
+
+
+def test_update_dataframe():
+    """Test wfn.analysis.dataframe.base.DataFrameFanpy.update_dataframe."""
+
+    params = [1.0, 0.75, 0.5, 0.25]
+
+    df1 = DataFrameFanpy()
+    df2 = pd.DataFrame({"Wavefunction": params})
+    df1.update_dataframe(df2)
+
+    assert df1["Wavefunction"].tolist() == params
+
+
+def test_base_dataframe_wfn():
+    """Test creating an analysis.dataframe.base.DataFrameFanpy object."""
+
+    # Create a custom BaseWavefunction object
+    nelec = 4
+    nspin = 8
+
+    sds = sd_list.sd_list(nelec, nspin)
+    params = np.random.rand(len(sds))
+
+    wfn = BaseWavefunction(nelec, nspin)
+    wfn.assign_params(params)
+
+    # Create a DataFrameFanpy object
+    df = DataFrameFanpy(wfn_label="Wavefunction", wfn_params=wfn.params, wfn_index=sds)
+
+    assert df.shape == (len(sds), 1)
+    assert df.index.tolist() == sds
+    assert np.allclose(df["Wavefunction"], params)
+
+
+def test_ci_dataframe_wfn():
+    """Test creating an analysis.dataframe.ci.DataFrameCI object."""
+
+    # Create a custom CIWavefunction object
+    nelec = 4
+    nspin = 8
+
+    sds = sd_list.sd_list(nelec, nspin)
+
+    wfn = CIWavefunction(nelec, nspin, sds=sds)
+
+    params = np.random.rand(*wfn.params.shape)
+    wfn.assign_params(params)
+
+    # Create a DataFrameCI object
+    df = DataFrameCI(wfn, wfn_label="CIWavefunction")
+
+    assert df.shape == (len(sds), 1)
+    assert df.index.tolist() == sds
+    assert np.allclose(df["CIWavefunction"], params)
+
+
+def test_ci_dataframe_formats():
+    """Test analysis.dataframe.ci.DataFrameCI formatting methods."""
+
+    # Create a custom CIWavefunction object
+    nelec = 4
+    nspin = 8
+    nspatial = nspin // 2
+
+    sds = sd_list.sd_list(nelec, nspin)
+
+    wfn = CIWavefunction(nelec, nspin, sds=sds)
+
+    # Create a DataFrameCI object
+    df = DataFrameCI(wfn, wfn_label="CIWavefunction")
+
+    # Convert Slater determinants from integers to formatted strings
+    formatted_sds = [
+        " ".join(
+            [
+                format(slater.split_spin(sd, nspatial)[0], f"0{nspatial}b")[::-1],
+                format(slater.split_spin(sd, nspatial)[1], f"0{nspatial}b")[::-1],
+            ]
+        )
+        for sd in sds
+    ]
+
+    # Convert Slater determinants from integers to strings in DataFrameCI
+    df.set_formatted_sds_as_index()
+    assert df.index.tolist() == formatted_sds
+
+    # Convert Slater determinants from strings to integers in DataFrameCI
+    df.set_sds_as_index()
+    assert df.index.tolist() == sds
+
+
+def test_cc_dataframe_wfn():
+    """Test creating an analysis.dataframe.cc.DataFrameCC object."""
+
+    # Create a custom CIWavefunction object
+    nelec = 4
+    nspin = 8
+    ranks = [1, 2, 3, 4]
+
+    counter = 0
+    exops = {}
+    for rank in ranks:
+        for annihilators in combinations(range(nspin), rank):
+            for creators in combinations([i for i in range(nspin) if i not in annihilators], rank):
+                exops[(*annihilators, *creators)] = counter
+                counter += 1
+
+    wfn = BaseCC(nelec, nspin)
+    wfn.exops = exops
+
+    params = np.random.rand(len(exops))
+    wfn.assign_params(params)
+
+    # Convert operators from tuple to strings
+    exops_str = []
+    for excitation_op in exops:
+        exops_str.append(" ".join(map(str, excitation_op)))
+
+    # Create a DataFrameCC object
+    df = DataFrameCC(wfn, wfn_label="BaseCC")
+
+    assert df.shape == (len(exops), 1)
+    assert df.index.tolist() == exops_str
+    assert np.allclose(df["BaseCC"], params)
+
+
+def test_cc_dataframe_formats():
+    """Test analysis.dataframe.cc.DataFrameCC formatting methods."""
+
+    # Create a StandardCC object
+    nelec = 4
+    nspin = 8
+    nspatial = nspin // 2
+
+    wfn = StandardCC(nelec, nspin)
+    exops = wfn.exops.keys()
+    ref_sd = wfn.refwfn
+
+    # Convert operators from tuple to strings
+    exops_str = []
+    for excitation_op in exops:
+        exops_str.append(" ".join(map(str, excitation_op)))
+
+    # Create a DataFrameCC object
+    df = DataFrameCC(wfn, wfn_label="BaseCC")
+
+    sds = []
+
+    # Convert excitation operators to Slater determinants format
+    for excitation_op in exops:
+        excitation_wfn = list(format(ref_sd, f"0{2*nspatial}b")[::-1])
+
+        for index in excitation_op:
+            if excitation_wfn[index] == "1":
+                excitation_wfn[index] = "0"
+            elif excitation_wfn[index] == "0":
+                excitation_wfn[index] = "1"
+
+        # Add the formatted excitation operator and parameter to the list
+        excitation_wfn = int("".join(excitation_wfn[::-1]), 2)
+        sds.append(excitation_wfn)
+
+    # Convert excitation operators to Slater determinants in DataFrameCC
+    df.set_sds_as_index()
+    assert df.index.tolist() == sds
+
+    # Convert Slater determinants from integers to formatted strings
+    formatted_sds = [
+        " ".join(
+            [
+                format(slater.split_spin(sd, nspatial)[0], f"0{nspatial}b")[::-1],
+                format(slater.split_spin(sd, nspatial)[1], f"0{nspatial}b")[::-1],
+            ]
+        )
+        for sd in sds
+    ]
+
+    # Convert Slater determinants integers to strings in DataFrameCC
+    df.set_formatted_sds_as_index()
+    assert df.index.tolist() == formatted_sds
+
+    # Convert Slater determinants strings to operators indices in DataFrameCC
+    df.set_operators_as_index()
+    assert df.index.tolist() == exops_str
+
+
+def test_geminal_dataframe_wfn():
+    """Test creating an analysis.dataframe.geminal.DataFrameGeminal object."""
+
+    # Create a custom BaseGeminal object
+    nelec = 4
+    nspin = 8
+    ngem = 2
+
+    orbpairs = tuple((i, j) for i in range(nspin) for j in range(i + 1, nspin))
+
+    wfn = BaseGeminal(nelec, nspin, ngem=ngem, orbpairs=orbpairs)
+
+    params = np.random.rand(len(orbpairs) * ngem)
+    wfn.assign_params(params)
+
+    # Create a DataFrameGeminal object
+    df = DataFrameGeminal(wfn, wfn_label="BaseGeminal")
+
+    orbpairs_str = tuple(" ".join(map(str, [i, j])) for i in range(nspin) for j in range(i + 1, nspin))
+    ind_orbpairs = list(product(range(ngem), orbpairs_str))
+
+    assert df.shape == (len(orbpairs) * ngem, 1)
+    assert df.index.tolist() == ind_orbpairs
+    assert np.allclose(df["BaseGeminal"], params)
+
+
+def test_geminal_dataframe_formats():
+    """Test analysis.dataframe.geminal.DataFrameGeminal formatting methods."""
+
+    # Create a custom BaseGeminal object
+    nelec = 4
+    nspin = 8
+    nspatial = nspin // 2
+
+    wfn = BaseGeminal(nelec, nspin)
+
+    geminals = [i for i in range(wfn.ngem)]
+    orbpairs = tuple(" ".join(map(str, [i, j])) for i in range(nspin) for j in range(i + 1, nspin))
+    ind_orbpairs = list(product(geminals, orbpairs))
+
+    # Create a DataFrameGeminal object
+    df = DataFrameGeminal(wfn, wfn_label="BaseGeminal")
+
+    sds = []
+
+    for orbital_pair in orbpairs:
+        wfn_pair = [
+            "0",
+        ] * nspin
+
+        for orbital in list(map(int, orbital_pair.split())):
+            wfn_pair[orbital] = "1"
+
+        wfn_pair = int("".join(wfn_pair[::-1]), 2)
+        sds.append(wfn_pair)
+
+    ind_sds = list(product(geminals, sds))
+
+    # Convert geminal pairs to Slater determinants in DataFrameGeminal
+    df.set_sds_as_index()
+    assert df.index.tolist() == ind_sds
+
+    # Convert Slater determinants from integers to formatted strings
+    formatted_sds = [
+        " ".join(
+            [
+                format(slater.split_spin(sd, nspatial)[0], f"0{nspatial}b")[::-1],
+                format(slater.split_spin(sd, nspatial)[1], f"0{nspatial}b")[::-1],
+            ]
+        )
+        for sd in sds
+    ]
+
+    ind_formatted_sds = list(product(geminals, formatted_sds))
+
+    # Convert Slater determinants integers to strings in DataFrameGeminal
+    df.set_formatted_sds_as_index()
+    assert df.index.tolist() == ind_formatted_sds
+
+    # Convert Slater determinants strings to geminal pairs in DataFrameGeminal
+    df.set_geminals_as_index()
+    assert df.index.tolist() == ind_orbpairs
+
+
+def test_geminal_ref_sd_dataframe_formats():
+    """Test analysis.dataframe.geminal.DataFrameGeminal formatting methods for Wavefunctions with reference Slater determinats."""
+
+    # Create AP1roG object
+    nelec = 4
+    nspin = 8
+    nspatial = nspin // 2
+
+    wfn = AP1roG(nelec, nspin)
+
+    geminals = list(wfn.dict_reforbpair_ind.keys())
+    geminals_str = []
+    for geminal in geminals:
+        geminals_str.append(" ".join(map(str, geminal)))
+
+    orbpairs = list(wfn.dict_orbpair_ind.keys())
+    orbpairs_str = []
+    for orbpair in orbpairs:
+        orbpairs_str.append(" ".join(map(str, orbpair)))
+
+    ind_orbpairs = list(product(geminals_str, orbpairs_str))
+
+    # Create a DataFrameGeminal object
+    df = DataFrameGeminal(wfn, wfn_label="APIG")
+
+    ind_sds = []
+
+    for geminal, orbital_pair in ind_orbpairs:
+        sd_pair = list(format(wfn.ref_sd, f"0{2*nspatial}b")[::-1])
+
+        for orbital in list(map(int, geminal.split())):
+            sd_pair[orbital] = "0"
+
+        for orbital in list(map(int, orbital_pair.split())):
+            sd_pair[orbital] = "1"
+
+        sd_pair = int("".join(sd_pair[::-1]), 2)
+        ind_sds.append((geminal, sd_pair))
+
+    # Convert geminal pairs to Slater determinants in DataFrameGeminal
+    df.set_sds_as_index()
+    assert df.index.tolist() == ind_sds
+
+    # Convert Slater determinants from integers to formatted strings
+    ind_formatted_sds = [
+        (
+            geminal,
+            " ".join(
+                [
+                    format(slater.split_spin(sd, nspatial)[0], f"0{nspatial}b")[::-1],
+                    format(slater.split_spin(sd, nspatial)[1], f"0{nspatial}b")[::-1],
+                ]
+            ),
+        )
+        for geminal, sd in ind_sds
+    ]
+
+    # Convert Slater determinants integers to strings in DataFrameGeminal
+    df.set_formatted_sds_as_index()
+    assert df.index.tolist() == ind_formatted_sds
+
+    # Convert Slater determinants strings to geminal pairs in DataFrameGeminal
+    df.set_geminals_as_index()
+    assert df.index.tolist() == ind_orbpairs
+
+
+def test_dataframe_io():
+    """Test analysis.dataframe.base.DataFrameFanpy I/O methods."""
+
+    nelec = 4
+    nspin = 8
+
+    sds = sd_list.sd_list(nelec, nspin)
+
+    wfn = CIWavefunction(nelec, nspin, sds=sds)
+
+    params = np.random.rand(*wfn.params.shape)
+    wfn.assign_params(params)
+
+    # Create a DataFrameCI object
+    df = DataFrameCI(wfn, wfn_label="CIWavefunction")
+
+    # Save the DataFrame to a CSV file
+    df.to_csv("test.csv")
+
+    # Load the DataFrame from the CSV file
+    df_loaded = DataFrameCI()
+    df_loaded.read_csv("test.csv")
+
+    assert df_loaded.shape == df.shape
+    assert df_loaded.index.tolist() == df.index.tolist()
+    assert np.allclose(df_loaded["CIWavefunction"].tolist(), df["CIWavefunction"].tolist())


### PR DESCRIPTION
Added missing support to MultiIndex when importing DataFrames for Geminals using CSV files.

The solution is obtained by recreating the MultiIndex system after loading.
```
self.dataframe = self.dataframe.reset_index()
self.dataframe = self.dataframe.set_index(["geminal", "pair"])
```