### PR TITLE
fix: ci tests fail on forks with different name

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -2,7 +2,7 @@ name: Test Fanpy
 
 on:
   push:
-    branches: [main]
+    branches: [92-bug-ci-tests-fail-on-forks-with-different-name]
   pull_request:
     branches: [main]
 
@@ -37,7 +37,7 @@ jobs:
           git clone https://github.com/theochem/pyci.git && cd pyci
           make
           python -m pip install .
-          cd ../Fanpy
+          cd -
       - name: Run tests with pytest
         run: |
           pip install pytest pytest-cov

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -2,7 +2,7 @@ name: Test Fanpy
 
 on:
   push:
-    branches: [92-bug-ci-tests-fail-on-forks-with-different-name]
+    branches: [main]
   pull_request:
     branches: [main]
 

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -2,7 +2,7 @@ name: Test Fanpy
 
 on:
   push:
-    branches: [main]
+    branches: [92-bug-ci-tests-fail-on-forks-with-different-name]
   pull_request:
     branches: [main]
 
@@ -30,6 +30,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install -e ".[test, pyscf, tensorflow]"
+          fanpy_dir=$(pwd)
       - name : Install PyCI
         run: |
           pwd 
@@ -37,7 +38,8 @@ jobs:
           git clone https://github.com/theochem/pyci.git && cd pyci
           make
           python -m pip install .
-          cd -
+          cd $fanpy_dir
+          pwd
       - name: Run tests with pytest
         run: |
           pip install pytest pytest-cov

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -30,15 +30,15 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install -e ".[test, pyscf, tensorflow]"
-          fanpy_dir=$(pwd)
       - name : Install PyCI
         run: |
           pwd 
-          cd ..
+          mkdir dependencies
+          cd dependencies
           git clone https://github.com/theochem/pyci.git && cd pyci
           make
           python -m pip install .
-          cd $fanpy_dir
+          cd ../../
           pwd
       - name: Run tests with pytest
         run: |


### PR DESCRIPTION
## Problem
This PR fixes the issue @rugwed-lokhande discovered. Previously, the test workflow would fail if the forks name is not `Fanpy`. This was because we were cloning `PyCI` in the same folder as the `Fanpy` code. We would go back to the `Fanpy` directory with `cd ../Fanpy`. 

## Fix
The workflow no creates a directory called `dependencies` inside `Fanpy`. We clone and install `PyCI` in that folder. Thus, we only need to execute`cd ../../` to get back to the folder of FanPY. Below is the folder structure for the test automation: 

```bash
Fanpy_fork_name
├── dependencies
│   └── pyci
├── fanpy
├── tests
└── tools
    
```

We can use the `dependencies` folder if we need to install further packages manually (i.e. `git clone`). 