### PR TITLE
maint: add type property to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,6 +1,7 @@
 name: Bug report
 description: "Report a bug."
 labels: "bug"
+type: "Bug"
 title: "BUG: "
 
 body:

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,6 +1,7 @@
 name: Feature Request
 description: "Suggest a feature."
 labels: "enhancement"
+type: "Feature"
 title: "ENH: "
 
 body:


### PR DESCRIPTION
The bug and feature request template did not choose a `type` for the GitHub issue. The picture below shows the bug template with the empty type property. The issue submitter or the maintainers would have to assign this property manually. 
<img width="1391" height="458" alt="Screenshot 2025-08-08 at 13 53 43" src="https://github.com/user-attachments/assets/c13b49a4-4483-4397-9011-626aca79a1cc" />

This PR assigns the respective types for bugs and feature requests. 

Note: As far as I am aware, there is no way of testing how this works, until it is merged into the `main` branch. The `type` property is only available for organizations. Therefore, I cannot test these templates it in one of my own repositories.