### PR TITLE
fix: raise type error in the get overlap method of ProductWavefunction

### DIFF
--- a/fanpy/wfn/composite/product.py
+++ b/fanpy/wfn/composite/product.py
@@ -141,9 +141,9 @@ class ProductWavefunction(LinearCombinationWavefunction):
                 isinstance(deriv, tuple)
                 and len(deriv) == 2
                 and isinstance(deriv[0], BaseWavefunction)
-                # and isinstance(deriv[1], np.ndarray)
-                # and deriv[1].ndim == 1
-                # and np.issubdtype(deriv[1].dtype, np.integer)
+                and isinstance(deriv[1], np.ndarray)
+                and deriv[1].ndim == 1
+                and np.issubdtype(deriv[1].dtype, np.integer)
             ):
                 raise TypeError(
                     "Derivative indices must be given as a 2-tuple whose first element is the "

--- a/tests/test_wfn_composite_product.py
+++ b/tests/test_wfn_composite_product.py
@@ -30,7 +30,6 @@ def test_init():
         wfn = ProductWavefunction([wfn1, wfn1])
 
 
-@pytest.mark.skip(reason="This test fails and is being worked on (Issue 55).")
 def test_get_overlap():
     """Test ProductWavefunction.get_overlap."""
     wfn1 = CIWavefunction(4, 10)


### PR DESCRIPTION
### Problem 
The `get_overlap` method in the `ProductWavefunction` requires `deriv` to be a list with two elements. The first is a wavefunction and the second is a 1 dimensional `numpy` array. The test expects the code to raise a `TypeError` if these requirements are not met. A previous [commit](https://github.com/mqcomplab/Fanpy/commit/fea00d32e80b322db81cae1f17c2ccc8717dce42) commented out some of the checks, which is why the test failed.

### Solution 

I have uncommented the checks so that the `ProductWavefunction` passes the tests. 