### PR TITLE
fix: legacy fanci evaluation when updating fanci objective for FanPT

### DIFF
--- a/fanpy/fanpt/utils.py
+++ b/fanpy/fanpt/utils.py
@@ -1,7 +1,7 @@
 """ FANPT wrapper"""
 
 from fanpy.ham.restricted_chemical import RestrictedMolecularHamiltonian
-from fanpy.interface.fanci import ProjectedSchrodingerPyCI
+from fanpy.interface.fanci import ProjectedSchrodingerFanCI
 import numpy as np
 import pyci
 
@@ -27,7 +27,7 @@ def update_fanci_objective(new_ham, fanci_objective, norm_det=None):
     fanpy_objective_class = fanci_objective.fanpy_objective.__class__
 
     # Determine if the legacy FanCI interface is used
-    legacy_fanci = isinstance(fanci_objective, ProjectedSchrodingerPyCI)
+    legacy_fanci = isinstance(fanci_objective, ProjectedSchrodingerFanCI)
 
     # Convert new_ham to RestrictedMolecularHamiltonian if necessary
     if isinstance(new_ham, pyci.hamiltonian):


### PR DESCRIPTION
This pull request fixes the `legacy_fanci` evaluation during FanPT calculations in the `update_fanci_objective` function. 

`legacy_fanci` has to be `True` when using the legacy interface. Previously, we set it to `True` when the objective was `ProjectedSchrodingerPyCI`, which is the new fanci objective. 

**Solution:** change the fanci objective class to `ProjectedSchrodingerFanCI`, where we determine what `legacy_fanci` is. 