### PR TITLE
feat: implemented 2nd and 3rd derivatives in energy_param.py container for FANPT and updated the constant_terms.py accordingly

### DIFF
--- a/fanpy/fanpt/containers/constant_terms.py
+++ b/fanpy/fanpt/containers/constant_terms.py
@@ -141,7 +141,7 @@ class FANPTConstantTerms:
 
     def gen_constant_terms(self):
         r"""Generate the constant terms.
-
+    
         Returns
         -------
         constant_terms : np.ndarray
@@ -158,11 +158,38 @@ class FANPTConstantTerms:
                     r_vector += (
                         comb * self.previous_responses[o - 1][-1] * self.previous_responses[self.order - o - 1][:-1]
                     )
+    
                 constant_terms = -self.order * np.dot(
                     self.fanpt_container.d2_g_lambda_wfnparams, self.previous_responses[-1][:-1]
                 ) - np.dot(self.fanpt_container.d2_g_e_wfnparams, r_vector)
+    
+                if self.order == 2:
+                    #second derivative contribution w.r.t. p_k, p_l
+                    constant_terms -= np.einsum(
+                        "mkl,k,l->m", self.fanpt_container.d2_g_wfnparams2, self.previous_responses[0][:-1], self.previous_responses[0][:-1]
+                        
+                    )
+                    
+                elif self.order == 3:
+                    #second derivative contribution w.r.t. p_k, p_l
+                    constant_terms -= 3*np.einsum(
+                        "mkl,k,l->m", self.fanpt_container.d2_g_wfnparams2, self.previous_responses[1][:-1], self.previous_responses[0][:-1]
+                        
+                    )
+                    #third derivative contribution w.r.t. energy, p_k, p_l
+                    constant_terms -= 3*self.previous_responses[0][-1] * np.einsum(
+                        "mkl,k,l->m", self.fanpt_container.d3_g_e_wfnparams2, self.previous_responses[1][:-1], self.previous_responses[0][:-1]
+                        
+                    )
+                    #third derivative contribution w.r.t. lambda, p_k, p_l
+                    constant_terms -= 3*np.einsum(
+                        "mkl,k,l->m", self.fanpt_container.d3_g_lambda_wfnparams2, self.previous_responses[0][:-1], self.previous_responses[0][:-1]
+                        
+                    )
+                    
             else:
                 constant_terms = -self.order * np.dot(
                     self.fanpt_container.d2_g_lambda_wfnparams, self.previous_responses[-1]
                 )
+    
         self.constant_terms = constant_terms

--- a/fanpy/fanpt/containers/energy_param.py
+++ b/fanpy/fanpt/containers/energy_param.py
@@ -118,6 +118,7 @@ class FANPTContainerEParam(FANPTContainer):
         f_pot_ci_op=None,
         ovlp_s=None,
         d_ovlp_s=None,
+        dd_ovlp_s=None,
     ):
         r"""Initialize the FANPT container.
 
@@ -158,9 +159,12 @@ class FANPTContainerEParam(FANPTContainer):
             f_pot_ci_op,
             ovlp_s,
             d_ovlp_s,
+            dd_ovlp_s,
         )
         self.der2_g_e_wfnparams()
