### PR TITLE
fix: handle pspace generated with DOCI wfn in pyci

### DIFF
--- a/fanpy/interface/fanci/legacy.py
+++ b/fanpy/interface/fanci/legacy.py
@@ -1092,7 +1092,7 @@ class ProjectedSchrodingerFanCI(ProjectedSchrodingerLegacyFanCI):
         # FIXME: converting occs_array to slater determinants to be converted back to indices is a waste
         # convert slater determinants
         sds = []
-        if isinstance(occs_array[0, 0], np.ndarray):
+        if isinstance(occs_array[0, 0], np.ndarray): # pspace generated with FCI
             for i, occs in enumerate(occs_array):
                 # FIXME: CHECK IF occs IS BOOLEAN OR INTEGERS
                 # convert occupation vector to sd
@@ -1101,11 +1101,12 @@ class ProjectedSchrodingerFanCI(ProjectedSchrodingerLegacyFanCI):
                 sd = slater.create(0, *occs[0])
                 sd = slater.create(sd, *(occs[1] + self.fanpy_wfn.nspatial))
                 sds.append(sd)
-        else:
+        else: # pspace generated with DOCI
             for i, occs in enumerate(occs_array):
                 if occs.dtype == bool:
                     occs = np.where(occs)
                 sd = slater.create(0, *occs)
+                sd = slater.create(sd, *(occs + self.fanpy_wfn.nspatial))
                 sds.append(sd)
 
         # Feed in parameters into fanpy wavefunction
@@ -1161,7 +1162,7 @@ class ProjectedSchrodingerFanCI(ProjectedSchrodingerLegacyFanCI):
         # a waste
         # convert slater determinants
         sds = []
-        if isinstance(occs_array[0, 0], np.ndarray):
+        if isinstance(occs_array[0, 0], np.ndarray): # pspace generated with FCI
             for i, occs in enumerate(occs_array):
                 # FIXME: CHECK IF occs IS BOOLEAN OR INTEGERS
                 # convert occupation vector to sd
@@ -1170,11 +1171,12 @@ class ProjectedSchrodingerFanCI(ProjectedSchrodingerLegacyFanCI):
                 sd = slater.create(0, *occs[0])
                 sd = slater.create(sd, *(occs[1] + self.fanpy_wfn.nspatial))
                 sds.append(sd)
-        else:
+        else: # pspace generated with DOCI
             for i, occs in enumerate(occs_array):
                 if occs.dtype == bool:
                     occs = np.where(occs)
                 sd = slater.create(0, *occs)
+                sd = slater.create(sd, *(occs + self.fanpy_wfn.nspatial))
                 sds.append(sd)
 
         # Select sds according to selected chunks

--- a/fanpy/interface/fanci/pyci.py
+++ b/fanpy/interface/fanci/pyci.py
@@ -302,7 +302,7 @@ class ProjectedSchrodingerPyCI(FanCI):
         # a waste
         # convert slater determinants
         sds = []
-        if isinstance(occs_array[0, 0], np.ndarray):
+        if isinstance(occs_array[0, 0], np.ndarray): # if pspace generated with FCI
             for i, occs in enumerate(occs_array):
                 # FIXME: CHECK IF occs IS BOOLEAN OR INTEGERS
                 # convert occupation vector to sd
@@ -311,11 +311,12 @@ class ProjectedSchrodingerPyCI(FanCI):
                 sd = slater.create(0, *occs[0])
                 sd = slater.create(sd, *(occs[1] + self.fanpy_wfn.nspatial))
                 sds.append(sd)
-        else:
+        else: # if pspace generated with DOCI
             for i, occs in enumerate(occs_array):
                 if occs.dtype == bool:
                     occs = np.where(occs)
                 sd = slater.create(0, *occs)
+                sd = slater.create(sd, *(occs + self.fanpy_wfn.nspatial))
                 sds.append(sd)
 
         # Feed in parameters into fanpy wavefunction
@@ -371,7 +372,7 @@ class ProjectedSchrodingerPyCI(FanCI):
         # a waste
         # convert slater determinants
         sds = []
-        if isinstance(occs_array[0, 0], np.ndarray):
+        if isinstance(occs_array[0, 0], np.ndarray): # if pspace generated with FCI
             for i, occs in enumerate(occs_array):
                 # FIXME: CHECK IF occs IS BOOLEAN OR INTEGERS
                 # convert occupation vector to sd
@@ -380,11 +381,12 @@ class ProjectedSchrodingerPyCI(FanCI):
                 sd = slater.create(0, *occs[0])
                 sd = slater.create(sd, *(occs[1] + self.fanpy_wfn.nspatial))
                 sds.append(sd)
-        else:
+        else: # if pspace generated with DOCI
             for i, occs in enumerate(occs_array):
                 if occs.dtype == bool:
                     occs = np.where(occs)
                 sd = slater.create(0, *occs)
+                sd = slater.create(sd, *(occs + self.fanpy_wfn.nspatial))
                 sds.append(sd)
 
         # Select sds according to selected chunks


### PR DESCRIPTION
This pull request fixes the handling of Slater determinant construction in both `legacy.py` and `pyci.py` interfaces, specifically for cases where the pspace is generated with DOCI. The changes ensure that occupation vectors are consistently mapped to the correct spin orbitals. Additionally, comments have been added for clarity.