### PR TITLE
Test: add tests for the energy constraint

### DIFF
--- a/fanpy/eqn/constraints/energy.py
+++ b/fanpy/eqn/constraints/energy.py
@@ -7,12 +7,8 @@ class EnergyConstraint(EnergyOneSideProjection):
     """Energy constraint.
     This class implements an energy constraint based on a reference energy.
     The objective function is the difference between the calculated energy and the reference energy.
-    If the calculated energy is lower than the reference energy, the reference energy is adjusted downwards
-    to be closer to the calculated energy.
-    If the calculated energy is higher than the reference energy, the objective function is simply the energy
-    difference.
-    If the energy difference does not change significantly over a number of calls, the reference energy is
-    adjusted downwards to be closer to the calculated energy.
+    The prupose of this "constraint" is to keep a downward pressure on the energy, and avoid getting stuck in local minima.
+    
 
     Attributes
     ----------
@@ -89,6 +85,10 @@ class EnergyConstraint(EnergyOneSideProjection):
 
     def objective(self, params):
         """Calculate the difference between calculated energy and reference energy. The reference energy is adjusted if needed.
+        The reference energy is adjusted if:
+
+        1. The calculated energy is lower than the reference energy.
+        2. The energy difference does not change significantly over a number of calls.
 
         Parameters
         ----------
@@ -98,7 +98,7 @@ class EnergyConstraint(EnergyOneSideProjection):
         Returns
         -------
         float
-            Objective function value.
+            Difference between calculated energy and reference energy.
         """
 
         if self.energy_variable:

--- a/fanpy/eqn/constraints/energy.py
+++ b/fanpy/eqn/constraints/energy.py
@@ -80,7 +80,6 @@ class EnergyConstraint(EnergyOneSideProjection):
         self.queue_size = queue_size
         self.base = base
         self.min_diff = min_diff
-        self.energy_variable = None
         self.simple = simple
 
     def objective(self, params):
@@ -101,10 +100,7 @@ class EnergyConstraint(EnergyOneSideProjection):
             Difference between calculated energy and reference energy.
         """
 
-        if self.energy_variable:
-            energy = self.energy_variable.params[0]
-        else:
-            energy = super().objective(params)
+        energy = super().objective(params)
         energy_diff = energy - self.ref_energy
         if self.simple:
             return energy_diff

--- a/fanpy/eqn/constraints/energy.py
+++ b/fanpy/eqn/constraints/energy.py
@@ -105,15 +105,15 @@ class EnergyConstraint(EnergyOneSideProjection):
         if self.simple:
             return energy_diff
 
+        self.energy_diff_history.append(energy_diff)
+        if len(self.energy_diff_history) > self.queue_size:
+            self.energy_diff_history.popleft()
+
         # if calculated energy is lower than the reference, bring down reference energy
         if energy_diff <= 0:
             print("Energy lower than reference. Adjusting reference energy: {}" "".format(self.ref_energy))
             self.ref_energy += self.base * energy_diff
             return energy_diff
-
-        self.energy_diff_history.append(energy_diff)
-        if len(self.energy_diff_history) > self.queue_size:
-            self.energy_diff_history.popleft()
 
         if len(self.energy_diff_history) != self.queue_size or any(i <= 0 for i in self.energy_diff_history):
             return energy_diff

--- a/fanpy/eqn/constraints/energy.py
+++ b/fanpy/eqn/constraints/energy.py
@@ -142,7 +142,4 @@ class EnergyConstraint(EnergyOneSideProjection):
             )
             self.energy_diff_history = deque([])
 
-        # if all(abs(energy - i) < 1e-3 for i in self.energy_history):
-        #     self.ref_energy = energy - 1e-3
-
         return energy_diff

--- a/tests/test_eqn_constraint_energy.py
+++ b/tests/test_eqn_constraint_energy.py
@@ -1,0 +1,48 @@
+from fanpy.eqn.constraints.energy import EnergyConstraint
+from fanpy.wfn.base import BaseWavefunction
+from fanpy.ham.base import BaseHamiltonian
+import numpy as np
+
+
+class DummyWavefunction(BaseWavefunction):
+    """A dummy wavefunction for testing purposes."""
+
+    def __init__(self, nspin, nelec):
+        super().__init__(nspin, nelec)
+        self.params = np.array([0.0])
+
+    def assign_params(self, params):
+        self.params = params
+
+    def get_overlap(self, sd, deriv=False):
+        return 1.0 if not deriv else (1.0, np.array([0.0]))
+
+class DummyHamiltonian(BaseHamiltonian):
+    """A dummy Hamiltonian for testing purposes."""
+
+    def __init__(self, nspin):
+        self._nspin = nspin
+    
+    @property
+    def nspin(self):
+        """Return the number of spin orbitals.
+
+        Returns
+        -------
+        nspin : int
+            Number of spin orbitals.
+
+        """
+        return self._nspin
+    def integrate_sd_wfn(self, sd, wfn, deriv=False):
+        return -0.5 if not deriv else (-0.5, np.array([0.0]))
+    
+
+def test_energy_constraint_simple():
+    wfn = DummyWavefunction(4, 8)
+    ham = DummyHamiltonian(8)
+    const = EnergyConstraint(wfn, ham, ref_energy=-1.0, simple=True)
+    assert const.objective(wfn.params) == 0.5 # difference is 0.5 (-0.5 - -1.0)
+    const.ref_energy = 0.0
+    assert const.objective(wfn.params) == -0.5 
+    assert const.ref_energy == 0.0 # ref energy should not change in simple mode

