### PR TITLE
fix: (un)freezing parameters in legacy interface

### DIFF
--- a/fanpy/interface/fanci/legacy.py
+++ b/fanpy/interface/fanci/legacy.py
@@ -503,10 +503,10 @@ class ProjectedSchrodingerLegacyFanCI(metaclass=ABCMeta):
 
         """
         for param in params:
-            self.mask[param] = False
+            self._mask[param] = False
 
         # Update nactive
-        self.nactive = self.mask.sum()
+        self._nactive = self._mask.sum()
 
     def unfreeze_parameter(self, *params: Sequence[int]) -> None:
         """
@@ -519,10 +519,10 @@ class ProjectedSchrodingerLegacyFanCI(metaclass=ABCMeta):
 
         """
         for param in params:
-            self.mask[param] = True
+            self._mask[param] = True
 
         # Update nactive
-        self.nactive = self.mask.sum()
+        self._nactive = self._mask.sum()
 
     def compute_objective(self, x: np.ndarray) -> np.ndarray:
         """


### PR DESCRIPTION
This pr fixes the `freeze_parameter` and `unfreeze_parameter` method in the `ProjectedSchrodingerLegacyFanCI` class, which is the legacy interface.

The code previously tried to change `self.mask` that returns the write protected `self._mask_view`. This caused: `ValueError: assignment destination is read-only`.  

**Solution:** use `self._mask` and `self._nactive`, similarly to the `(un)freeze_parameter` method in the new `ProjectedSchrodingerPyCI` class.