### PR TITLE
fanpt.optimize not working with guess_params = none

### DIFF
--- a/fanpy/fanpt/fanpt.py
+++ b/fanpy/fanpt/fanpt.py
@@ -209,6 +209,7 @@ class FANPT:
     def optimize(
         self,
         guess_params,
+        guess_energy,
         final_order=None,
         lambda_i=None,
         lambda_f=None,
@@ -222,6 +223,8 @@ class FANPT:
         ---------
             guess_params : np.ndarray
                 Initial guess for wave function parameters.
+            guess_energy : float
+                Initial guess for electronic energy.
             final_order : int, optional
                 Final order of the FANPT calculation. Defaults to 1.
             lambda_i : float, optional
@@ -238,6 +241,9 @@ class FANPT:
             params: np.ndarray
             Solution of the FANPT calculation.
         """
+
+        # Format guess_params to FanPT including energy as parameter
+        guess_params = np.append(guess_params, guess_energy)
 
         # Assign attributes
         final_order = final_order or self.final_order


### PR DESCRIPTION
As observed, there is an issue with the default value of `guess_params` in FanPT. We decided to remove the default for `guess_params`, requiring users to provide these values.

Additionally, an argument for `guess_energy` was added. This change was made because the correct shape of the FanPT parameters array is `[param1, param2, ..., paramN, energy]`. To prevent potential user mistakes due to the differing shapes between FanPT and FanCI guess `arrays`, we opted to ask for them separately and then construct the `guess_params` array in the correct shape.