### PR TITLE
Fix the CC embedding test

### DIFF
--- a/tests/test_wfn_cc_embedding.py
+++ b/tests/test_wfn_cc_embedding.py
@@ -17,7 +17,7 @@ def test_embeddingcc_init():
                                     (1, 0): 4, (1, 1): 5, (1, 2): 6, (1, 3): 7}
     assert test.ranks == [1, 2]
     assert test.refwfn == 0b00110011
-    assert test.refwfn_list == [0b0011, 0b0011]
+    assert test.refwfn_list == [0b0101, 0b0101]
     assert test.exops == {(0, 1): 0, (0, 3): 1, (2, 1): 2, (2, 3): 3, (0, 2, 1, 3): 4,
                           (4, 5): 5, (4, 7): 6, (6, 5): 7, (6, 7): 8, (4, 6, 5, 7): 9}
     assert np.allclose(test.params, np.zeros(test.nparams))


### PR DESCRIPTION
## Issue
This test failed because the way we calculate the `refwfn_list` has been updated, while test remained in its original form. 

Previous `refwfn_list`:
```python
        occ_indices_list = [[] for i in self.indices_list]
        for i in slater.occ_indices(self.refwfn):
            system_ind, j = dict_system_sub[i]
            occ_indices_list[system_ind].append(j)
        refwfn_list = []
        for occ_indices in occ_indices_list:
            refwfn_list.append(slater.create(0, *occ_indices))
        # NOTE: not used by class but is used to test
        self.refwfn_list = refwfn_list
```

Current `refwfn_list`:
```python
        if not refwfn_list:
            refwfn_list = []
            for nelec, nspin in zip(nelec_list, nspin_list):
                refwfn_list.append(slater.ground(nelec, nspin))
            # NOTE: not used by class but is used to test
        self.refwfn_list = refwfn_list
```
## Solution 
Both `EmbeddedCC` wavefunction tests have the same number of electrons and spinorbitals in their subsystems. Thus, they have to have the same `refwfn_list` as well. This assumes that the updated code correctly calculates `refwfn_list`.  