### PR TITLE
Added energy key to FanCI and FanPT results

### DIFF
--- a/fanpy/fanpt/fanpt.py
+++ b/fanpy/fanpt/fanpt.py
@@ -307,4 +307,7 @@ class FANPT:
             if not self.energy_active:
                 fanci_objective.freeze_parameter(-1)
 
+        # Add the energy to the results dictionary
+        results["energy"] = fanpt_params[-1]
+
         return results

--- a/fanpy/interface/fanci/legacy.py
+++ b/fanpy/interface/fanci/legacy.py
@@ -1533,6 +1533,10 @@ class ProjectedSchrodingerFanCI(ProjectedSchrodingerLegacyFanCI):
 
         # Run optimizer
         results = optimizer(*opt_args, **opt_kwargs)
+
+        # Add the energy to the results dictionary
+        results["energy"] = results.x[-1]
+
         return results
 
     def print(self, *args, **kwargs):

--- a/fanpy/interface/fanci/pyci.py
+++ b/fanpy/interface/fanci/pyci.py
@@ -885,6 +885,10 @@ class ProjectedSchrodingerPyCI(FanCI):
 
         # Run optimizer
         results = optimizer(*opt_args, **opt_kwargs)
+
+        # Add the energy to the results dictionary
+        results["energy"] = results.x[-1]
+
         return results
 
     def print(self, *args, **kwargs):


### PR DESCRIPTION
Our investigation revealed that the incorrect electronic energy values in FanPT e-free calculations stemmed not from the calculations or their results, but from the final `results` dictionary holding optimization data.

Usually, `results.x[-1]` is used as the energy, but this is inaccurate for e-free calculations because `results.x` does not include the energy as a parameter.

To solve this, we added an `energy` key to the `results` dictionary, which is updated within the FanCI interface and the FanPT optimizer. This change enables users to directly access the final energy without errors related to the formatting of `results.x`.