### PR TITLE
chore: ignore vscode settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ qaworkdir
 
 # Ignore Cython generated files
 fanpy/eqn/schrodinger/*.c
+
+# VS Code
+*.vscode


### PR DESCRIPTION
VS Code saves some settings in the `.vscode` folder. These are helpful for the editor, but not needed for the code. Therefore, I have added the folder to the `.gitignore` file so that it does not end up accidentally in the repository. 