### PR TITLE
test: fix sign in cc apg1rosd and apset1grosd tests

### DIFF
--- a/tests/test_wfn_cc_apg1ro_sd.py
+++ b/tests/test_wfn_cc_apg1ro_sd.py
@@ -48,7 +48,6 @@ def check_sign(occ_indices, exops):
         sd = slater.excite(sd, *exop)
     return sign
 
-@pytest.mark.skip(reason="This test fails and is being worked on (Issue 56).")
 def test_generate_possible_exops():
     """Test APG1roSD.generate_possible_exops."""
     test = TempAPG1roSD()
@@ -64,46 +63,46 @@ def test_generate_possible_exops():
     sign = check_sign([0, 1, 4], [[0, 2], [1, 3], [4, 6]]) / base_sign
     assert np.allclose(
         test.exop_combinations[(0, 1, 4, 2, 3, 6)][3][0],
-        [test.get_ind((0, 2)), test.get_ind((1, 3)), test.get_ind((4, 6)), sign if sign == 1 else 255],
+        [test.get_ind((0, 2)), test.get_ind((1, 3)), test.get_ind((4, 6)), sign if sign == 1 else 0],
     )
     sign = check_sign([0, 1, 4], [[0, 2], [1, 6], [4, 3]]) / base_sign
     assert np.allclose(
         test.exop_combinations[(0, 1, 4, 2, 3, 6)][3][1],
-        [test.get_ind((0, 2)), test.get_ind((1, 6)), test.get_ind((4, 3)), sign if sign == 1 else 255],
+        [test.get_ind((0, 2)), test.get_ind((1, 6)), test.get_ind((4, 3)), sign if sign == 1 else 0],
     )
     sign = check_sign([0, 1, 4], [[0, 3], [1, 2], [4, 6]]) / base_sign
     assert np.allclose(
         test.exop_combinations[(0, 1, 4, 2, 3, 6)][3][2],
-        [test.get_ind((0, 3)), test.get_ind((1, 2)), test.get_ind((4, 6)), sign if sign == 1 else 255],
+        [test.get_ind((0, 3)), test.get_ind((1, 2)), test.get_ind((4, 6)), sign if sign == 1 else 0],
     )
     sign = check_sign([0, 1, 4], [[0, 3], [1, 6], [4, 2]]) / base_sign
     assert np.allclose(
         test.exop_combinations[(0, 1, 4, 2, 3, 6)][3][3],
-        [test.get_ind((0, 3)), test.get_ind((1, 6)), test.get_ind((4, 2)), sign if sign == 1 else 255],
+        [test.get_ind((0, 3)), test.get_ind((1, 6)), test.get_ind((4, 2)), sign if sign == 1 else 0],
     )
     sign = check_sign([0, 1, 4], [[0, 6], [1, 2], [4, 3]]) / base_sign
     assert np.allclose(
         test.exop_combinations[(0, 1, 4, 2, 3, 6)][3][4],
-        [test.get_ind((0, 6)), test.get_ind((1, 2)), test.get_ind((4, 3)), sign if sign == 1 else 255],
+        [test.get_ind((0, 6)), test.get_ind((1, 2)), test.get_ind((4, 3)), sign if sign == 1 else 0],
     )
     sign = check_sign([0, 1, 4], [[0, 6], [1, 3], [4, 2]]) / base_sign
     assert np.allclose(
         test.exop_combinations[(0, 1, 4, 2, 3, 6)][3][5],
-        [test.get_ind((0, 6)), test.get_ind((1, 3)), test.get_ind((4, 2)), sign if sign == 1 else 255],
+        [test.get_ind((0, 6)), test.get_ind((1, 3)), test.get_ind((4, 2)), sign if sign == 1 else 0],
     )
 
     sign = check_sign([0, 1, 4], [[1, 2], [0, 4, 3, 6]]) / base_sign
     assert np.allclose(
         test.exop_combinations[(0, 1, 4, 2, 3, 6)][2][0],
-        [test.get_ind((1, 2)), test.get_ind((0, 4, 3, 6)), sign if sign == 1 else 255],
+        [test.get_ind((1, 2)), test.get_ind((0, 4, 3, 6)), sign if sign == 1 else 0],
     )
     sign = check_sign([0, 1, 4], [[1, 3], [0, 4, 2, 6]]) / base_sign
     assert np.allclose(
         test.exop_combinations[(0, 1, 4, 2, 3, 6)][2][1],
-        [test.get_ind((1, 3)), test.get_ind((0, 4, 2, 6)), sign if sign == 1 else 255],
+        [test.get_ind((1, 3)), test.get_ind((0, 4, 2, 6)), sign if sign == 1 else 0],
     )
     sign = check_sign([0, 1, 4], [[1, 6], [0, 4, 2, 3]]) / base_sign
     assert np.allclose(
         test.exop_combinations[(0, 1, 4, 2, 3, 6)][2][2],
-        [test.get_ind((1, 6)), test.get_ind((0, 4, 2, 3)), sign if sign == 1 else 255],
+        [test.get_ind((1, 6)), test.get_ind((0, 4, 2, 3)), sign if sign == 1 else 0],
     )

