### PR TITLE
refactor(hci): split `assign_sds` into `assign_e_s_pairs` + `assign_sds` for clarity and tests

### DIFF
--- a/fanpy/wfn/ci/hci.py
+++ b/fanpy/wfn/ci/hci.py
@@ -126,6 +126,8 @@ class hCI(CIWavefunction):
         Compute and store the admissible hierarchy indices implied by the current
         version, pattern, and settings.
 
+    assign_e_s_pairs()
+        Generates list of allowed (e,s) pairs for a given pattern and hierarchy
     """
 
     def __init__(

--- a/fanpy/wfn/ci/hci.py
+++ b/fanpy/wfn/ci/hci.py
@@ -375,13 +375,19 @@ class hCI(CIWavefunction):
             self.refwfn = refwfn
 
 
-    def assign_e_s_pairs(self):
-        """Return the list of allowed (e, s) pairs implied by the current settings.
-    
+    def calculate_e_s_pairs(self):
+        """    
         Uses self.pos_hierarchies, self.alpha1, self.alpha2, and self.nelec to
         derive valid excitation/seniority combinations following the hierarchy
         relation:  h = alpha1 * e + alpha2 * s.
-    
+
+        Returns
+        -------
+        list[list[int]]
+            A list of [e, s] pairs, where each pair represents a valid combination
+            of excitation order (e) and seniority (s) satisfying the hierarchy
+            relation for the given system.
+        
         Notes
         -----
         Assumes the system is referenced to a maximum-pairing configuration
@@ -439,7 +445,7 @@ class hCI(CIWavefunction):
             )
     
         # ---------- allowed (e, s) pairs ----------
-        e_s_pairs = self.assign_e_s_pairs()
+        e_s_pairs = self.calculate_e_s_pairs()
     
         # ---------- determinants from (e, s) ----------
         ground_state = slater.ground(self.nelec, self.nspin)
@@ -470,6 +476,4 @@ class hCI(CIWavefunction):
             f"alpha1={self.alpha1:.3g}, alpha2={self.alpha2:.3g} | total determinants={len(allowed_sds)}"
         )
         super().assign_sds(allowed_sds)
-    
-
 

--- a/fanpy/wfn/ci/hci.py
+++ b/fanpy/wfn/ci/hci.py
@@ -418,7 +418,17 @@ class hCI(CIWavefunction):
     
         Ignores user input and uses the Slater determinants implied by the current
         hierarchy/pattern (within the given spin constraints).
+        Parameters
+        ----------
+        sds : iterable of int
+            List of Slater determinants (in the form of integers that describe the occupation as a
+            bitstring)
+        Raises
+        ------
+        ValueError
+            If the sds is not `None` (default value).
         """
+        
         if __debug__ and sds is not None:
             raise ValueError(
                 "Only the default list of Slater determinants is allowed. i.e. sds "


### PR DESCRIPTION
- Extract computation of allowed (e, s) pairs into `assign_e_s_pairs()`.
- Keep `assign_sds()` focused on enumerating Slater determinants from those pairs.
- No numerical/behavioral changes; only decomposition for readability and unit testability.
- `__init__` flow unchanged; `assign_sds()` now calls `assign_e_s_pairs()` internally.