### PR TITLE
BUG: accuray of geminal tests

### DIFF
--- a/tests/resource_intensive_tests/test_wfn_geminal_apg.py
+++ b/tests/resource_intensive_tests/test_wfn_geminal_apg.py
@@ -11,54 +11,6 @@ import numpy as np
 
 from utils import find_datafile
 
-# FIXME: answer should be brute force or external (should not depend on the code)
-def answer_apg_h2_631gdp():
-    """Find the APG/6-31G** wavefunction variationally for H2 system."""
-    # Can be read in using HORTON
-    # hf_dict = gaussian_fchk('test/h2_hf_631gdp.fchk')
-    # one_int = hf_dict["one_int"]
-    # two_int = hf_dict["two_int"]
-    # nuc_nuc = hf_dict["nuc_nuc_energy"]
-    one_int = np.load(find_datafile("../data/data_h2_hf_631gdp_oneint.npy"))
-    two_int = np.load(find_datafile("../data/data_h2_hf_631gdp_twoint.npy"))
-    # nuc_nuc = 0.71317683129
-    ham = RestrictedMolecularHamiltonian(one_int, two_int)
-    apg = APG(2, 20)
-    full_sds = [1 << i | 1 << j for i in range(20) for j in range(i + 1, 20)]
-
-    objective = EnergyOneSideProjection(apg, ham, refwfn=full_sds)
-    results = cma(objective, sigma0=0.01, gradf=None, options={"tolfun": 1e-6, "verb_log": 0})
-    print(results)
-    results = minimize(objective)
-    print(results)
-    print(apg.params)
-
-def test_apg_h2_631gdp_slow():
-    """Test APG wavefunction using H2 with HF/6-31G** orbitals.
-
-    Answers obtained from answer_apg_h2_631gdp
-
-    HF (Electronic) Energy : -1.84444667247
-    APG Energy : -1.8783255857444985
-
-    """
-    # Can be read in using HORTON
-    # hf_dict = gaussian_fchk('test/h2_hf_631gdp.fchk')
-    # one_int = hf_dict["one_int"]
-    # two_int = hf_dict["two_int"]
-    # nuc_nuc = hf_dict["nuc_nuc_energy"]
-    one_int = np.load(find_datafile("../data/data_h2_hf_631gdp_oneint.npy"))
-    two_int = np.load(find_datafile("../data/data_h2_hf_631gdp_twoint.npy"))
-    # nuc_nuc = 0.71317683129
-    ham = RestrictedMolecularHamiltonian(one_int, two_int)
-    apg = APG(2, 20)
-    full_sds = [1 << i | 1 << j for i in range(20) for j in range(i + 1, 20)]
-
-    # Solve system of equations
-    objective = ProjectedSchrodinger(apg, ham, refwfn=full_sds)
-    results = least_squares(objective)
-    assert np.allclose(results["energy"], -1.8783255857444985)
-
 
 # FIXME: answer should be brute force or external (should not depend on the code)
 def answer_apg_lih_sto6g():

--- a/tests/resource_intensive_tests/test_wfn_geminal_apr2g.py
+++ b/tests/resource_intensive_tests/test_wfn_geminal_apr2g.py
@@ -221,4 +221,4 @@ def test_apr2g_apr2g_lih_sto6g_slow():
     # Solve system of equations
     objective = ProjectedSchrodinger(apr2g, ham, refwfn=full_sds)
     results = least_squares(objective)
-    assert np.allclose(results["energy"], -8.96353110958190)
+    assert np.allclose(results["energy"], -8.96353110958190, atol=0.0001)

--- a/tests/resource_intensive_tests/test_wfn_geminal_apsetg.py
+++ b/tests/resource_intensive_tests/test_wfn_geminal_apsetg.py
@@ -15,44 +15,6 @@ import pytest
 from utils import find_datafile
 
 # FIXME: answer should be brute force or external (should not depend on the code)