--- a/tests/test_wfn_cc_apset1gro_sd.py
+++ b/tests/test_wfn_cc_apset1gro_sd.py
@@ -46,7 +46,7 @@ def check_sign(occ_indices, exops):
         sd = slater.excite(sd, *exop)
     return sign
 
-@pytest.mark.skip(reason="This test fails and is being worked on (Issue 56).")
+
 def test_generate_possible_exops():
     """Test APset1GroSD.generate_possible_exops."""
     test = TempAPset1GroSD()
@@ -69,21 +69,21 @@ def test_generate_possible_exops():
     sign = check_sign([0, 1, 4], [[0, 2], [1, 3], [4, 6]]) / base_sign
     assert np.allclose(
         test.exop_combinations[(0, 1, 4, 2, 3, 6)][3][0],
-        [test.get_ind((0, 2)), test.get_ind((1, 3)), test.get_ind((4, 6)), sign if sign == 1 else 255],
+        [test.get_ind((0, 2)), test.get_ind((1, 3)), test.get_ind((4, 6)), sign if sign == 1 else 0],
     )
     sign = check_sign([0, 1, 4], [[0, 3], [1, 2], [4, 6]]) / base_sign
     assert np.allclose(
         test.exop_combinations[(0, 1, 4, 2, 3, 6)][3][1],
-        [test.get_ind((0, 3)), test.get_ind((1, 2)), test.get_ind((4, 6)), sign if sign == 1 else 255],
+        [test.get_ind((0, 3)), test.get_ind((1, 2)), test.get_ind((4, 6)), sign if sign == 1 else 0],
     )
 
     sign = check_sign([0, 1, 4], [[1, 2], [0, 4, 3, 6]]) / base_sign
     assert np.allclose(
         test.exop_combinations[(0, 1, 4, 2, 3, 6)][2][0],
-        [test.get_ind((1, 2)), test.get_ind((0, 4, 3, 6)), sign if sign == 1 else 255],
+        [test.get_ind((1, 2)), test.get_ind((0, 4, 3, 6)), sign if sign == 1 else 0],
     )
     sign = check_sign([0, 1, 4], [[1, 3], [0, 4, 2, 6]]) / base_sign
     assert np.allclose(
         test.exop_combinations[(0, 1, 4, 2, 3, 6)][2][1],
-        [test.get_ind((1, 3)), test.get_ind((0, 4, 2, 6)), sign if sign == 1 else 255],
+        [test.get_ind((1, 3)), test.get_ind((0, 4, 2, 6)), sign if sign == 1 else 0],
     )


### PR DESCRIPTION
Previously we stored the -1 sign in the CC wavefunctions as 255. However, pr #42 changed this, so that we store the -1 sign as 0. `test_wfn_cc_apg1ro_sd.py` and `test_wfn_apset1gro_sd.py` still expected to get 255 for the -1 sign. I updated the tests to reflect the changes made in pr #42.  