### PR TITLE
Fix: chunking in the new interface

### DIFF
--- a/fanpy/interface/fanci/legacy.py
+++ b/fanpy/interface/fanci/legacy.py
@@ -1660,16 +1660,16 @@ class ProjectedSchrodingerFanCI(ProjectedSchrodingerLegacyFanCI):
             isamp += 1
 
     def calculate_overlap_deriv_chunks(self):
-
-        tensor_mem = self.nactive * 8 / 1e6
+        size_sspace = self._sspace.shape[0]
+        tensor_mem = size_sspace * 8 / 1e6
         avail_mem = (self.max_memory - current_memory()) * 0.9
 
         chunk_size = max(1, math.floor(avail_mem / tensor_mem))
-        chunk_size = min(chunk_size, self.nactive)
+        chunk_size = min(chunk_size, size_sspace)
 
         chunks_list = []
-        for s_chunk in range(0, self.nactive, chunk_size):
-            f_chunk = min(self.nactive, s_chunk + chunk_size)
+        for s_chunk in range(0, size_sspace, chunk_size):
+            f_chunk = min(size_sspace, s_chunk + chunk_size)
             chunks_list.append([s_chunk, f_chunk])
 
         return chunks_list

--- a/fanpy/interface/fanci/pyci.py
+++ b/fanpy/interface/fanci/pyci.py
@@ -1013,15 +1013,16 @@ class ProjectedSchrodingerPyCI(FanCI):
 
     def calculate_overlap_deriv_chunks(self):
 
-        tensor_mem = self.nactive * 8 / 1e6
+        size_sspace = self._sspace.shape[0]
+        tensor_mem = size_sspace * 8 / 1e6
         avail_mem = (self.max_memory - current_memory()) * 0.9
 
         chunk_size = max(1, math.floor(avail_mem / tensor_mem))
-        chunk_size = min(chunk_size, self.nactive)
+        chunk_size = min(chunk_size, size_sspace)
 
         chunks_list = []
-        for s_chunk in range(0, self.nactive, chunk_size):
-            f_chunk = min(self.nactive, s_chunk + chunk_size)
+        for s_chunk in range(0, size_sspace, chunk_size):
+            f_chunk = min(size_sspace, s_chunk + chunk_size)
             chunks_list.append([s_chunk, f_chunk])
 
         return chunks_list

--- a/fanpy/wfn/utils.py
+++ b/fanpy/wfn/utils.py
@@ -957,16 +957,17 @@ def convert_to_fanci(
                 isamp += 1
 
         def calculate_overlap_deriv_chunks(self):
-
-            tensor_mem = self._nactive * 8 / 1e6
+            size_sspace = self._sspace.shape[0]
+            tensor_mem = size_sspace * 8 / 1e6
             avail_mem = (self.max_memory - current_memory()) * 0.9
 
             chunk_size = max(1, math.floor(avail_mem / tensor_mem))
-            chunk_size = min(chunk_size, self._nactive)
+            
+            chunk_size = min(chunk_size, size_sspace)
 
             chunks_list = []
-            for s_chunk in range(0, self._nactive, chunk_size):
-                f_chunk = min(self._nactive, s_chunk + chunk_size)
+            for s_chunk in range(0, size_sspace, chunk_size):
+                f_chunk = min(size_sspace, s_chunk + chunk_size)
                 chunks_list.append([s_chunk, f_chunk])
 
             return chunks_list

--- a/tests/test_interface_pyci.py
+++ b/tests/test_interface_pyci.py
@@ -1,0 +1,52 @@
+import pytest
+import numpy as np
+
+from fanpy.interface.pyci import PYCI
+from fanpy.eqn.projected import ProjectedSchrodinger
+from fanpy.ham.restricted_chemical import RestrictedMolecularHamiltonian
+from fanpy.wfn.cc.standard_cc import StandardCC
+from fanpy.tools.sd_list import sd_list
+from fanpy.tools.performance import current_memory
+
+
+@pytest.mark.parametrize("legacy_fanci", [True, False])
+def test_norm_constraint_chunking(legacy_fanci):
+    """Test norm constraint chunking in PYCI interface. We do this by comparing the jacobian of the norm constraint with and without chunking.
+    """
+
+    # todo: technically this test relies only on the classes in fanpy.interface.fanci. We do not necessarily need to use PYCI here.
+    # However, utilizing PYCI gets rid of some of the setup code that would otherwise be necessary. Once we have unit testing for the interface,
+    # we can move this test to that location.
+
+    # set up fanpy wfn, ham, and objective
+    test_wfn = StandardCC(4, 8)
+    one_int = np.random.rand(4, 4)
+    two_int = np.random.rand(4, 4, 4, 4)
+    test_ham = RestrictedMolecularHamiltonian(
+        one_int, two_int
+    )
+    pspace = sd_list(4, 8, num_limit=None, exc_orders=[1, 2, 3, 4], spin=0)
+    fanpy_objective = ProjectedSchrodinger(test_wfn, test_ham, energy_type="compute", pspace = pspace)
+
+    # compute jacobian without chunking
+    pyci_no_chunk = PYCI(fanpy_objective, 0.0, legacy_fanci=legacy_fanci)
+    chunks = pyci_no_chunk.objective.calculate_overlap_deriv_chunks()
+    if len(chunks) > 1: # chunks depend on memory available, so this check ensures that no chunking is happening
+        raise RuntimeError("Test is invalid because chunking is occurring for the 'no chunking reference'.")
+    jac_constraint = pyci_no_chunk.objective.make_norm_constraint()[1] # index 1 corresponds to jacobian, while 0 is constraint value
+    x = np.random.rand(len(test_wfn.params) + 1)
+    jac_constraint = jac_constraint(x)
+
+    # compute jacobian with chunking
+    max_mem = 4.5 * len(pspace) * 8 / (0.9 * 10**6) + current_memory() # creates chunks of length 4 (this equation depends on calculate_overlap_deriv_chunks)
+    pyci_chunk = PYCI(fanpy_objective, 0.0, legacy_fanci=legacy_fanci, max_memory=max_mem)
+    chunks = pyci_chunk.objective.calculate_overlap_deriv_chunks()
+    # Note: since we determine max memory based on the equations in calculate_overlap_deriv_chunks, this should not be an issue.
+    # This check ensures that chunks are generated as expected, even if there are changes to that method in the future.
+    if len(chunks) < 2: 
+        raise RuntimeError("Test is invalid because no chunking is occurring.")
+    jac_constraint_chunk = pyci_chunk.objective.make_norm_constraint()[1] # index 1 corresponds to jacobian, while 0 is constraint value
+    jac_constraint_chunk = jac_constraint_chunk(x)
+
+    # compare jacobians
+    assert np.allclose(jac_constraint, jac_constraint_chunk)


### PR DESCRIPTION
This pull request fixes the calculation of chunk sizes for overlap derivative computations in the impacted modules and adds a new test to verify correct chunking behavior. The main focus is to ensure that chunking is based on the actual size of the s-space rather than the number of parameters.

**Refactor chunk calculation logic:**

* Updated `calculate_overlap_deriv_chunks` in `fanpy/interface/fanci/legacy.py`, `fanpy/interface/fanci/pyci.py`, and `fanpy/wfn/utils.py` to use the size of the  s-space (`self._sspace.shape[0]`) instead of the number of active parameters for memory and chunk size calculations, ensuring more accurate and consistent chunking. 

**Testing improvements:**

* Added a new test `test_norm_constraint_chunking` in `tests/test_interface_pyci.py` to verify that the norm constraint Jacobian is computed correctly with and without chunking, ensuring the refactored chunking logic produces consistent results.