### PR TITLE
Test: Add guard rails for interface refactor

### DIFF
--- a/tests/test_interface_pyci.py
+++ b/tests/test_interface_pyci.py
@@ -2,6 +2,7 @@ import pytest
 import numpy as np
 
 from fanpy.interface.pyci import PYCI
+from fanpy.wfn.base import BaseWavefunction
 from fanpy.eqn.projected import ProjectedSchrodinger
 from fanpy.ham.restricted_chemical import RestrictedMolecularHamiltonian
 from fanpy.wfn.cc.standard_cc import StandardCC
@@ -50,3 +51,140 @@ def test_norm_constraint_chunking(legacy_fanci):
 
     # compare jacobians
     assert np.allclose(jac_constraint, jac_constraint_chunk)
+
+class FakeWavefunction(BaseWavefunction):
+    """ A fake wavefunction for testing purposes.
+    """
+
+    def __init__(self, nelec, nspin, params):
+        """ Initialize FakeWavefunction.
+
+        Args:
+            nelec (int): Number of electrons.
+            nspin (int): Number of spin orbitals.
+        """
+        self.assign_params(params)
+        super().__init__(nelec, nspin)
+
+    def get_overlap(self, sd, deriv=None):
+        """ Get overlap with a Slater determinant.
+
+        Args:
+            sd (int): Slater determinant in integer representation. -> not used for fake implementation.
+            deriv (np.ndarray, optional): If provided, compute the derivative of the overlap.
+
+        Returns:
+            float: Overlap value.
+        """
+        if deriv is not None:
+            return np.zeros(len(deriv))
+        else:
+            return 1.0 
+        
+    def assign_params(self, params):
+        """ Assign parameters to the wavefunction.
+
+        Args:
+            params (np.ndarray): Parameters to assign.
+        """
+        self.params = params
+
+
+class PyCITestSetup:
+    """ A test setup for PyCI interface. It sets up the Restricted Hamiltonian and a fake wavefunction.
+    """
+    def __init__(self):
+        self.nelec = 2
+        self.nspin = 4
+        self.e_nuc = 0
+        self.params = np.array([0.5, 0.5])
+        self.wfn = FakeWavefunction(self.nelec, self.nspin, self.params)
+        one_int = np.zeros((self.nelec, self.nelec)) # one electron integrals
+        two_int = np.zeros((self.nelec, self.nelec, self.nelec, self.nelec)) # two electron integrals
+        self.ham = RestrictedMolecularHamiltonian(one_int=one_int, two_int=two_int)
+        self.eqn = ProjectedSchrodinger(self.wfn, self.ham) # default eqn setup
+
+@pytest.mark.parametrize("legacy_fanci", [True, False])
+def test_pyci_interface_nproj(legacy_fanci):
+    """ Test whether nproj is correctly set in PyCI interface. For the default case.
+    """
+    setup_class = PyCITestSetup()
+
+    interface = PYCI(setup_class.eqn, setup_class.e_nuc, legacy_fanci=legacy_fanci)
+
+    # check nproj type
+    assert isinstance(interface.nproj, int)
+
+    # check nproj range: should be between 1 and FCI
+    fci_pspace = sd_list(setup_class.nelec, setup_class.nspin, spin=0)
+    assert 1 <= interface.nproj <= len(fci_pspace)
+
+@pytest.mark.parametrize("legacy_fanci", [True, False])
+def test_pspace_trimming(legacy_fanci):
+    """ Test whether spin unrestricted pspace is trimmed to spin restricted in PyCI interface.
+    """
+    setup_data = PyCITestSetup()
+
+    # set up Objective with unrestricted pspace
+    pspace_unrestr = sd_list(setup_data.nelec, setup_data.nspin) 
+    # spin unrestricted FCI space not supported in PyCI -> interface should trim it to spin restricted
+    eqn = ProjectedSchrodinger(setup_data.wfn, setup_data.ham, pspace=pspace_unrestr)
+
+    pspace_restr = sd_list(setup_data.nelec, setup_data.nspin, spin=0)
+
+    # interface setup
+    interface = PYCI(eqn, setup_data.e_nuc, legacy_fanci=legacy_fanci)
+    assert interface.nproj == len(pspace_restr)
+
+@pytest.mark.parametrize("legacy_fanci", [True, False])
+def test_mask(legacy_fanci):
+    """ Test whether mask is correctly set in PyCI interface.
+    """
+    setup_data = PyCITestSetup()
+
+    interface = PYCI(setup_data.eqn, setup_data.e_nuc, legacy_fanci=legacy_fanci)
+
+    assert interface.mask.shape == (interface.nparam,) # consistent with number of parameters
+    nparams = len(setup_data.wfn.params) + 1 # wfn params + energy
+    assert interface.mask.shape == (nparams,) 
+
+@pytest.mark.parametrize("legacy_fanci", [True, False])
+def test_jac(legacy_fanci):
+    """ Basic test to see if jac can be computed and has the correct dimensions.
+    """
+    setup_data = PyCITestSetup()
+    interface = PYCI(setup_data.eqn, setup_data.e_nuc, legacy_fanci=legacy_fanci)
+
+    nparams = len(setup_data.wfn.params) + 1 # wfn params + energy
+    jac_params = np.ones(interface.nparam) 
+    jac = interface.objective.compute_jacobian(jac_params)
+
+    assert jac.shape == (interface.nproj+1, nparams) # we need to add one for the normalization condition
+
+@pytest.mark.parametrize("legacy_fanci", [True, False])
+def test_objective(legacy_fanci):
+    """ Test shape of objective computation."""
+    setup_data = PyCITestSetup()
+    eqn = ProjectedSchrodinger(setup_data.wfn, setup_data.ham)
+
+    interface = PYCI(eqn, setup_data.e_nuc, legacy_fanci=legacy_fanci)
+    obj_params = np.ones(interface.nparam) 
+    objective = interface.objective.compute_objective(obj_params)
+
+    assert objective.shape == (interface.nproj+1,) # we need to add one for the normalization condition
+
+@pytest.mark.parametrize("legacy_fanci", [True, False])
+def test_energy(legacy_fanci):
+    """ Basic test to see if energy can be computed and appears in results dictionary."""
+    setup_data = PyCITestSetup()
+    eqn = ProjectedSchrodinger(setup_data.wfn, setup_data.ham)
+
+    interface = PYCI(eqn, setup_data.e_nuc, legacy_fanci=legacy_fanci)
+    x0 = np.ones(interface.nparam)
+    results = interface.objective.optimize(x0=x0) # dictionary with energy and other info
+
+    # check if energy keyword is present
+    assert 'energy' in results
+
+    # check if energy is a float
+    assert isinstance(results['energy'], float)