-
+        self.der2_g_wfnparams2()
+        self.der3_g_lambda_wfnparams2()
+        self.der3_g_e_wfnparams2()
     def der_g_lambda(self):
         r"""Derivative of the FANPT equations with respect to the lambda parameter.
 
@@ -199,6 +203,48 @@ class FANPTContainerEParam(FANPTContainer):
             self.f_pot_ci_op(d_ovlp_col, out=f_proj_col)
         self.d2_g_lambda_wfnparams = f
 
+    def der3_g_lambda_wfnparams2(self):
+        r"""Compute the third derivative of the FANPT equations with respect to two wavefunction 
+        parameters and the lambda perturbation parameter.
+    
+        This evaluates:
+        d^3G / dp_k dλ dp_l = sum_n <m|V|n> d^2 f_n / dp_k dp_l
+    
+        - For each projection equation m
+        - For each pair of active wavefunction parameters (k, l)
+        - Stores the result in a tensor: (# equations, # active params, # active params)
+    
+        Notes
+        -----
+        If `self.active_energy` is True, the last wfn parameter is omitted.
+        Only `self.nproj` projection equations are non-zero.
+        """
+        # Determine how many wavefunction parameters to use
+        if self.active_energy:
+            ncolumns = self.nactive - 1
+        else:
+            ncolumns = self.nactive
+    
+        # Allocate tensor: (nequation, ncolumns, ncolumns)
+        f = np.zeros((self.nequation, ncolumns, ncolumns), order="F")
+    
+        # Only the projected equations get contributions
+        f_proj = f[: self.nproj]
+    
+        # Loop over all (k, l) pairs
+        for k in range(ncolumns):
+            for l in range(ncolumns):
+                # Slice the second derivative overlap vector: shape (nproj,)
+                d2_ovlp_vector = self.dd_ovlp_s[:, k, l]
+    
+                # Apply perturbation operator: sum_n <m|V|n> * d2_ovlp
+                # This fills the result for all projected equations
+                self.f_pot_ci_op(d2_ovlp_vector, out=f_proj[:, k, l])
+    
+        # Store result
+        self.d3_g_lambda_wfnparams2 = f
+
+
     def der2_g_e_wfnparams(self):
         r"""Derivative of the FANPT equations with respect to the energy and the wavefunction
         parameters.
@@ -220,6 +266,30 @@ class FANPTContainerEParam(FANPTContainer):
         else:
             self.d2_g_e_wfnparams = None
 
+    def der3_g_e_wfnparams2(self):
+        r"""Compute the third derivative of the FANPT equations with respect to two
+        wavefunction parameters and the energy.
+    
+        Computes:
+        d^3G / dp_k dp_l dE = -d^2 f / dp_k dp_l
+    
+        Only computed if `self.active_energy` is True.
+    
+        Generates
+        ---------
+        d3_g_wfnparams2_e : np.ndarray
+            Third derivative tensor with shape:
+            (# equations, # active params, # active params)
+        """
+        if self.active_energy:
+            ncolumns = self.nactive - 1
+            f = np.zeros((self.nequation, ncolumns, ncolumns), order="F")
+            f[: self.nproj] = -self.dd_ovlp_s[: self.nproj]
+            self.d3_g_e_wfnparams2 = f
+        else:
+            self.d3_g_e_wfnparams2 = None
+
+
     def gen_coeff_matrix(self):
         r"""Generate the coefficient matrix of the linear FANPT system of equations.
 
@@ -236,3 +306,38 @@ class FANPTContainerEParam(FANPTContainer):
             numpy array with shape (self.nequations, len(self.nactive)).
         """
         self.c_matrix = self.fanci_objective.compute_jacobian(self.params)
+
+    def der2_g_wfnparams2(self):
+        r"""
+        Compute the second derivative of the FANCI projection equations with respect to 
+        two wavefunction parameters.
+    
+        Specifically, this evaluates the tensor:
+            d²Gₘ / dp_k dp_l = ⟨m|H|∂²ψ/∂p_k ∂p_l⟩ - E ⋅ ∂²fₘ / ∂p_k ∂p_l
+    
+        The result is a rank-3 tensor where each entry corresponds to the second 
+        derivative of the m-th projection equation with respect to the k-th and l-th 
+        active wavefunction parameters, accounting for energy-dependent correction.
+    
+        Returns
+        -------
+        d2_g_wfnparams_wfnparams : np.ndarray
+            A tensor of shape (nequation, ncolumns, ncolumns), where
+            ncolumns = nactive - 1 if active_energy is True, else nactive.
+            Contains the second derivatives of the projection equations.
+        """
+        if self.active_energy:
+            ncolumns= self.nactive - 1
+            f = np.zeros((self.nequation, ncolumns, ncolumns), order = "F")
+            f_proj = f[:self.nproj]
+            energy=self.params[-1]
+            
+
+        for i in range(ncolumns):
+            for j in range(ncolumns):
+                self.ham_ci_op(self.dd_ovlp_s[:,i,j], out= f_proj[:,i,j])
+                dd_ovlp_proj= self.dd_ovlp_s[:, i, j][:self.nproj]
+                dd_ovlp_proj *= energy
+                f_proj[:,i,j] -= dd_ovlp_proj
+        self.d2_g_wfnparams2 = f
+


### PR DESCRIPTION
feat: implement 2nd and 3rd derivatives in energy_param.py for FANPT
- Added der3_g_lambda_wfnparams for ∂³G / ∂p_k ∂λ ∂p_l using V·(∂²f/∂p_k∂p_l)
- Added der3_g_wfnparams2_e for ∂³G / ∂p_k ∂p_l ∂E as -∂²f/∂p_k∂p_l
- Added der2_g_wfnparams_wfnparams

-added the additional constant terms for order 2 and 3 for higher order FANPT in constant_terms.py