--- a/tests/test_eqn_constraint_energy.py
+++ b/tests/test_eqn_constraint_energy.py
@@ -7,8 +7,8 @@ import numpy as np
 class DummyWavefunction(BaseWavefunction):
     """A dummy wavefunction for testing purposes."""
 
-    def __init__(self, nspin, nelec):
-        super().__init__(nspin, nelec)
+    def __init__(self, nelec, nspin):
+        super().__init__(nelec, nspin)
         self.params = np.array([0.0])
 
     def assign_params(self, params):
@@ -43,7 +43,8 @@ def test_energy_constraint_simple():
     wfn = DummyWavefunction(4, 8)
     ham = DummyHamiltonian(8)
     const = EnergyConstraint(wfn, ham, ref_energy=-1.0, simple=True)
-    assert const.objective(wfn.params) == 0.5 # difference is 0.5 (-0.5 - -1.0)
+    # E_calc = -0.5, E_ref = -1.0, so difference is 0.5 = (-0.5 - -1.0)
+    assert const.objective(wfn.params) == 0.5
     const.ref_energy = 0.0
     assert const.objective(wfn.params) == -0.5 
     assert const.ref_energy == 0.0 # ref energy should not change in simple mode
@@ -57,7 +58,7 @@ def test_energy_constraint_dynamic():
     ham = DummyHamiltonian(8)
     # change ref E if diff < 0
     const = EnergyConstraint(wfn, ham, ref_energy=0.0, base=10, simple=False)
-    assert np.allclose(const.objective(wfn.params), -0.5) 
+    assert np.allclose(const.objective(wfn.params), -0.5) # check Ediff
     assert np.allclose(const.ref_energy, -5.0) # E_ref,n+1 = E_ref,n + base * diff 
     assert len(const.energy_diff_history) == 1 # check if ediff history is updated
 
@@ -66,6 +67,6 @@ def test_energy_constraint_dynamic():
     for _ in range(4):
         const.objective(wfn.params)
     assert -1.0 != const.ref_energy # ref energy should change
-    assert np.allclose(const.ref_energy, -0.55) # change in ref e is Energy - 10**(ediff order -1)
+    assert np.allclose(const.ref_energy, -0.55) # E_ref,n+1 = E - diff / base
     # check if ediff history is reset
     assert len(const.energy_diff_history) == 0

--- a/tests/test_eqn_constraint_energy.py
+++ b/tests/test_eqn_constraint_energy.py
@@ -39,6 +39,7 @@ class DummyHamiltonian(BaseHamiltonian):
     
 
 def test_energy_constraint_simple():
+    """Test the energy constraint in simple mode. The reference energy does not change."""
     wfn = DummyWavefunction(4, 8)
     ham = DummyHamiltonian(8)
     const = EnergyConstraint(wfn, ham, ref_energy=-1.0, simple=True)
@@ -46,3 +47,25 @@ def test_energy_constraint_simple():
     const.ref_energy = 0.0
     assert const.objective(wfn.params) == -0.5 
     assert const.ref_energy == 0.0 # ref energy should not change in simple mode
+
+def test_energy_constraint_dynamic():
+    """Test the energy constraint in dynamic mode. The reference energy changes 
+    if the calculated energy is lower than the reference or if the energy 
+    difference does not change significantly.    
+    """
+    wfn = DummyWavefunction(4, 8)
+    ham = DummyHamiltonian(8)
+    # change ref E if diff < 0
+    const = EnergyConstraint(wfn, ham, ref_energy=0.0, base=10, simple=False)
+    assert np.allclose(const.objective(wfn.params), -0.5) 
+    assert np.allclose(const.ref_energy, -5.0) # E_ref,n+1 = E_ref,n + base * diff 
+    assert len(const.energy_diff_history) == 1 # check if ediff history is updated
+
+    # change ref E if diff does not change significantly
+    const = EnergyConstraint(wfn, ham, ref_energy=-1.0, base=10, simple=False)
+    for _ in range(4):
+        const.objective(wfn.params)
+    assert -1.0 != const.ref_energy # ref energy should change
+    assert np.allclose(const.ref_energy, -0.55) # change in ref e is Energy - 10**(ediff order -1)
+    # check if ediff history is reset
+    assert len(const.energy_diff_history) == 0


### PR DESCRIPTION
This pull request adds tests for the energy constraint that is inside of the equations submodule. 

## Changes to Energy constraint
* added docstrings to the class 
* removed the variable energy option. This was not something that the user could provide in every optimization step. 
* the history of energy differences is being updated before any energy difference is returned. Previously, this was after the case for the negative energy difference. Thus, negative values would never be added to the history, even though the code afterward would expect to handle negative energy differences: 
```python
if len(self.energy_diff_history) != self.queue_size or any(i <= 0 for i in self.energy_diff_history):
``` 

## Tests for E constraint
* check if the energy diff is calculated properly for simple and non-simple options
* updates to reference energy are happening as expected 
* note: that the energy constraint has 0 checks. It is relying on other parts of the code to check input. 
