### PR TITLE
Correcting size of overlaps deriv arrays

### DIFF
--- a/fanpy/interface/fanci/legacy.py
+++ b/fanpy/interface/fanci/legacy.py
@@ -1191,7 +1191,7 @@ class ProjectedSchrodingerFanCI(ProjectedSchrodingerLegacyFanCI):
         else:
             # Select parameters according to selected chunks
             y = np.zeros(
-                (f_chunk - s_chunk, self.nactive - self.mask[-1]),
+                (len(sds), self.nactive - self.mask[-1]),
                 dtype=pyci.c_double,
             )
 

--- a/fanpy/interface/fanci/pyci.py
+++ b/fanpy/interface/fanci/pyci.py
@@ -407,7 +407,7 @@ class ProjectedSchrodingerPyCI(FanCI):
         else:
             # Select parameters according to selected chunks
             y = np.zeros(
-                (f_chunk - s_chunk, self.nactive - self.mask[-1]),
+                (len(sds), self.nactive - self.mask[-1]),
                 dtype=pyci.c_double,
             )
 


### PR DESCRIPTION
There's an issue in `compute_overlap_deriv` when using `None` for chunk indices (which means a full calculation) if the number of s-space projections is less than the number of parameters.

To deal with the None values for the chunks indices, it was replaced:

```
            # Select parameters according to selected chunks
            y = np.zeros(
                (f_chunk - s_chunk, self.nactive - self.mask[-1]),
                dtype=pyci.c_double,
            )
```
by:
```
            # Select parameters according to selected chunks
            y = np.zeros(
                (len(sds), self.nactive - self.mask[-1]),
                dtype=pyci.c_double,
            )
```