### PR TITLE
fix: overdetermined root without constraints

### DIFF
--- a/fanpy/solver/system.py
+++ b/fanpy/solver/system.py
@@ -135,12 +135,15 @@ def root(objective, **kwargs):
         print("Too many equations for root solver. Excess equations will be truncated.")
         num_constraints = len(objective.constraints)
         objective.pspace = objective.pspace[: objective.active_params.size - num_constraints]
-        objective.eqn_weights = np.hstack(
-            [
-                objective.eqn_weights[: objective.active_params.size - num_constraints],
-                objective.eqn_weights[-num_constraints:],
-            ]
-        )
+        if num_constraints == 0:
+            objective.eqn_weights = objective.eqn_weights[: objective.active_params.size]
+        else:
+            objective.eqn_weights = np.hstack(
+                [
+                    objective.eqn_weights[: objective.active_params.size - num_constraints],
+                    objective.eqn_weights[-num_constraints:],
+                ]
+            )
 
     kwargs.setdefault("method", "hybr")
     kwargs.setdefault("options", {})


### PR DESCRIPTION
This pull request introduces a small fix to the logic for setting equation weights in the `root` function of `fanpy/solver/system.py`. The change ensures that when there are zero constraints, `objective.eqn_weights` is sliced correctly to match the size of `objective.active_params`.