--- a/tests/test_interface_pyci.py
+++ b/tests/test_interface_pyci.py
@@ -1,6 +1,8 @@
 import pytest
 import numpy as np
 
+from utils import find_datafile
+
 from fanpy.interface.pyci import PYCI
 from fanpy.wfn.base import BaseWavefunction
 from fanpy.eqn.projected import ProjectedSchrodinger
@@ -232,8 +234,8 @@ def test_integration(legacy_fanci):
     """ Test if interface with real hamiltonian and wavefunction can compute jacobian, objective, and optimize without returning NaN or inf values. This is a basic sanity check to ensure that the interface is working as expected with real data.
     """
     test_wfn = StandardCC(2, 4)
-    one_int = np.load("data/data_h2_hf_sto6g_oneint.npy")
-    two_int = np.load("data/data_h2_hf_sto6g_twoint.npy")
+    one_int = np.load(find_datafile("data/data_h2_hf_sto6g_oneint.npy"))
+    two_int = np.load(find_datafile("data/data_h2_hf_sto6g_twoint.npy"))
     test_ham = RestrictedMolecularHamiltonian(
         one_int, two_int
     )
@@ -265,8 +267,8 @@ def test_integration(legacy_fanci):
 @pytest.mark.parametrize("legacy_fanci", [True, False])
 def test_behavior_regression_small_system(legacy_fanci):
     test_wfn = StandardCC(2, 4)
-    one_int = np.load("data/data_h2_hf_sto6g_oneint.npy")
-    two_int = np.load("data/data_h2_hf_sto6g_twoint.npy")
+    one_int = np.load(find_datafile("data/data_h2_hf_sto6g_oneint.npy"))
+    two_int = np.load(find_datafile("data/data_h2_hf_sto6g_twoint.npy"))
     test_ham = RestrictedMolecularHamiltonian(
         one_int, two_int
     )


### PR DESCRIPTION
This pull request significantly expands the test coverage for the `PYCI` interface in `tests/test_interface_pyci.py`. It introduces new helper classes for testing, adds multiple parameterized tests for core interface behaviors, and includes regression and integration tests to ensure correctness and robustness.

New test infrastructure:

* Added `FakeWavefunction` and `FakeHamiltonian` classes to provide controlled, minimal implementations for unit testing without relying on real quantum chemistry data.
* Introduced `PyCITestSetup` class to streamline setup of test cases, including wavefunction, Hamiltonian, and equation objects.

Core interface tests:

* Added parameterized tests to verify correct handling of `nproj`, mask shapes, and trimming of spin-unrestricted spaces to spin-restricted spaces in the `PYCI` interface.
* Added tests for objective and Jacobian computation, including checks for shape and absence of NaN or infinite values.

Integration and regression tests:

* Added integration tests using real Hamiltonian and wavefunction data to ensure the interface computes valid results and optimizes correctly.
* Added regression test for a small system, verifying that computed objectives and Jacobians match expected values and that optimization reduces the cost as intended.

These changes collectively improve the reliability and maintainability of the `PYCI` interface by providing comprehensive test coverage and robust validation of its key behaviors.