### PR TITLE
fix: add mask_function to pyci interface

### DIFF
--- a/fanpy/interface/fanci/pyci.py
+++ b/fanpy/interface/fanci/pyci.py
@@ -670,6 +670,37 @@ class ProjectedSchrodingerPyCI(FanCI):
 
         return f, dfdx
 
+    def mask_function(self, f: Callable, x_ref: np.ndarray) -> Callable:
+        """
+        Generate masked function for optimization with frozen parameters.
+
+        Parameters
+        ----------
+        f : Callable
+            Initial function.
+        x_ref : np.ndarray
+            Full parameter vector including frozen terms.
+
+        Returns
+        -------
+        f : Callable
+            Masked function.
+
+        """
+        if self.nactive == self.nparam:
+            return f
+
+        def masked_f(x: np.ndarray) -> Any:
+            """
+            Masked function.
+
+            """
+            y = np.copy(x_ref)
+            y[self.mask] = x
+            return f(y)
+
+        return masked_f
+
     def optimize(
         self,
         x0: np.ndarray,

--- a/fanpy/interface/fanci/pyci.py
+++ b/fanpy/interface/fanci/pyci.py
@@ -10,7 +10,7 @@ from fanpy.eqn.base import BaseSchrodinger
 from fanpy.wfn.composite.product import ProductWavefunction
 from fanpy.tools.performance import current_memory
 
-from typing import Any, List, Tuple, Union, Sequence
+from typing import Any, Callable, List, Tuple, Union, Sequence
 
 import os
 import math


### PR DESCRIPTION
The new `PyCI` interface calls a `mask_function` method in line 781 of `fanpy/interface/fanci/pyci.py`. This has not been declared in the scope of the class. 

**solution** 
implement the same `mask_function` as the one in the legacy interface  class (`ProjectedSchrodingerLegacyFanCI`). 