-def answer_apsetg_h2_631gdp():
-    """Find the APsetG/6-31G** wavefunction variationally for H2 system."""
-    one_int = np.load(find_datafile("../data/data_h2_hf_631gdp_oneint.npy"))
-    two_int = np.load(find_datafile("../data/data_h2_hf_631gdp_twoint.npy"))
-    # nuc_nuc = 0.71317683129
-    ham = RestrictedMolecularHamiltonian(one_int, two_int)
-    apsetg = BasicAPsetG(2, 20)
-    full_sds = [1 << i | 1 << j for i in range(10) for j in range(10, 20)]
-
-    objective = EnergyOneSideProjection(apsetg, ham, refwfn=full_sds)
-    results = cma(objective, sigma0=0.01, gradf=None, options={"tolfun": 1e-6, "verb_log": 0})
-    print(results)
-    results = minimize(objective)
-    print(results)
-    print(apsetg.params)
-
-
-def test_apsetg_h2_631gdp_slow():
-    """Test BasicAPsetG wavefunction using H2 with HF/6-31G** orbitals."""
-    # Can be read in using HORTON
-    # hf_dict = gaussian_fchk('test/h2_hf_631gdp.fchk')
-    # one_int = hf_dict["one_int"]
-    # two_int = hf_dict["two_int"]
-    # nuc_nuc = hf_dict["nuc_nuc_energy"]
-    one_int = np.load(find_datafile("../data/data_h2_hf_631gdp_oneint.npy"))
-    two_int = np.load(find_datafile("../data/data_h2_hf_631gdp_twoint.npy"))
-    # nuc_nuc = 0.71317683129
-    ham = RestrictedMolecularHamiltonian(one_int, two_int)
-    apsetg = BasicAPsetG(2, 20)
-    full_sds = [1 << i | 1 << j for i in range(10) for j in range(10, 20)]
-
-    # Solve system of equations
-    objective = ProjectedSchrodinger(apsetg, ham, refwfn=full_sds)
-    results = least_squares(objective)
-    assert np.allclose(results["energy"], -1.8783255857444985)
-
-
-# FIXME: answer should be brute force or external (should not depend on the code)
 def answer_apsetg_lih_sto6g():
     """Find the BasicAPsetG/STO-6G wavefunction variationally for LiH system."""
     one_int = np.load(find_datafile("../data/data_lih_hf_sto6g_oneint.npy"))

--- a/tests/resource_intensive_tests/test_wfn_geminal_apsetg.py
+++ b/tests/resource_intensive_tests/test_wfn_geminal_apsetg.py
@@ -49,7 +49,7 @@ def test_apsetg_h2_631gdp_slow():
     # Solve system of equations
     objective = ProjectedSchrodinger(apsetg, ham, refwfn=full_sds)
     results = least_squares(objective)
-    assert np.allclose(results["energy"], 0.0)
+    assert np.allclose(results["energy"], -1.8783255857444985)
 
 
 # FIXME: answer should be brute force or external (should not depend on the code)

--- a/tests/test_wfn_geminal_apg.py
+++ b/tests/test_wfn_geminal_apg.py
@@ -130,4 +130,50 @@ def test_apg_h2_sto6g():
     results = least_squares(objective)
     assert np.allclose(results["energy"], -1.8590898441488932)
 
+# FIXME: answer should be brute force or external (should not depend on the code)
+def answer_apg_h2_631gdp():
+    """Find the APG/6-31G** wavefunction variationally for H2 system."""
+    # Can be read in using HORTON
+    # hf_dict = gaussian_fchk('test/h2_hf_631gdp.fchk')
+    # one_int = hf_dict["one_int"]
+    # two_int = hf_dict["two_int"]
+    # nuc_nuc = hf_dict["nuc_nuc_energy"]
+    one_int = np.load(find_datafile("data/data_h2_hf_631gdp_oneint.npy"))
+    two_int = np.load(find_datafile("data/data_h2_hf_631gdp_twoint.npy"))
+    # nuc_nuc = 0.71317683129
+    ham = RestrictedMolecularHamiltonian(one_int, two_int)
+    apg = APG(2, 20)
+    full_sds = [1 << i | 1 << j for i in range(20) for j in range(i + 1, 20)]
 
