### PR TITLE
131 managing original rbm version

### DIFF
--- a/fanpy/wfn/network/rbm.py
+++ b/fanpy/wfn/network/rbm.py
@@ -267,7 +267,7 @@ class RestrictedBoltzmannMachine(BaseWavefunction):
         return self._olp_deriv(sd)[deriv]
 
     def _olp(self, sd):
-	"""Evaluate the overlap of the wavefunction with a single Slater determinant.
+        """Evaluate the overlap of the wavefunction with a single Slater determinant.
 
         This function wraps `_olp_helper` by taking the product across all 
         hidden-unit activations and applying the global scaling factor. The 


### PR DESCRIPTION
**Summary:**
This PR replaces the current version of the Restricted Boltzmann Machine (RBM) with the original implementation written by David. This update is made to ensure compatibility with the test cases located in:

- `tests/test_wfn_composite_embedding.py`
- `tests/test_wfn_composite_embedding_fixedelectron.py`

**Details:**
- The original RBM version, written by David in a feed-forward neural Network fashion, has been restored to resolve any inconsistencies with the existing test cases.
- Added documentation to functions in the original RBM file.
- No modifications have been made to the tests in this commit.

**Next Steps:**
- The latest developments and improvements to the RBM wavefunction will be integrated into the rbm_dev branch after thorough testing is completed.