### PR TITLE
test: fix sign conversion in standard cc test

### DIFF
--- a/tests/test_wfn_cc_standard_cc.py
+++ b/tests/test_wfn_cc_standard_cc.py
@@ -58,13 +58,17 @@ def scale_sign(sgn):
     """Convert sign to 1 or -1.
     
     Args:
-        sgn (int): Sign of the excitation in exop_comb (-1 is stored as 0).
+        sgn (uint): Sign of the excitation in exop_comb (-1 is stored as 0).
     
     Returns:
         int: 1 or -1.
     """
-
-    return sgn * 2 - 1
+    if sgn == 0:
+        return -1
+    elif sgn == 1:
+        return 1
+    else:
+        raise ValueError(f"Invalid sign value: {sgn}. Expected 1 or 0, where 0 represents -1.")
 
 def test_generate_possible_exops():
     """Test StandardCC.generate_possible_exops."""
@@ -84,6 +88,9 @@ def test_generate_possible_exops():
         test.exop_combinations[(0, 2, 1, 3)][2][1][0:2], [test.get_ind((0, 3)), test.get_ind((2, 1))]
     )
     base_sign = slater.sign_excite(0b0101, [0, 2], [1, 3]) # base sign of excitation
+    print("DEBUG: base_sign", base_sign)
+    print("DEBUG: scale_sign", scale_sign(test.exop_combinations[(0, 2, 1, 3)][2][0][-1]))
+    print("DEBUG: check_sign", check_sign([0, 2], [[0, 1], [2, 3]]))
     assert  base_sign * scale_sign(test.exop_combinations[(0, 2, 1, 3)][2][0][-1] ) == check_sign([0, 2], [[0, 1], [2, 3]])
     assert base_sign * scale_sign(test.exop_combinations[(0, 2, 1, 3)][2][1][-1] ) == check_sign([0, 2], [[0, 3], [2, 1]])
 
@@ -367,6 +374,7 @@ def test_generate_possible_exops():
         (test.get_ind((0, 1, 4, 2, 3, 6)), ),
     )
     base_sign = slater.sign_excite(0b10011, [0, 1, 4], [2, 3, 6])
+    print("DEBUG: base_sign", base_sign)
     assert base_sign * scale_sign(test.exop_combinations[(0, 1, 4, 2, 3, 6)][3][0][-1]) == check_sign([0, 1, 4],
         ((0, 2), (1, 3), (4, 6)),)
     assert base_sign * scale_sign(test.exop_combinations[(0, 1, 4, 2, 3, 6)][3][1][-1]) == check_sign([0, 1, 4],

--- a/tests/test_wfn_cc_standard_cc.py
+++ b/tests/test_wfn_cc_standard_cc.py
@@ -88,9 +88,6 @@ def test_generate_possible_exops():
         test.exop_combinations[(0, 2, 1, 3)][2][1][0:2], [test.get_ind((0, 3)), test.get_ind((2, 1))]
     )
     base_sign = slater.sign_excite(0b0101, [0, 2], [1, 3]) # base sign of excitation
-    print("DEBUG: base_sign", base_sign)
-    print("DEBUG: scale_sign", scale_sign(test.exop_combinations[(0, 2, 1, 3)][2][0][-1]))
-    print("DEBUG: check_sign", check_sign([0, 2], [[0, 1], [2, 3]]))
     assert  base_sign * scale_sign(test.exop_combinations[(0, 2, 1, 3)][2][0][-1] ) == check_sign([0, 2], [[0, 1], [2, 3]])
     assert base_sign * scale_sign(test.exop_combinations[(0, 2, 1, 3)][2][1][-1] ) == check_sign([0, 2], [[0, 3], [2, 1]])
 

--- a/tests/test_wfn_cc_standard_cc.py
+++ b/tests/test_wfn_cc_standard_cc.py
@@ -371,7 +371,6 @@ def test_generate_possible_exops():
         (test.get_ind((0, 1, 4, 2, 3, 6)), ),
     )
     base_sign = slater.sign_excite(0b10011, [0, 1, 4], [2, 3, 6])
-    print("DEBUG: base_sign", base_sign)
     assert base_sign * scale_sign(test.exop_combinations[(0, 1, 4, 2, 3, 6)][3][0][-1]) == check_sign([0, 1, 4],
         ((0, 2), (1, 3), (4, 6)),)
     assert base_sign * scale_sign(test.exop_combinations[(0, 1, 4, 2, 3, 6)][3][1][-1]) == check_sign([0, 1, 4],


### PR DESCRIPTION
The problem in #76 was the following: `scipy` had a recent release (version 1.16) that requires python 3.11 and `numpy` 1.25. One of our test cases is with python version 3.11. Thus, during the installation of `fanpy`, `numpy` was upgraded to version `2.3`. This resulted in the overflow bug in the standard CC test. Changing the `scale_sign` function fixes this issue. 