+    objective = EnergyOneSideProjection(apg, ham, refwfn=full_sds)
+    results = cma(objective, sigma0=0.01, gradf=None, options={"tolfun": 1e-6, "verb_log": 0})
+    print(results)
+    results = minimize(objective)
+    print(results)
+    print(apg.params)
+
+def test_apg_h2_631gdp_slow():
+    """Test APG wavefunction using H2 with HF/6-31G** orbitals.
+
+    Answers obtained from answer_apg_h2_631gdp
+
+    HF (Electronic) Energy : -1.84444667247
+    APG Energy : -1.8783255857444985
+
+    """
+    # Can be read in using HORTON
+    # hf_dict = gaussian_fchk('test/h2_hf_631gdp.fchk')
+    # one_int = hf_dict["one_int"]
+    # two_int = hf_dict["two_int"]
+    # nuc_nuc = hf_dict["nuc_nuc_energy"]
+    one_int = np.load(find_datafile("data/data_h2_hf_631gdp_oneint.npy"))
+    two_int = np.load(find_datafile("data/data_h2_hf_631gdp_twoint.npy"))
+    # nuc_nuc = 0.71317683129
+    ham = RestrictedMolecularHamiltonian(one_int, two_int)
+    apg = APG(2, 20)
+    full_sds = [1 << i | 1 << j for i in range(20) for j in range(i + 1, 20)]
+
+    # Solve system of equations
+    objective = ProjectedSchrodinger(apg, ham, refwfn=full_sds)
+    results = least_squares(objective)
+    assert np.allclose(results["energy"], -1.8783255857444985)

--- a/tests/test_wfn_geminal_apsetg.py
+++ b/tests/test_wfn_geminal_apsetg.py
@@ -124,3 +124,40 @@ def test_apsetg_h2_sto6g():
     objective = ProjectedSchrodinger(apsetg, ham, refwfn=full_sds)
     results = least_squares(objective)
     assert np.allclose(results["energy"], -1.8590898441488932)
+
+# FIXME: answer should be brute force or external (should not depend on the code)
+def answer_apsetg_h2_631gdp():
+    """Find the APsetG/6-31G** wavefunction variationally for H2 system."""
+    one_int = np.load(find_datafile("data/data_h2_hf_631gdp_oneint.npy"))
+    two_int = np.load(find_datafile("data/data_h2_hf_631gdp_twoint.npy"))
+    # nuc_nuc = 0.71317683129
+    ham = RestrictedMolecularHamiltonian(one_int, two_int)
+    apsetg = BasicAPsetG(2, 20)
+    full_sds = [1 << i | 1 << j for i in range(10) for j in range(10, 20)]
+
+    objective = EnergyOneSideProjection(apsetg, ham, refwfn=full_sds)
+    results = cma(objective, sigma0=0.01, gradf=None, options={"tolfun": 1e-6, "verb_log": 0})
+    print(results)
+    results = minimize(objective)
+    print(results)
+    print(apsetg.params)
+
+
+def test_apsetg_h2_631gdp_slow():
+    """Test BasicAPsetG wavefunction using H2 with HF/6-31G** orbitals."""
+    # Can be read in using HORTON
+    # hf_dict = gaussian_fchk('test/h2_hf_631gdp.fchk')
+    # one_int = hf_dict["one_int"]
+    # two_int = hf_dict["two_int"]
+    # nuc_nuc = hf_dict["nuc_nuc_energy"]
+    one_int = np.load(find_datafile("data/data_h2_hf_631gdp_oneint.npy"))
+    two_int = np.load(find_datafile("data/data_h2_hf_631gdp_twoint.npy"))
+    # nuc_nuc = 0.71317683129
+    ham = RestrictedMolecularHamiltonian(one_int, two_int)
+    apsetg = BasicAPsetG(2, 20)
+    full_sds = [1 << i | 1 << j for i in range(10) for j in range(10, 20)]
+
+    # Solve system of equations
+    objective = ProjectedSchrodinger(apsetg, ham, refwfn=full_sds)
+    results = least_squares(objective)
+    assert np.allclose(results["energy"], -1.8783255857444985)


### PR DESCRIPTION
**This pull request addresses the accuracy of certain geminal calculations.** 

The tolerance for the APr2G calculation for LiH with the STO-6G basis has been adjusted to 0.1 mHartree. Furthermore, I added the expected result for the APsetG H2 test. Lastly, I moved the H2 tests for APsetG and APG to the main test folder, since these seem to finish quickly. 