### PR TITLE
fix: unfreeze energy before FanCI steps

### DIFF
--- a/fanpy/fanpt/fanpt.py
+++ b/fanpy/fanpt/fanpt.py
@@ -255,10 +255,17 @@ class FANPT:
         print(f"Solving FanPT problem using the ideal Hamiltonian")
         self.fanci_interface.update_objective(self.ham0)
         fanci_objective = self.fanci_interface.objective
+        if not self.energy_active:
+            # unfreeze the energy parameter if it is not active
+            fanci_objective.unfreeze_parameter(-1)
 
         # Get initial guess for parameters at initial lambda value.
         results = fanci_objective.optimize(guess_params, **solver_kwargs)
         guess_params[fanci_objective.mask] = results.x
+
+         # Rebuild active parameters mask according to energy_active
+        if not self.energy_active:
+            fanci_objective.freeze_parameter(-1)
 
         # Solve FANPT equations
         for l in np.linspace(lambda_i, lambda_f, steps, endpoint=False):
@@ -295,6 +302,9 @@ class FANPT:
             # Initialize perturbed Hamiltonian with the current value of lambda using the static method of fanpt_container.
             self.fanci_interface.update_objective(fanpt_updater.new_ham)
             fanci_objective = self.fanci_interface.objective
+            if not self.energy_active:
+                # unfreeze the energy parameter if it is not active
+                fanci_objective.unfreeze_parameter(-1)
 
             # Solve the fanci problem with fanpt_params as initial guess.
             # Take the params given by fanci and use them as initial params in the FANPT calculation for the next lambda.


### PR DESCRIPTION
This pull request addresses the discrepancy @rugwed-lokhande and I discovered between the "old" and "new" energy free FanPT results. 

Currently, the energy is frozen both for the FanPT step and the FanCI step. However, it should only be frozen for the FanPT step. Therefore, I introduced freezing/unfreezing logic before each FanCI step that only affects energy free FanPT. Whenever the optimizer reaches a FanCI step, it checks whether the energy is supposed to be an active parameter. If it is not, it will unfreeze the energy for the FanCI calculation and freeze it afterwards. Thus, this change does not affect the eparam FanPT optimization. 

Note: we were manually freezing the energy at the end of every for loop. Thus, I only had add a "refreeze" step for the initial FanCI step before the for loop. 