### PR TITLE
Chore: extract calculations from interface and clean up

### DIFF
--- a/fanpy/interface/fanci/legacy.py
+++ b/fanpy/interface/fanci/legacy.py
@@ -3,12 +3,11 @@ Legacy version of FanCI objective class.
 Based of the original class from FanCI code.
 """
 
-from fanpy.tools import slater
-
 from fanpy.wfn.base import BaseWavefunction
 from fanpy.eqn.base import BaseSchrodinger
 from fanpy.wfn.composite.product import ProductWavefunction
 from fanpy.interface.fanci.alias import Alias
+from fanpy.interface.fanci.utils import convert_pyci_occs_to_fanpy_sds
 from fanpy.tools.performance import current_memory
 
 from typing import Any, Callable, Dict, List, Sequence, Tuple, Union
@@ -1087,7 +1086,6 @@ class ProjectedSchrodingerFanCI(ProjectedSchrodingerLegacyFanCI):
             **kwargs,
         )
 
-    # todo: not interface, move to some other function. 
     def compute_overlap(self, x: np.ndarray, occs_array: Union[np.ndarray, str]) -> np.ndarray:
         """
         Compute the FanCI overlap vector.
@@ -1117,23 +1115,7 @@ class ProjectedSchrodingerFanCI(ProjectedSchrodingerLegacyFanCI):
             raise ValueError("invalid `occs_array` argument")
         # FIXME: converting occs_array to slater determinants to be converted back to indices is a waste
         # convert slater determinants
-        sds = []
-        if isinstance(occs_array[0, 0], np.ndarray): # pspace generated with FCI
-            for i, occs in enumerate(occs_array):
-                # FIXME: CHECK IF occs IS BOOLEAN OR INTEGERS
-                # convert occupation vector to sd
-                if occs.dtype == bool:
-                    occs = np.where(occs)[0]
-                sd = slater.create(0, *occs[0])
-                sd = slater.create(sd, *(occs[1] + self.fanpy_wfn.nspatial))
-                sds.append(sd)
-        else: # pspace generated with DOCI
-            for i, occs in enumerate(occs_array):
-                if occs.dtype == bool:
-                    occs = np.where(occs)
-                sd = slater.create(0, *occs)
-                sd = slater.create(sd, *(occs + self.fanpy_wfn.nspatial))
-                sds.append(sd)
+        sds = convert_pyci_occs_to_fanpy_sds(occs_array, nspatial = self.fanpy_wfn.nspatial)
 
         # Feed in parameters into fanpy wavefunction
         for component, indices in self.param_selection.items():
@@ -1152,7 +1134,6 @@ class ProjectedSchrodingerFanCI(ProjectedSchrodingerLegacyFanCI):
                 y[i] = self.fanpy_wfn.get_overlap(sd)
         return y
 
-    # todo: same as compute overlap
     def compute_overlap_deriv(
         self, x: np.ndarray, occs_array: Union[np.ndarray, str], chunk_idx=[None, None]
     ) -> np.ndarray:
@@ -1188,23 +1169,7 @@ class ProjectedSchrodingerFanCI(ProjectedSchrodingerLegacyFanCI):
         # FIXME: converting occs_array to slater determinants to be converted back to indices is
         # a waste
         # convert slater determinants
-        sds = []
-        if isinstance(occs_array[0, 0], np.ndarray): # pspace generated with FCI
-            for i, occs in enumerate(occs_array):
-                # FIXME: CHECK IF occs IS BOOLEAN OR INTEGERS
-                # convert occupation vector to sd
-                if occs.dtype == bool:
-                    occs = np.where(occs)[0]
-                sd = slater.create(0, *occs[0])
-                sd = slater.create(sd, *(occs[1] + self.fanpy_wfn.nspatial))
-                sds.append(sd)
-        else: # pspace generated with DOCI
-            for i, occs in enumerate(occs_array):
-                if occs.dtype == bool:
-                    occs = np.where(occs)
-                sd = slater.create(0, *occs)
-                sd = slater.create(sd, *(occs + self.fanpy_wfn.nspatial))
-                sds.append(sd)
+        sds = convert_pyci_occs_to_fanpy_sds(occs_array, nspatial = self.fanpy_wfn.nspatial)
 
         # Select sds according to selected chunks
         s_chunk, f_chunk = chunk_idx
@@ -1251,7 +1216,6 @@ class ProjectedSchrodingerFanCI(ProjectedSchrodingerLegacyFanCI):
 
         return y
 
-    # todo: same as compute_overlap
     def compute_overlap_double_deriv(self, x: np.ndarray, occs_array: Union[np.ndarray, str]) -> np.ndarray:
         """
         Compute the FanCI overlap double derivative tensor.
@@ -1286,22 +1250,7 @@ class ProjectedSchrodingerFanCI(ProjectedSchrodingerLegacyFanCI):
         "Must be a CC-type FanPy wavefunction (BaseCC) with "
         "`get_overlap_double_derivative(sd)` implemented.")
         # Convert occs -> Slater determinants
-        sds = []
-        if isinstance(occs_array[0, 0], np.ndarray):
-            for i, occs in enumerate(occs_array):
-                # FIXME: CHECK IF occs IS BOOLEAN OR INTEGERS
-                # convert occupation vector to sd
-                if occs.dtype == bool:
-                    occs = np.where(occs)[0]
-                sd = slater.create(0, *occs[0])
-                sd = slater.create(sd, *(occs[1] + self.fanpy_wfn.nspatial))
-                sds.append(sd)
-        else:
-            for i, occs in enumerate(occs_array):
-                if occs.dtype == bool:
-                    occs = np.where(occs)
-                sd = slater.create(0, *occs)
-                sds.append(sd)        
+        sds = convert_pyci_occs_to_fanpy_sds(occs_array, nspatial = self.fanpy_wfn.nspatial)      
         
         # Update Fanpy params
         for component, indices in self.param_selection.items():

--- a/fanpy/interface/fanci/legacy.py
+++ b/fanpy/interface/fanci/legacy.py
@@ -18,9 +18,8 @@ import os
 import math
 
 import pyci
-import cma
 import numpy as np
-from scipy.optimize import OptimizeResult, least_squares, root, minimize
+from scipy.optimize import OptimizeResult, least_squares, root
 
 __all__ = [
     "ProjectedSchrodingerFanCI",

--- a/fanpy/interface/fanci/legacy.py
+++ b/fanpy/interface/fanci/legacy.py
@@ -1268,13 +1268,13 @@ class ProjectedSchrodingerFanCI(ProjectedSchrodingerLegacyFanCI):
         -------
         ovlp_hessian : np.ndarray
             Shape: (N_SD, nparam, nparam)
-        """
-        if occs_array == "P":
+       """
+        if isinstance(occs_array, np.ndarray):
+            pass
+        elif occs_array == "P":
             occs_array = self.pspace
         elif occs_array == "S":
             occs_array = self.sspace
-        elif isinstance(occs_array, np.ndarray):
-            pass
         else:
             raise ValueError("invalid `occs_array` argument")
         from fanpy.wfn.cc.base import BaseCC

--- a/fanpy/interface/fanci/legacy.py
+++ b/fanpy/interface/fanci/legacy.py
@@ -1286,40 +1286,17 @@ class ProjectedSchrodingerFanCI(ProjectedSchrodingerLegacyFanCI):
             Objective vector.
 
         """
-        if self.objective_type == "projected":
-            output = super().compute_objective(x)
-            self.print_queue["Electronic Energy"] = x[-1]
-            self.print_queue["Cost"] = np.sum(output[: self.nproj] ** 2)
-            self.print_queue["Cost from constraints"] = np.sum(output[self.nproj :] ** 2)
-            if self.step_print:
-                print("(Mid Optimization) Electronic Energy: {}".format(self.print_queue["Electronic Energy"]))
-                print("(Mid Optimization) Cost: {}".format(self.print_queue["Cost"]))
-                if self.constraints:
-                    print(
-                        "(Mid Optimization) Cost from constraints: {}".format(self.print_queue["Cost from constraints"])
-                    )
-        else: #todo: this else block does not get called, since the objective type has to be projected. As such, it should be moved to utility function. 
-            # NOTE: ignores energy and constraints
-            # Allocate objective vector
-            output = np.zeros(self.nproj, dtype=pyci.c_double)
-
-            # Compute overlaps of determinants in sspace:
-            #
-            #   c_m
-            #
-            ovlp = self.compute_overlap(x[:-1], "S")
-
-            # Compute objective function:
-            #
-            #   f_n = (\sum_n <\Psi|n> <n|H|\Psi>) / \sum_n <\Psi|n> <n|\Psi>
-            #
-            # Note: we update ovlp in-place here
-            self.ci_op(ovlp, out=output)
-            output = np.sum(output * ovlp[: self.nproj])
-            output /= np.sum(ovlp[: self.nproj] ** 2)
-            self.print_queue["Electronic Energy"] = output
-            if self.step_print:
-                print("(Mid Optimization) Electronic Energy: {}".format(self.print_queue["Electronic Energy"]))
+        output = super().compute_objective(x)
+        self.print_queue["Electronic Energy"] = x[-1]
+        self.print_queue["Cost"] = np.sum(output[: self.nproj] ** 2)
+        self.print_queue["Cost from constraints"] = np.sum(output[self.nproj :] ** 2)
+        if self.step_print:
+            print("(Mid Optimization) Electronic Energy: {}".format(self.print_queue["Electronic Energy"]))
+            print("(Mid Optimization) Cost: {}".format(self.print_queue["Cost"]))
+            if self.constraints:
+                print(
+                    "(Mid Optimization) Cost from constraints: {}".format(self.print_queue["Cost from constraints"])
+                )
 
         if self.step_save:
             self.save_params()
@@ -1343,66 +1320,10 @@ class ProjectedSchrodingerFanCI(ProjectedSchrodingerLegacyFanCI):
             Jacobian matrix.
 
         """
-        if self.objective_type == "projected":
-            output = super().compute_jacobian(x)
-            self.print_queue["Norm of the Jacobian"] = np.linalg.norm(output)
-            if self.step_print:
-                print("(Mid Optimization) Norm of the Jacobian: {}".format(self.print_queue["Norm of the Jacobian"]))
-        else: # todo: same as compute_objective
-            # NOTE: ignores energy and constraints
-            # Allocate Jacobian matrix (in transpose memory order)
-            output = np.zeros((self.nproj, self.nactive), order="F", dtype=pyci.c_double)
-            integrals = np.zeros(self.nproj, dtype=pyci.c_double)
-
-            # Compute Jacobian:
-            #
-            #   J_{nk} = d(<n|H|\Psi>)/d(p_k) - E d(<n|\Psi>)/d(p_k) - dE/d(p_k) <n|\Psi>
-            #   J_{nk} = (\sum_n d<\Psi|n> <n|H|\Psi> + <\Psi|n> d<n|H|\Psi>) / \sum_n <\Psi|n>^2 -
-            #            (\sum_n <\Psi|n> <n|H|\Psi>) / (\sum_n <\Psi|n> <n|\Psi>)^2 * (2 \sum_n <\Psi|n>)
-            #   J_{nk} = ((\sum_n d<\Psi|n> <n|H|\Psi> + <\Psi|n> d<n|H|\Psi>) (\sum_n <\Psi|n>^2)
-            #             - (\sum_n <\Psi|n> <n|H|\Psi>) * (2 \sum_n <\Psi|n> d<\Psi|n>))
-            #            / (\sum_n <\Psi|n>^2)^2
-            #   J_{nk} = ((\sum_n d<\Psi|n> <n|H|\Psi> + <\Psi|n> d<n|H|\Psi>) N
-            #             - H * (2 \sum_n <\Psi|n> d<\Psi|n>))
-            #            / N^2
-            #   J_{nk} = (\sum_n N (d<\Psi|n> <n|H|\Psi> + <\Psi|n> d<n|H|\Psi>) - 2 H <\Psi|n> d<\Psi|n>)
-            #            / N^2
-            #
-            # Compute overlap derivatives in sspace:
-            #
-            #   d(c_m)/d(p_k)
-            #
-            overlaps = self.compute_overlap(x[:-1], "S")
-            norm = np.sum(overlaps[: self.nproj] ** 2)
-            self.ci_op(overlaps, out=integrals)
-            energy_integral = np.sum(overlaps[: self.nproj] * integrals)
-
-            d_ovlp = self.compute_overlap_deriv(x[:-1], "S")
-
-            # Iterate over remaining columns of Jacobian and d_ovlp
-            for output_col, d_ovlp_col in zip(output.transpose(), d_ovlp.transpose()):
-                #
-                # Compute each column of the Jacobian:
-                #
-                #   d(<n|H|\Psi>)/d(p_k) = <m|H|n> d(c_m)/d(p_k)
-                #
-                #   E d(<n|\Psi>)/d(p_k) = E \delta_{nk} d(c_n)/d(p_k)
-                #
-                # Note: we update d_ovlp in-place here
-                self.ci_op(d_ovlp_col, out=output_col)
-                output_col *= overlaps[: self.nproj]
-                output_col += d_ovlp_col[: self.nproj] * integrals
-                output_col *= norm
-                output_col -= 2 * energy_integral * overlaps[: self.nproj] * d_ovlp_col[: self.nproj]
-                output_col /= norm**2
-            output = np.sum(output, axis=0)
-            self.print_queue["Norm of the gradient of the energy"] = np.linalg.norm(output)
-            if self.step_print:
-                print(
-                    "(Mid Optimization) Norm of the gradient of the energy: {}".format(
-                        self.print_queue["Norm of the gradient of the energy"]
-                    )
-                )
+        output = super().compute_jacobian(x)
+        self.print_queue["Norm of the Jacobian"] = np.linalg.norm(output)
+        if self.step_print:
+            print("(Mid Optimization) Norm of the Jacobian: {}".format(self.print_queue["Norm of the Jacobian"]))
 
         if self.step_save:
             self.save_params()

--- a/fanpy/interface/fanci/legacy.py
+++ b/fanpy/interface/fanci/legacy.py
@@ -1474,7 +1474,7 @@ class ProjectedSchrodingerFanCI(ProjectedSchrodingerLegacyFanCI):
             opt_kwargs["options"].setdefault("xtol", 1.0e-9)
             opt_kwargs.setdefault("callback", self.print)
         else:
-            raise ValueError("Invalid mode parameter. Only 'root' and 'lstsq' are supported for the ProjectedSchrodingerPyCI class.")
+            raise ValueError("Invalid mode parameter. Only 'root' and 'lstsq' are supported for the ProjectedSchrodingerFanCI class.")
 
         # Run optimizer
         results = optimizer(*opt_args, **opt_kwargs)

--- a/fanpy/interface/fanci/legacy.py
+++ b/fanpy/interface/fanci/legacy.py
@@ -1473,32 +1473,8 @@ class ProjectedSchrodingerFanCI(ProjectedSchrodingerLegacyFanCI):
             opt_kwargs.setdefault("options", {})
             opt_kwargs["options"].setdefault("xtol", 1.0e-9)
             opt_kwargs.setdefault("callback", self.print)
-        elif mode == "cma":
-            optimizer = cma.fmin
-            opt_kwargs.setdefault("sigma0", 0.01)
-            opt_kwargs.setdefault("options", {})
-            opt_kwargs["options"].setdefault("ftarget", None)
-            opt_kwargs["options"].setdefault("timeout", np.inf)
-            opt_kwargs["options"].setdefault("tolfun", 1e-11)
-            opt_kwargs["options"].setdefault("verb_log", 0)
-            if self.objective_type != "energy":
-                raise ValueError("objective_type must be energy")
-        elif mode == "bfgs":
-            if self.objective_type != "energy":
-                raise ValueError("objective_type must be energy")
-            optimizer = minimize
-            opt_kwargs["method"] = "bfgs"
-            opt_kwargs.setdefault("options", {"gtol": 1e-8})
-            # opt_kwargs["options"]['schrodinger'] = objective
-            opt_kwargs.setdefault("callback", self.print)
-        elif mode == "trustregion":
-            raise NotImplementedError
-        elif mode == "trf":
-            if self.objective_type != "projected":
-                raise ValueError("objective_type must be energy")
-            raise NotImplementedError
         else:
-            raise ValueError("invalid mode parameter")
+            raise ValueError("Invalid mode parameter. Only 'root' and 'lstsq' are supported for the ProjectedSchrodingerPyCI class.")
 
         # Run optimizer
         results = optimizer(*opt_args, **opt_kwargs)

--- a/fanpy/interface/fanci/legacy.py
+++ b/fanpy/interface/fanci/legacy.py
@@ -274,7 +274,7 @@ class ProjectedSchrodingerLegacyFanCI(metaclass=ABCMeta):
         self._pspace.setflags(write=False)
         self._sspace.setflags(write=False)
         self._mask_view.setflags(write=False)
-
+    # todo: check if I can move the functions to tools: this is used in multiple places. 
     def make_norm_constraint(self):
         def f(x: np.ndarray) -> float:
             r""" "
@@ -529,7 +529,7 @@ class ProjectedSchrodingerLegacyFanCI(metaclass=ABCMeta):
 
         # Update nactive
         self._nactive = self._mask.sum()
-
+    # todo: check if test exists for this. PyCI might have it since it is from it. May have to extract
     def compute_objective(self, x: np.ndarray) -> np.ndarray:
         """
         Compute the FanCI objective function.
@@ -580,6 +580,7 @@ class ProjectedSchrodingerLegacyFanCI(metaclass=ABCMeta):
         # Return objective
         return f
 
+    # todo: same as compute_objective
     def compute_jacobian(self, x: np.ndarray) -> np.ndarray:
         """
         Compute the Jacobian of the FanCI objective function.
@@ -652,6 +653,7 @@ class ProjectedSchrodingerLegacyFanCI(metaclass=ABCMeta):
         # Return Jacobian
         return jac
 
+    #todo: same as norm constraint
     def make_param_constraint(self, i: int, val: float) -> Tuple[Callable, Callable]:
         """
         Generate parameter constraint functions.
@@ -690,7 +692,8 @@ class ProjectedSchrodingerLegacyFanCI(metaclass=ABCMeta):
             return y
 
         return f, dfdx
-
+    
+    #todo: same as norm constraint
     def make_det_constraint(self, i: int, val: float) -> Tuple[Callable, Callable]:
         """
         Generate determinant overlap constraint functions.
@@ -1084,6 +1087,7 @@ class ProjectedSchrodingerFanCI(ProjectedSchrodingerLegacyFanCI):
             **kwargs,
         )
 
+    # todo: not interface, move to some other function. 
     def compute_overlap(self, x: np.ndarray, occs_array: Union[np.ndarray, str]) -> np.ndarray:
         """
         Compute the FanCI overlap vector.
@@ -1148,6 +1152,7 @@ class ProjectedSchrodingerFanCI(ProjectedSchrodingerLegacyFanCI):
                 y[i] = self.fanpy_wfn.get_overlap(sd)
         return y
 
+    # todo: same as compute overlap
     def compute_overlap_deriv(
         self, x: np.ndarray, occs_array: Union[np.ndarray, str], chunk_idx=[None, None]
     ) -> np.ndarray:
@@ -1246,6 +1251,7 @@ class ProjectedSchrodingerFanCI(ProjectedSchrodingerLegacyFanCI):
 
         return y
 
+    # todo: same as compute_overlap
     def compute_overlap_double_deriv(self, x: np.ndarray, occs_array: Union[np.ndarray, str]) -> np.ndarray:
         """
         Compute the FanCI overlap double derivative tensor.
@@ -1343,7 +1349,7 @@ class ProjectedSchrodingerFanCI(ProjectedSchrodingerLegacyFanCI):
                     print(
                         "(Mid Optimization) Cost from constraints: {}".format(self.print_queue["Cost from constraints"])
                     )
-        else:
+        else: #todo: this else block does not get called, since the objective type has to be projected. As such, it should be moved to utility function. 
             # NOTE: ignores energy and constraints
             # Allocate objective vector
             output = np.zeros(self.nproj, dtype=pyci.c_double)
@@ -1393,7 +1399,7 @@ class ProjectedSchrodingerFanCI(ProjectedSchrodingerLegacyFanCI):
             self.print_queue["Norm of the Jacobian"] = np.linalg.norm(output)
             if self.step_print:
                 print("(Mid Optimization) Norm of the Jacobian: {}".format(self.print_queue["Norm of the Jacobian"]))
-        else:
+        else: # todo: same as compute_objective
             # NOTE: ignores energy and constraints
             # Allocate Jacobian matrix (in transpose memory order)
             output = np.zeros((self.nproj, self.nactive), order="F", dtype=pyci.c_double)
@@ -1578,6 +1584,7 @@ class ProjectedSchrodingerFanCI(ProjectedSchrodingerLegacyFanCI):
             opt_kwargs["jac"] = j
 
         # Parse mode parameter; choose optimizer and fix arguments
+        # todo: limit methods for optimization. We have projected schrodinger objective not one energy. 
         if mode == "lstsq":
             optimizer = least_squares
             opt_kwargs.setdefault("xtol", 1.0e-8)

--- a/fanpy/interface/fanci/legacy.py
+++ b/fanpy/interface/fanci/legacy.py
@@ -1454,7 +1454,6 @@ class ProjectedSchrodingerFanCI(ProjectedSchrodingerLegacyFanCI):
             opt_kwargs["jac"] = j
 
         # Parse mode parameter; choose optimizer and fix arguments
-        # todo: limit methods for optimization. We have projected schrodinger objective not one energy. 
         if mode == "lstsq":
             optimizer = least_squares
             opt_kwargs.setdefault("xtol", 1.0e-8)

--- a/fanpy/interface/fanci/pyci.py
+++ b/fanpy/interface/fanci/pyci.py
@@ -4,7 +4,6 @@ Based of the original class from FanCI code.
 """
 #todo: update docstrings
 
-from fanpy.tools import slater
 
 from fanpy.wfn.base import BaseWavefunction
 from fanpy.eqn.base import BaseSchrodinger

--- a/fanpy/interface/fanci/pyci.py
+++ b/fanpy/interface/fanci/pyci.py
@@ -440,22 +440,7 @@ class ProjectedSchrodingerPyCI(FanCI):
             raise NotImplementedError(f"{type(self.fanpy_wfn).__name__} is not supported for second derivative overlap. "
         "Must be a CC-type FanPy wavefunction (BaseCC) with "
         "`get_overlap_double_derivative(sd)` implemented.")
-        sds = []
-        if isinstance(occs_array[0, 0], np.ndarray):
-            for i, occs in enumerate(occs_array):
-                # FIXME: CHECK IF occs IS BOOLEAN OR INTEGERS
-                # convert occupation vector to sd
-                if occs.dtype == bool:
-                    occs = np.where(occs)[0]
-                sd = slater.create(0, *occs[0])
-                sd = slater.create(sd, *(occs[1] + self.fanpy_wfn.nspatial))
-                sds.append(sd)
-        else:
-            for i, occs in enumerate(occs_array):
-                if occs.dtype == bool:
-                    occs = np.where(occs)
-                sd = slater.create(0, *occs)
-                sds.append(sd)        
+        sds = convert_pyci_occs_to_fanpy_sds(occs_array, self.fanpy_wfn.nspatial)  
         
         # Update Fanpy params
         for component, indices in self.param_selection.items():

--- a/fanpy/interface/fanci/pyci.py
+++ b/fanpy/interface/fanci/pyci.py
@@ -2,6 +2,7 @@
 Legacy version of FanCI objective class.
 Based of the original class from FanCI code.
 """
+#todo: update docstrings
 
 from fanpy.tools import slater
 
@@ -9,6 +10,7 @@ from fanpy.wfn.base import BaseWavefunction
 from fanpy.eqn.base import BaseSchrodinger
 from fanpy.wfn.composite.product import ProductWavefunction
 from fanpy.tools.performance import current_memory
+from fanpy.interface.fanci.utils import convert_pyci_occs_to_fanpy_sds
 
 from typing import Any, Callable, List, Tuple, Union, Sequence
 
@@ -182,6 +184,7 @@ class ProjectedSchrodingerPyCI(FanCI):
         tmpfile: str,
         **kwargs: Any,
     ) -> None:
+        # todo: add default values to some of these arguments.
         """
         Initialize the FanCI problem.
 
@@ -270,6 +273,7 @@ class ProjectedSchrodingerPyCI(FanCI):
             **kwargs,
         )
 
+    #todo: move to utility file. 
     def compute_overlap(self, x: np.ndarray, occs_array: Union[np.ndarray, str]) -> np.ndarray:
         """
         Compute the FanCI overlap vector.
@@ -301,23 +305,7 @@ class ProjectedSchrodingerPyCI(FanCI):
         # FIXME: converting occs_array to slater determinants to be converted back to indices is
         # a waste
         # convert slater determinants
-        sds = []
-        if isinstance(occs_array[0, 0], np.ndarray): # if pspace generated with FCI
-            for i, occs in enumerate(occs_array):
-                # FIXME: CHECK IF occs IS BOOLEAN OR INTEGERS
-                # convert occupation vector to sd
-                if occs.dtype == bool:
-                    occs = np.where(occs)[0]
-                sd = slater.create(0, *occs[0])
-                sd = slater.create(sd, *(occs[1] + self.fanpy_wfn.nspatial))
-                sds.append(sd)
-        else: # if pspace generated with DOCI
-            for i, occs in enumerate(occs_array):
-                if occs.dtype == bool:
-                    occs = np.where(occs)
-                sd = slater.create(0, *occs)
-                sd = slater.create(sd, *(occs + self.fanpy_wfn.nspatial))
-                sds.append(sd)
+        sds = convert_pyci_occs_to_fanpy_sds(occs_array, nspatial=self.fanpy_wfn.nspatial)
 
         # Feed in parameters into fanpy wavefunction
         for component, indices in self.param_selection.items():
@@ -336,6 +324,7 @@ class ProjectedSchrodingerPyCI(FanCI):
                 y[i] = self.fanpy_wfn.get_overlap(sd)
         return y
 
+    #todo: move to utility file. 
     def compute_overlap_deriv(
         self, x: np.ndarray, occs_array: Union[np.ndarray, str], chunk_idx=[None, None]
     ) -> np.ndarray:
@@ -434,6 +423,7 @@ class ProjectedSchrodingerPyCI(FanCI):
 
         return y
 
+    #todo: move to utility file. 
     def compute_overlap_double_deriv(self, x: np.ndarray, occs_array: Union[np.ndarray, str]) -> np.ndarray:
         """
         Compute the FanCI overlap double derivative tensor.
@@ -528,7 +518,7 @@ class ProjectedSchrodingerPyCI(FanCI):
                     print(
                         "(Mid Optimization) Cost from constraints: {}".format(self.print_queue["Cost from constraints"])
                     )
-        else:
+        else: #todo: move to utility file. 
             # NOTE: ignores energy and constraints
             # Allocate objective vector
             output = np.zeros(self.nproj, dtype=pyci.c_double)
@@ -581,7 +571,7 @@ class ProjectedSchrodingerPyCI(FanCI):
             self.print_queue["Norm of the Jacobian"] = np.linalg.norm(output)
             if self.step_print:
                 print("(Mid Optimization) Norm of the Jacobian: {}".format(self.print_queue["Norm of the Jacobian"]))
-        else:
+        else: #todo: move to utility file. 
             # NOTE: ignores energy and constraints
             # Allocate Jacobian matrix (in transpose memory order)
             output = np.zeros((self.nproj, self.nactive), order="F", dtype=pyci.c_double)
@@ -641,6 +631,7 @@ class ProjectedSchrodingerPyCI(FanCI):
             self.save_params()
         return output
 
+    #todo: move to utility file. 
     # TODO: This implementation was needed because PyCI does not support frozen parameters.
     # TODO: It can be removed in the future if PyCI adds support.
     def masked_compute_jacobian(self, x: np.ndarray) -> np.ndarray:
@@ -780,6 +771,7 @@ class ProjectedSchrodingerPyCI(FanCI):
         """
         return np.hstack([comp.params.ravel()[inds] for comp, inds in self.param_selection.items()])
 
+    #todo: move to utility file. 
     def make_norm_constraint(self):
         def f(x: np.ndarray) -> float:
             """ "
@@ -904,6 +896,7 @@ class ProjectedSchrodingerPyCI(FanCI):
         if use_jac:
             opt_kwargs["jac"] = j
 
+        # todo: remove modes that do not work with projected Schrodinger equation. 
         # Parse mode parameter; choose optimizer and fix arguments
         if mode == "lstsq":
             optimizer = least_squares

--- a/fanpy/interface/fanci/pyci.py
+++ b/fanpy/interface/fanci/pyci.py
@@ -508,14 +508,13 @@ class ProjectedSchrodingerPyCI(FanCI):
             Jacobian matrix.
 
         """
-        if self.objective_type == "projected":
-            if self.nactive == self.nparam:
-                output = super().compute_jacobian(x)
-            else:
-                output = self.masked_compute_jacobian(x)
-            self.print_queue["Norm of the Jacobian"] = np.linalg.norm(output)
-            if self.step_print:
-                print("(Mid Optimization) Norm of the Jacobian: {}".format(self.print_queue["Norm of the Jacobian"]))
+        if self.nactive == self.nparam:
+            output = super().compute_jacobian(x)
+        else:
+            output = self.masked_compute_jacobian(x)
+        self.print_queue["Norm of the Jacobian"] = np.linalg.norm(output)
+        if self.step_print:
+            print("(Mid Optimization) Norm of the Jacobian: {}".format(self.print_queue["Norm of the Jacobian"]))
 
         if self.step_save:
             self.save_params()

--- a/fanpy/interface/fanci/pyci.py
+++ b/fanpy/interface/fanci/pyci.py
@@ -785,7 +785,6 @@ class ProjectedSchrodingerPyCI(FanCI):
         if use_jac:
             opt_kwargs["jac"] = j
 
-        # todo: remove modes that do not work with projected Schrodinger equation. 
         # Parse mode parameter; choose optimizer and fix arguments
         if mode == "lstsq":
             optimizer = least_squares

--- a/fanpy/interface/fanci/pyci.py
+++ b/fanpy/interface/fanci/pyci.py
@@ -273,7 +273,7 @@ class ProjectedSchrodingerPyCI(FanCI):
             **kwargs,
         )
 
-    #todo: move to utility file. 
+
     def compute_overlap(self, x: np.ndarray, occs_array: Union[np.ndarray, str]) -> np.ndarray:
         """
         Compute the FanCI overlap vector.
@@ -324,7 +324,6 @@ class ProjectedSchrodingerPyCI(FanCI):
                 y[i] = self.fanpy_wfn.get_overlap(sd)
         return y
 
-    #todo: move to utility file. 
     def compute_overlap_deriv(
         self, x: np.ndarray, occs_array: Union[np.ndarray, str], chunk_idx=[None, None]
     ) -> np.ndarray:
@@ -360,23 +359,7 @@ class ProjectedSchrodingerPyCI(FanCI):
         # FIXME: converting occs_array to slater determinants to be converted back to indices is
         # a waste
         # convert slater determinants
-        sds = []
-        if isinstance(occs_array[0, 0], np.ndarray): # if pspace generated with FCI
-            for i, occs in enumerate(occs_array):
-                # FIXME: CHECK IF occs IS BOOLEAN OR INTEGERS
-                # convert occupation vector to sd
-                if occs.dtype == bool:
-                    occs = np.where(occs)[0]
-                sd = slater.create(0, *occs[0])
-                sd = slater.create(sd, *(occs[1] + self.fanpy_wfn.nspatial))
-                sds.append(sd)
-        else: # if pspace generated with DOCI
-            for i, occs in enumerate(occs_array):
-                if occs.dtype == bool:
-                    occs = np.where(occs)
-                sd = slater.create(0, *occs)
-                sd = slater.create(sd, *(occs + self.fanpy_wfn.nspatial))
-                sds.append(sd)
+        sds = convert_pyci_occs_to_fanpy_sds(occs_array, nspatial=self.fanpy_wfn.nspatial)
 
         # Select sds according to selected chunks
         s_chunk, f_chunk = chunk_idx

--- a/fanpy/interface/fanci/pyci.py
+++ b/fanpy/interface/fanci/pyci.py
@@ -518,7 +518,6 @@ class ProjectedSchrodingerPyCI(FanCI):
             self.save_params()
         return output
 
-    #todo: move to utility file. 
     # TODO: This implementation was needed because PyCI does not support frozen parameters.
     # TODO: It can be removed in the future if PyCI adds support.
     def masked_compute_jacobian(self, x: np.ndarray) -> np.ndarray:

--- a/fanpy/interface/fanci/pyci.py
+++ b/fanpy/interface/fanci/pyci.py
@@ -805,32 +805,8 @@ class ProjectedSchrodingerPyCI(FanCI):
             opt_kwargs.setdefault("options", {})
             opt_kwargs["options"].setdefault("xtol", 1.0e-9)
             opt_kwargs.setdefault("callback", self.print)
-        elif mode == "cma":
-            optimizer = cma.fmin
-            opt_kwargs.setdefault("sigma0", 0.01)
-            opt_kwargs.setdefault("options", {})
-            opt_kwargs["options"].setdefault("ftarget", None)
-            opt_kwargs["options"].setdefault("timeout", np.inf)
-            opt_kwargs["options"].setdefault("tolfun", 1e-11)
-            opt_kwargs["options"].setdefault("verb_log", 0)
-            if self.objective_type != "energy":
-                raise ValueError("objective_type must be energy")
-        elif mode == "bfgs":
-            if self.objective_type != "energy":
-                raise ValueError("objective_type must be energy")
-            optimizer = minimize
-            opt_kwargs["method"] = "bfgs"
-            opt_kwargs.setdefault("options", {"gtol": 1e-8})
-            # opt_kwargs["options"]['schrodinger'] = objective
-            opt_kwargs.setdefault("callback", self.print)
-        elif mode == "trustregion":
-            raise NotImplementedError
-        elif mode == "trf":
-            if self.objective_type != "projected":
-                raise ValueError("objective_type must be energy")
-            raise NotImplementedError
         else:
-            raise ValueError("invalid mode parameter")
+            raise ValueError("Invalid mode parameter. Only 'root' and 'lstsq' are supported for the ProjectedSchrodingerPyCI class.")
 
         # Run optimizer
         results = optimizer(*opt_args, **opt_kwargs)

--- a/fanpy/interface/fanci/pyci.py
+++ b/fanpy/interface/fanci/pyci.py
@@ -474,18 +474,17 @@ class ProjectedSchrodingerPyCI(FanCI):
             Objective vector.
 
         """
-        if self.objective_type == "projected":
-            output = super().compute_objective(x)
-            self.print_queue["Electronic Energy"] = x[-1]
-            self.print_queue["Cost"] = np.sum(output[: self.nproj] ** 2)
-            self.print_queue["Cost from constraints"] = np.sum(output[self.nproj :] ** 2)
-            if self.step_print:
-                print("(Mid Optimization) Electronic Energy: {}".format(self.print_queue["Electronic Energy"]))
-                print("(Mid Optimization) Cost: {}".format(self.print_queue["Cost"]))
-                if self.constraints:
-                    print(
-                        "(Mid Optimization) Cost from constraints: {}".format(self.print_queue["Cost from constraints"])
-                    )
+        output = super().compute_objective(x)
+        self.print_queue["Electronic Energy"] = x[-1]
+        self.print_queue["Cost"] = np.sum(output[: self.nproj] ** 2)
+        self.print_queue["Cost from constraints"] = np.sum(output[self.nproj :] ** 2)
+        if self.step_print:
+            print("(Mid Optimization) Electronic Energy: {}".format(self.print_queue["Electronic Energy"]))
+            print("(Mid Optimization) Cost: {}".format(self.print_queue["Cost"]))
+            if self.constraints:
+                print(
+                    "(Mid Optimization) Cost from constraints: {}".format(self.print_queue["Cost from constraints"])
+                )
 
         if self.step_save:
             self.save_params()

--- a/fanpy/interface/fanci/pyci.py
+++ b/fanpy/interface/fanci/pyci.py
@@ -1,8 +1,8 @@
 """
-Legacy version of FanCI objective class.
-Based of the original class from FanCI code.
+Projected Schrodinger objective class for PyCI calculations
+This class inherits from PyCI's FanCI class and defines methods 
+such as compute overlap with Fanpy functionality
 """
-#todo: update docstrings
 
 
 from fanpy.wfn.base import BaseWavefunction
@@ -19,9 +19,8 @@ import math
 import pyci
 from pyci.fanci import FanCI
 
-import cma
 import numpy as np
-from scipy.optimize import OptimizeResult, least_squares, root, minimize
+from scipy.optimize import OptimizeResult, least_squares, root
 
 __all__ = [
     "ProjectedSchrodingerFanCI",
@@ -657,7 +656,6 @@ class ProjectedSchrodingerPyCI(FanCI):
         """
         return np.hstack([comp.params.ravel()[inds] for comp, inds in self.param_selection.items()])
 
-    #todo: move to utility file. 
     def make_norm_constraint(self):
         def f(x: np.ndarray) -> float:
             """ "

--- a/fanpy/interface/fanci/pyci.py
+++ b/fanpy/interface/fanci/pyci.py
@@ -424,12 +424,12 @@ class ProjectedSchrodingerPyCI(FanCI):
         ovlp_hessian : np.ndarray
             Shape: (N_SD, nparam, nparam)
         """
-        if occs_array == "P":
+        if isinstance(occs_array, np.ndarray):
+            pass
+        elif occs_array == "P":
             occs_array = self.pspace
         elif occs_array == "S":
             occs_array = self.sspace
-        elif isinstance(occs_array, np.ndarray):
-            pass
         else:
             raise ValueError("invalid `occs_array` argument")
         from fanpy.wfn.cc.base import BaseCC

--- a/fanpy/interface/fanci/pyci.py
+++ b/fanpy/interface/fanci/pyci.py
@@ -486,28 +486,6 @@ class ProjectedSchrodingerPyCI(FanCI):
                     print(
                         "(Mid Optimization) Cost from constraints: {}".format(self.print_queue["Cost from constraints"])
                     )
-        else: #todo: move to utility file. 
-            # NOTE: ignores energy and constraints
-            # Allocate objective vector
-            output = np.zeros(self.nproj, dtype=pyci.c_double)
-
-            # Compute overlaps of determinants in sspace:
-            #
-            #   c_m
-            #
-            ovlp = self.compute_overlap(x[:-1], "S")
-
-            # Compute objective function:
-            #
-            #   f_n = (\sum_n <\Psi|n> <n|H|\Psi>) / \sum_n <\Psi|n> <n|\Psi>
-            #
-            # Note: we update ovlp in-place here
-            self.ci_op(ovlp, out=output)
-            output = np.sum(output * ovlp[: self.nproj])
-            output /= np.sum(ovlp[: self.nproj] ** 2)
-            self.print_queue["Electronic Energy"] = output
-            if self.step_print:
-                print("(Mid Optimization) Electronic Energy: {}".format(self.print_queue["Electronic Energy"]))
 
         if self.step_save:
             self.save_params()

--- a/fanpy/interface/fanci/pyci.py
+++ b/fanpy/interface/fanci/pyci.py
@@ -516,61 +516,6 @@ class ProjectedSchrodingerPyCI(FanCI):
             self.print_queue["Norm of the Jacobian"] = np.linalg.norm(output)
             if self.step_print:
                 print("(Mid Optimization) Norm of the Jacobian: {}".format(self.print_queue["Norm of the Jacobian"]))
-        else: #todo: move to utility file. 
-            # NOTE: ignores energy and constraints
-            # Allocate Jacobian matrix (in transpose memory order)
-            output = np.zeros((self.nproj, self.nactive), order="F", dtype=pyci.c_double)
-            integrals = np.zeros(self.nproj, dtype=pyci.c_double)
-
-            # Compute Jacobian:
-            #
-            #   J_{nk} = d(<n|H|\Psi>)/d(p_k) - E d(<n|\Psi>)/d(p_k) - dE/d(p_k) <n|\Psi>
-            #   J_{nk} = (\sum_n d<\Psi|n> <n|H|\Psi> + <\Psi|n> d<n|H|\Psi>) / \sum_n <\Psi|n>^2 -
-            #            (\sum_n <\Psi|n> <n|H|\Psi>) / (\sum_n <\Psi|n> <n|\Psi>)^2 * (2 \sum_n <\Psi|n>)
-            #   J_{nk} = ((\sum_n d<\Psi|n> <n|H|\Psi> + <\Psi|n> d<n|H|\Psi>) (\sum_n <\Psi|n>^2)
-            #             - (\sum_n <\Psi|n> <n|H|\Psi>) * (2 \sum_n <\Psi|n> d<\Psi|n>))
-            #            / (\sum_n <\Psi|n>^2)^2
-            #   J_{nk} = ((\sum_n d<\Psi|n> <n|H|\Psi> + <\Psi|n> d<n|H|\Psi>) N
-            #             - H * (2 \sum_n <\Psi|n> d<\Psi|n>))
-            #            / N^2
-            #   J_{nk} = (\sum_n N (d<\Psi|n> <n|H|\Psi> + <\Psi|n> d<n|H|\Psi>) - 2 H <\Psi|n> d<\Psi|n>)
-            #            / N^2
-            #
-            # Compute overlap derivatives in sspace:
-            #
-            #   d(c_m)/d(p_k)
-            #
-            overlaps = self.compute_overlap(x[:-1], "S")
-            norm = np.sum(overlaps[: self.nproj] ** 2)
-            self.ci_op(overlaps, out=integrals)
-            energy_integral = np.sum(overlaps[: self.nproj] * integrals)
-
-            d_ovlp = self.compute_overlap_deriv(x[:-1], "S")
-
-            # Iterate over remaining columns of Jacobian and d_ovlp
-            for output_col, d_ovlp_col in zip(output.transpose(), d_ovlp.transpose()):
-                #
-                # Compute each column of the Jacobian:
-                #
-                #   d(<n|H|\Psi>)/d(p_k) = <m|H|n> d(c_m)/d(p_k)
-                #
-                #   E d(<n|\Psi>)/d(p_k) = E \delta_{nk} d(c_n)/d(p_k)
-                #
-                # Note: we update d_ovlp in-place here
-                self.ci_op(d_ovlp_col, out=output_col)
-                output_col *= overlaps[: self.nproj]
-                output_col += d_ovlp_col[: self.nproj] * integrals
-                output_col *= norm
-                output_col -= 2 * energy_integral * overlaps[: self.nproj] * d_ovlp_col[: self.nproj]
-                output_col /= norm**2
-            output = np.sum(output, axis=0)
-            self.print_queue["Norm of the gradient of the energy"] = np.linalg.norm(output)
-            if self.step_print:
-                print(
-                    "(Mid Optimization) Norm of the gradient of the energy: {}".format(
-                        self.print_queue["Norm of the gradient of the energy"]
-                    )
-                )
 
         if self.step_save:
             self.save_params()

--- a/fanpy/interface/fanci/pyci.py
+++ b/fanpy/interface/fanci/pyci.py
@@ -406,7 +406,6 @@ class ProjectedSchrodingerPyCI(FanCI):
 
         return y
 
-    #todo: move to utility file. 
     def compute_overlap_double_deriv(self, x: np.ndarray, occs_array: Union[np.ndarray, str]) -> np.ndarray:
         """
         Compute the FanCI overlap double derivative tensor.

--- a/fanpy/interface/fanci/utils.py
+++ b/fanpy/interface/fanci/utils.py
@@ -1,0 +1,43 @@
+"""Utility functions for the PyCI interface"""
+
+import numpy as np
+
+from fanpy.tools import slater
+
+
+def convert_pyci_occs_to_fanpy_sds(occs_array: np.ndarray, nspatial: int):
+    """Functiont to convert occupation arrays into Slater determinants represented by integers.  
+
+    Parameters
+    ----------
+    occs_array : np.ndarray
+        Occupation array as a numpy array. This can be either the orbital occupation, or the spinorbital occupation vector. 
+    nspatial : int
+        number of spatial orbitals. 
+    
+    Returns
+    -------
+    sds : list of ints
+        The Slater Determinants represented as int 
+
+    """
+    #todo: check if length of occ array == nspatial!
+    
+    sds = []
+    if isinstance(occs_array[0, 0], np.ndarray): # if pspace generated with FCI
+        for i, occs in enumerate(occs_array):
+            # FIXME: CHECK IF occs IS BOOLEAN OR INTEGERS
+            # convert occupation vector to sd
+            if occs.dtype == bool:
+                occs = np.where(occs)[0]
+            sd = slater.create(0, *occs[0])
+            sd = slater.create(sd, *(occs[1] + nspatial))
+            sds.append(sd)
+    else: # if pspace generated with DOCI
+        for i, occs in enumerate(occs_array):
+            if occs.dtype == bool:
+                occs = np.where(occs)
+            sd = slater.create(0, *occs)
+            sd = slater.create(sd, *(occs + nspatial))
+            sds.append(sd)
+    return sds

--- a/fanpy/interface/fanci/utils.py
+++ b/fanpy/interface/fanci/utils.py
@@ -41,3 +41,29 @@ def convert_pyci_occs_to_fanpy_sds(occs_array: np.ndarray, nspatial: int):
             sd = slater.create(sd, *(occs + nspatial))
             sds.append(sd)
     return sds
+
+# todo: create utility function to calculate variational energy objective:
+# This is the objective function from the old interface class for objective type energy. 
+# Note: we do not have the features yet to implement this, thus it is staying here for now, until development on the variational interface is done. 
+#   else:
+#             # NOTE: ignores energy and constraints
+#             # Allocate objective vector
+#             output = np.zeros(self.nproj, dtype=pyci.c_double)
+
+#             # Compute overlaps of determinants in sspace:
+#             #
+#             #   c_m
+#             #
+#             ovlp = self.compute_overlap(x[:-1], "S")
+
+#             # Compute objective function:
+#             #
+#             #   f_n = (\sum_n <\Psi|n> <n|H|\Psi>) / \sum_n <\Psi|n> <n|\Psi>
+#             #
+#             # Note: we update ovlp in-place here
+#             self.ci_op(ovlp, out=output)
+#             output = np.sum(output * ovlp[: self.nproj])
+#             output /= np.sum(ovlp[: self.nproj] ** 2)
+#             self.print_queue["Electronic Energy"] = output
+#             if self.step_print:
+#                 print("(Mid Optimization) Electronic Energy: {}".format(self.print_queue["Electronic Energy"]))

--- a/fanpy/interface/fanci/utils.py
+++ b/fanpy/interface/fanci/utils.py
@@ -67,3 +67,62 @@ def convert_pyci_occs_to_fanpy_sds(occs_array: np.ndarray, nspatial: int):
 #             self.print_queue["Electronic Energy"] = output
 #             if self.step_print:
 #                 print("(Mid Optimization) Electronic Energy: {}".format(self.print_queue["Electronic Energy"]))
+
+# todo: create utility function to calculate variational energy objective derivative:
+# This is the compute jacobian function from the old interface class for objective type energy. 
+# Note: we do not have the features yet to implement this, thus it is staying here for now, until development on the variational interface is done. 
+        # else: #todo: move to utility file. 
+        #     # NOTE: ignores energy and constraints
+        #     # Allocate Jacobian matrix (in transpose memory order)
+        #     output = np.zeros((self.nproj, self.nactive), order="F", dtype=pyci.c_double)
+        #     integrals = np.zeros(self.nproj, dtype=pyci.c_double)
+
+        #     # Compute Jacobian:
+        #     #
+        #     #   J_{nk} = d(<n|H|\Psi>)/d(p_k) - E d(<n|\Psi>)/d(p_k) - dE/d(p_k) <n|\Psi>
+        #     #   J_{nk} = (\sum_n d<\Psi|n> <n|H|\Psi> + <\Psi|n> d<n|H|\Psi>) / \sum_n <\Psi|n>^2 -
+        #     #            (\sum_n <\Psi|n> <n|H|\Psi>) / (\sum_n <\Psi|n> <n|\Psi>)^2 * (2 \sum_n <\Psi|n>)
+        #     #   J_{nk} = ((\sum_n d<\Psi|n> <n|H|\Psi> + <\Psi|n> d<n|H|\Psi>) (\sum_n <\Psi|n>^2)
+        #     #             - (\sum_n <\Psi|n> <n|H|\Psi>) * (2 \sum_n <\Psi|n> d<\Psi|n>))
+        #     #            / (\sum_n <\Psi|n>^2)^2
+        #     #   J_{nk} = ((\sum_n d<\Psi|n> <n|H|\Psi> + <\Psi|n> d<n|H|\Psi>) N
+        #     #             - H * (2 \sum_n <\Psi|n> d<\Psi|n>))
+        #     #            / N^2
+        #     #   J_{nk} = (\sum_n N (d<\Psi|n> <n|H|\Psi> + <\Psi|n> d<n|H|\Psi>) - 2 H <\Psi|n> d<\Psi|n>)
+        #     #            / N^2
+        #     #
+        #     # Compute overlap derivatives in sspace:
+        #     #
+        #     #   d(c_m)/d(p_k)
+        #     #
+        #     overlaps = self.compute_overlap(x[:-1], "S")
+        #     norm = np.sum(overlaps[: self.nproj] ** 2)
+        #     self.ci_op(overlaps, out=integrals)
+        #     energy_integral = np.sum(overlaps[: self.nproj] * integrals)
+
+        #     d_ovlp = self.compute_overlap_deriv(x[:-1], "S")
+
+        #     # Iterate over remaining columns of Jacobian and d_ovlp
+        #     for output_col, d_ovlp_col in zip(output.transpose(), d_ovlp.transpose()):
+        #         #
+        #         # Compute each column of the Jacobian:
+        #         #
+        #         #   d(<n|H|\Psi>)/d(p_k) = <m|H|n> d(c_m)/d(p_k)
+        #         #
+        #         #   E d(<n|\Psi>)/d(p_k) = E \delta_{nk} d(c_n)/d(p_k)
+        #         #
+        #         # Note: we update d_ovlp in-place here
+        #         self.ci_op(d_ovlp_col, out=output_col)
+        #         output_col *= overlaps[: self.nproj]
+        #         output_col += d_ovlp_col[: self.nproj] * integrals
+        #         output_col *= norm
+        #         output_col -= 2 * energy_integral * overlaps[: self.nproj] * d_ovlp_col[: self.nproj]
+        #         output_col /= norm**2
+        #     output = np.sum(output, axis=0)
+        #     self.print_queue["Norm of the gradient of the energy"] = np.linalg.norm(output)
+        #     if self.step_print:
+        #         print(
+        #             "(Mid Optimization) Norm of the gradient of the energy: {}".format(
+        #                 self.print_queue["Norm of the gradient of the energy"]
+        #             )
+        #         )

--- a/fanpy/interface/pyci.py
+++ b/fanpy/interface/pyci.py
@@ -1,6 +1,5 @@
 from fanpy.ham.restricted_chemical import RestrictedMolecularHamiltonian
 from fanpy.eqn.projected import ProjectedSchrodinger
-from fanpy.interface.fanci import ProjectedSchrodingerFanCI
 from fanpy.tools.sd_list import sd_list
 
 import numpy as np

--- a/tests/test_interface_fanci_legacy.py
+++ b/tests/test_interface_fanci_legacy.py
@@ -1,0 +1,207 @@
+""" Test for fanpy.interface.fanci.legacy """
+
+import numpy as np
+import pytest
+
+from fanpy.interface.fanci.legacy import ProjectedSchrodingerFanCI
+import pyci
+
+from test_interface_pyci import FakeHamiltonian, FakeWavefunction
+
+from fanpy.eqn.projected import BaseSchrodinger
+from fanpy.wfn.cc.standard_cc import StandardCC
+
+############## Tools for testing purposes #########################
+
+class FakeSchrodinger(BaseSchrodinger):
+    """fake fanpy objective for testing purposes"""
+    def __init__(self, wfn, ham):
+        super().__init__(wfn, ham)
+    def objective(self, params):
+        return 3.08
+
+class FakeCC(StandardCC):
+    """fake CC wavefunction for testing purposes
+    This is used to test the double derivative of the overlap.
+    """
+    def __init__(self, nelec, nspin):
+        super().__init__(nelec, nspin)
+
+    def get_overlap_double_derivative(self, sd):
+        double_deriv = np.ones((self.nparams, self.nparams))
+        return double_deriv
+
+def make_test_instance(**overrides):
+    """make test instance of ProjectedSchrodingerPyCI with fake fanpy objective and fake pyci hamiltonian and wavefunction
+    This helps set up a class that requires a lot of parameters.
+    """
+    # build Fake fanpy objective
+    wfn = FakeWavefunction(2, 4, np.ones(4))
+    nocc = wfn.nelec // 2
+    ham = FakeHamiltonian(np.ones((2, 2)), np.ones((2, 2, 2, 2)))
+    obj = FakeSchrodinger(wfn, ham)
+
+    # build fake pyci hamiltonian
+    energy_nuc = 0.0
+    pyci_ham = pyci.hamiltonian(energy_nuc, ham.one_int, ham.two_int)
+
+    # build pyci wavefunction 
+    # use FCI pspace wavefunction
+    pyci_wfn = pyci.fullci_wfn(pyci_ham.nbasis, wfn.nelec - nocc, nocc)
+
+    defaults = {
+        "fanpy_objective" : obj,
+        "ham" : pyci_ham,
+        "wfn" : pyci_wfn,
+        "nocc" : 2,
+        "seniority": wfn.seniority,
+        "nproj": 1,
+        "fill": "excitation",
+        "mask": np.ones(wfn.params.shape, dtype=int),
+        "constraints": {},
+        "param_selection": obj.indices_component_params,
+        "norm_param": None,
+        "norm_det": None,
+        "objective_type": "projected",
+        "max_memory": 8000,
+        "step_print": False,
+        "step_save": False,
+        "tmpfile": ""
+    }
+    defaults.update(overrides)
+    return ProjectedSchrodingerFanCI(**defaults)
+
+################# init tests ###################################
+def test_init():
+    # errors
+    ham = "non_pyci_hamiltonian"
+    with pytest.raises(TypeError):
+        make_test_instance(ham=ham)
+    fanpy_ham = FakeHamiltonian(np.ones((2, 2)), np.ones((2, 2, 2, 2)))
+    with pytest.raises(TypeError):
+        make_test_instance(fanpy_ham=fanpy_ham)
+
+    # normalization constraints
+    # default is normalization constraint. 
+    # Note: the constraint attribute is just the keys of the constraints dictionary. This is a PyCI feature, not a Fanpy feature. 
+    constraints = None
+    norm_det  = None
+    pyci_obj = make_test_instance(constraints=constraints, norm_det=norm_det)
+    assert type(pyci_obj.constraints) == tuple
+    assert "<\\Phi|\\Psi> - 1>" in pyci_obj.constraints
+
+################# compute overlap tests ###################################
+
+def test_compute_overlap():
+    pyci_obj = make_test_instance()
+
+    # compute overlap between the pyci wavefunction and a random vector
+    # occ indices are the p-space:
+    overlap = pyci_obj.compute_overlap(np.random.rand(4), "P")
+    olp_size = len(pyci_obj.pspace) # note p-space contains occ indices
+    assert len(overlap) == olp_size
+    assert np.allclose(overlap, np.ones(olp_size))
+
+    # compute overlap between the pyci wavefunction and a random vector
+    # occ indices are the s-space:
+    overlap = pyci_obj.compute_overlap(np.random.rand(4), "S")
+    olp_size = len(pyci_obj.sspace) # note s-space contains occ indices
+    assert len(overlap) == len(pyci_obj.sspace)
+    assert np.allclose(overlap, np.ones(olp_size))
+
+    # compute overlap between the pyci wavefunction and a random vector
+    occ_indices = np.asarray([[0, 1]]) # use DOCI occs representation
+    overlap = pyci_obj.compute_overlap(np.random.rand(4), occ_indices)
+    olp_size = len(occ_indices) 
+    assert overlap.shape == (olp_size,)
+    assert np.allclose(overlap, np.ones(olp_size))
+
+    # compute overlap between the pyci wavefunction and a random vector
+    occ_indices = np.asarray([[[0, 1], [1, 0]], [[1, 1], [0, 0]]]) # use FCI occs representation, with two sd dets
+    overlap = pyci_obj.compute_overlap(np.random.rand(4), occ_indices)
+    olp_size = len(occ_indices) 
+    assert overlap.shape == (olp_size,)
+    assert np.allclose(overlap, np.ones(olp_size))
+
+def test_compute_overlap_type_check():
+    pyci_obj = make_test_instance()
+    with pytest.raises(ValueError):
+        pyci_obj.compute_overlap(np.array([[0, 1]]), "not_a_vector")
+
+
+################# compute overlap deriv tests ###################################
+
+def test_compute_overlap_deriv():
+    pyci_obj = make_test_instance()
+    # compute overlap derivatives between the pyci wavefunction and a random vector
+    overlap_deriv = pyci_obj.compute_overlap_deriv(np.random.rand(4), "P")
+    assert overlap_deriv.shape == (len(pyci_obj.pspace), pyci_obj.nactive - pyci_obj.mask[-1])
+    assert np.allclose(overlap_deriv, np.zeros(overlap_deriv.shape))
+
+    # compute overlap derivatives between the pyci wavefunction and a random vector
+    overlap_deriv = pyci_obj.compute_overlap_deriv(np.random.rand(4), "S")
+    assert overlap_deriv.shape == (len(pyci_obj.sspace), pyci_obj.nactive - pyci_obj.mask[-1])
+    assert np.allclose(overlap_deriv, np.zeros(overlap_deriv.shape))
+
+    # compute overlap derivatives between the pyci wavefunction and a random vector
+    occs_array = np.asarray([[0, 1]])
+    overlap_deriv = pyci_obj.compute_overlap_deriv(np.random.rand(4), occs_array=occs_array)
+    assert overlap_deriv.shape == (len(occs_array), pyci_obj.nactive - pyci_obj.mask[-1])
+    assert np.allclose(overlap_deriv, np.zeros(overlap_deriv.shape))
+
+def test_compute_overlap_deriv_type_check():
+    pyci_obj = make_test_instance()
+    with pytest.raises(ValueError):
+        pyci_obj.compute_overlap_deriv(np.array([[0, 1]]), "not_a_vector")
+
+################# compute overlap double derivtests ###################################
+
+def test_compute_overlap_double_deriv_errors():
+    pyci_obj = make_test_instance()
+    with pytest.raises(ValueError):
+        pyci_obj.compute_overlap_double_deriv(np.random.rand(4), "not_a_vector")
+    # double deriv is only implemented for CC as of now. 
+    with pytest.raises(NotImplementedError):
+        pyci_obj.compute_overlap_double_deriv(np.random.rand(4), "P")
+
+def test_compute_overlap_double_deriv():
+
+    # build python objective with CC wfn
+    wfn = FakeCC(nelec=2, nspin=4)
+    ham = FakeHamiltonian(np.ones((2, 2)), np.ones((2, 2, 2, 2)))
+    obj = FakeSchrodinger(wfn, ham)
+    pyci_obj = make_test_instance(fanpy_objective=obj)
+
+    # pspace double derivatives
+    double_deriv = pyci_obj.compute_overlap_double_deriv(np.random.rand(4), "P")
+    assert double_deriv.shape == (len(pyci_obj.pspace), wfn.nparams, wfn.nparams)
+    assert np.allclose(double_deriv, np.ones((len(pyci_obj.pspace), wfn.nparams, wfn.nparams)))
+
+    # sspace double derivatives
+    double_deriv = pyci_obj.compute_overlap_double_deriv(np.random.rand(4), "S")
+    assert double_deriv.shape == (len(pyci_obj.sspace), wfn.nparams, wfn.nparams)
+    assert np.allclose(double_deriv, np.ones((len(pyci_obj.sspace), wfn.nparams, wfn.nparams)))
+
+    # FCI occs vector double derivatives
+    occ_indices = np.asarray([[[0, 1], [1, 0]], [[1, 1], [0, 0]]]) # use FCI occs representation, with two sd dets
+    double_deriv = pyci_obj.compute_overlap_double_deriv(np.random.rand(4), occs_array=occ_indices)
+    assert double_deriv.shape == (len(occ_indices), wfn.nparams, wfn.nparams)
+    assert np.allclose(double_deriv, np.ones((len(occ_indices), wfn.nparams, wfn.nparams)))
+
+################# compute objective tests ###################################
+
+
+################# compute jacobian tests ###################################
+
+# compute masked jacobian tests
+# Mock the following: 
+# self.ci_op
+# compute overlap
+# compute overlap derivative 
+# that simplifies the testing procedure. 
+
+
+################# optimize tests ###################################
+
+
+################# utility methods tests ###################################

--- a/tests/test_interface_fanci_pyci.py
+++ b/tests/test_interface_fanci_pyci.py
@@ -9,6 +9,7 @@ import pyci
 from test_interface_pyci import FakeHamiltonian, FakeWavefunction
 
 from fanpy.eqn.projected import BaseSchrodinger
+from fanpy.wfn.cc.standard_cc import StandardCC
 
 class FakeSchrodinger(BaseSchrodinger):
     """fake fanpy objective for testing purposes"""
@@ -16,6 +17,17 @@ class FakeSchrodinger(BaseSchrodinger):
         super().__init__(wfn, ham)
     def objective(self, params):
         return 3.08
+
+class FakeCC(StandardCC):
+    """fake CC wavefunction for testing purposes
+    This is used to test the double derivative of the overlap.
+    """
+    def __init__(self, nelec, nspin):
+        super().__init__(nelec, nspin)
+
+    def get_overlap_double_derivative(self, sd):
+        double_deriv = np.ones((self.nparams, self.nparams))
+        return double_deriv
 
 def make_test_instance(**overrides):
     """make test instance of ProjectedSchrodingerPyCI with fake fanpy objective and fake pyci hamiltonian and wavefunction
@@ -115,3 +127,35 @@ def test_compute_overlap_deriv_type_check():
     pyci_obj = make_test_instance()
     with pytest.raises(ValueError):
         pyci_obj.compute_overlap_deriv(np.array([[0, 1]]), "not_a_vector")
+
+def test_compute_overlap_double_deriv_errors():
+    pyci_obj = make_test_instance()
+    with pytest.raises(ValueError):
+        pyci_obj.compute_overlap_double_deriv(np.random.rand(4), "not_a_vector")
+    # double deriv is only implemented for CC as of now. 
+    with pytest.raises(NotImplementedError):
+        pyci_obj.compute_overlap_double_deriv(np.random.rand(4), "P")
+
+def test_compute_overlap_double_deriv():
+
+    # build python objective with CC wfn
+    wfn = FakeCC(nelec=2, nspin=4)
+    ham = FakeHamiltonian(np.ones((2, 2)), np.ones((2, 2, 2, 2)))
+    obj = FakeSchrodinger(wfn, ham)
+    pyci_obj = make_test_instance(fanpy_objective=obj)
+
+    # pspace double derivatives
+    double_deriv = pyci_obj.compute_overlap_double_deriv(np.random.rand(4), "P")
+    assert double_deriv.shape == (len(pyci_obj.pspace), wfn.nparams, wfn.nparams)
+    assert np.allclose(double_deriv, np.ones((len(pyci_obj.pspace), wfn.nparams, wfn.nparams)))
+
+    # sspace double derivatives
+    double_deriv = pyci_obj.compute_overlap_double_deriv(np.random.rand(4), "S")
+    assert double_deriv.shape == (len(pyci_obj.sspace), wfn.nparams, wfn.nparams)
+    assert np.allclose(double_deriv, np.ones((len(pyci_obj.sspace), wfn.nparams, wfn.nparams)))
+
+    # FCI occs vector double derivatives
+    occ_indices = np.asarray([[[0, 1], [1, 0]], [[1, 1], [0, 0]]]) # use FCI occs representation, with two sd dets
+    double_deriv = pyci_obj.compute_overlap_double_deriv(np.random.rand(4), occs_array=occ_indices)
+    assert double_deriv.shape == (len(occ_indices), wfn.nparams, wfn.nparams)
+    assert np.allclose(double_deriv, np.ones((len(occ_indices), wfn.nparams, wfn.nparams)))

--- a/tests/test_interface_fanci_pyci.py
+++ b/tests/test_interface_fanci_pyci.py
@@ -11,6 +11,8 @@ from test_interface_pyci import FakeHamiltonian, FakeWavefunction
 from fanpy.eqn.projected import BaseSchrodinger
 from fanpy.wfn.cc.standard_cc import StandardCC
 
+############## Tools for testing purposes #########################
+
 class FakeSchrodinger(BaseSchrodinger):
     """fake fanpy objective for testing purposes"""
     def __init__(self, wfn, ham):
@@ -31,6 +33,7 @@ class FakeCC(StandardCC):
 
 def make_test_instance(**overrides):
     """make test instance of ProjectedSchrodingerPyCI with fake fanpy objective and fake pyci hamiltonian and wavefunction
+    This helps set up a class that requires a lot of parameters.
     """
     # build Fake fanpy objective
     wfn = FakeWavefunction(2, 4, np.ones(4))
@@ -68,6 +71,26 @@ def make_test_instance(**overrides):
     defaults.update(overrides)
     return ProjectedSchrodingerPyCI(**defaults)
 
+################# init tests ###################################
+def test_init():
+    # errors
+    ham = "non_pyci_hamiltonian"
+    with pytest.raises(TypeError):
+        make_test_instance(ham=ham)
+    fanpy_ham = FakeHamiltonian(np.ones((2, 2)), np.ones((2, 2, 2, 2)))
+    with pytest.raises(TypeError):
+        make_test_instance(fanpy_ham=fanpy_ham)
+
+    # normalization constraints
+    # default is normalization constraint. 
+    # Note: the constraint attribute is just the keys of the constraints dictionary. This is a PyCI feature, not a Fanpy feature. 
+    constraints = None
+    norm_det  = None
+    pyci_obj = make_test_instance(constraints=constraints, norm_det=norm_det)
+    assert type(pyci_obj.constraints) == tuple
+    assert "<\\Phi|\\Psi> - 1>" in pyci_obj.constraints
+
+################# compute overlap tests ###################################
 
 def test_compute_overlap():
     pyci_obj = make_test_instance()
@@ -105,7 +128,10 @@ def test_compute_overlap_type_check():
     with pytest.raises(ValueError):
         pyci_obj.compute_overlap(np.array([[0, 1]]), "not_a_vector")
 
-def test_compute_overlap_derig():
+
+################# compute overlap deriv tests ###################################
+
+def test_compute_overlap_deriv():
     pyci_obj = make_test_instance()
     # compute overlap derivatives between the pyci wavefunction and a random vector
     overlap_deriv = pyci_obj.compute_overlap_deriv(np.random.rand(4), "P")
@@ -127,6 +153,8 @@ def test_compute_overlap_deriv_type_check():
     pyci_obj = make_test_instance()
     with pytest.raises(ValueError):
         pyci_obj.compute_overlap_deriv(np.array([[0, 1]]), "not_a_vector")
+
+################# compute overlap double derivtests ###################################
 
 def test_compute_overlap_double_deriv_errors():
     pyci_obj = make_test_instance()
@@ -159,3 +187,15 @@ def test_compute_overlap_double_deriv():
     double_deriv = pyci_obj.compute_overlap_double_deriv(np.random.rand(4), occs_array=occ_indices)
     assert double_deriv.shape == (len(occ_indices), wfn.nparams, wfn.nparams)
     assert np.allclose(double_deriv, np.ones((len(occ_indices), wfn.nparams, wfn.nparams)))
+
+################# compute objective tests ###################################
+
+
+################# compute jacobian tests ###################################
+
+
+################# optimize tests ###################################
+
+
+################# utility methods tests ###################################
+

--- a/tests/test_interface_fanci_pyci.py
+++ b/tests/test_interface_fanci_pyci.py
@@ -42,7 +42,7 @@ def make_test_instance(**overrides):
         "seniority": wfn.seniority,
         "nproj": 1,
         "fill": "excitation",
-        "mask": np.ones(wfn.params.shape),
+        "mask": np.ones(wfn.params.shape, dtype=int),
         "constraints": {},
         "param_selection": obj.indices_component_params,
         "norm_param": None,
@@ -92,3 +92,26 @@ def test_compute_overlap_type_check():
     pyci_obj = make_test_instance()
     with pytest.raises(ValueError):
         pyci_obj.compute_overlap(np.array([[0, 1]]), "not_a_vector")
+
+def test_compute_overlap_derig():
+    pyci_obj = make_test_instance()
+    # compute overlap derivatives between the pyci wavefunction and a random vector
+    overlap_deriv = pyci_obj.compute_overlap_deriv(np.random.rand(4), "P")
+    assert overlap_deriv.shape == (len(pyci_obj.pspace), pyci_obj.nactive - pyci_obj.mask[-1])
+    assert np.allclose(overlap_deriv, np.zeros(overlap_deriv.shape))
+
+    # compute overlap derivatives between the pyci wavefunction and a random vector
+    overlap_deriv = pyci_obj.compute_overlap_deriv(np.random.rand(4), "S")
+    assert overlap_deriv.shape == (len(pyci_obj.sspace), pyci_obj.nactive - pyci_obj.mask[-1])
+    assert np.allclose(overlap_deriv, np.zeros(overlap_deriv.shape))
+
+    # compute overlap derivatives between the pyci wavefunction and a random vector
+    occs_array = np.asarray([[0, 1]])
+    overlap_deriv = pyci_obj.compute_overlap_deriv(np.random.rand(4), occs_array=occs_array)
+    assert overlap_deriv.shape == (len(occs_array), pyci_obj.nactive - pyci_obj.mask[-1])
+    assert np.allclose(overlap_deriv, np.zeros(overlap_deriv.shape))
+
+def test_compute_overlap_deriv_type_check():
+    pyci_obj = make_test_instance()
+    with pytest.raises(ValueError):
+        pyci_obj.compute_overlap_deriv(np.array([[0, 1]]), "not_a_vector")

--- a/tests/test_interface_fanci_pyci.py
+++ b/tests/test_interface_fanci_pyci.py
@@ -1,0 +1,63 @@
+""" Test for fanpy.interface.fanci.pyci """
+
+import numpy as np
+
+from fanpy.interface.fanci.pyci import ProjectedSchrodingerPyCI
+import pyci
+
+from test_interface_pyci import FakeHamiltonian, FakeWavefunction
+
+from fanpy.eqn.projected import BaseSchrodinger
+
+class FakeSchrodinger(BaseSchrodinger):
+    """fake fanpy objective for testing purposes"""
+    def __init__(self, wfn, ham):
+        super().__init__(wfn, ham)
+    def objective(self, params):
+        return 3.08
+
+def make_test_instance(**overrides):
+    """make test instance of ProjectedSchrodingerPyCI with fake fanpy objective and fake pyci hamiltonian and wavefunction
+    """
+    # build Fake fanpy objective
+    wfn = FakeWavefunction(2, 4, np.ones(4))
+    nocc = wfn.nelec // 2
+    ham = FakeHamiltonian(np.ones((2, 2)), np.ones((2, 2, 2, 2)))
+    obj = FakeSchrodinger(wfn, ham)
+
+    # build fake pyci hamiltonian
+    energy_nuc = 0.0
+    pyci_ham = pyci.hamiltonian(energy_nuc, ham.one_int, ham.two_int)
+
+    # build pyci wavefunction 
+    # use FCI pspace wavefunction
+    pyci_wfn = pyci.fullci_wfn(pyci_ham.nbasis, wfn.nelec - nocc, nocc)
+
+    defaults = {
+        "fanpy_objective" : obj,
+        "ham" : pyci_ham,
+        "wfn" : pyci_wfn,
+        "nocc" : 2,
+        "seniority": wfn.seniority,
+        "nproj": 1,
+        "fill": "excitation",
+        "mask": np.ones(wfn.params.shape),
+        "constraints": {},
+        "param_selection": obj.indices_component_params,
+        "norm_param": None,
+        "norm_det": None,
+        "objective_type": "projected",
+        "max_memory": 8000,
+        "step_print": False,
+        "step_save": False,
+        "tmpfile": ""
+    }
+    defaults.update(overrides)
+    return ProjectedSchrodingerPyCI(**defaults)
+
+
+def test_compute_overlap():
+    pyci_obj = make_test_instance()
+    overlap = pyci_obj.compute_overlap(np.random.rand(4), "P")
+    assert overlap[0] == 1.0
+

--- a/tests/test_interface_fanci_pyci.py
+++ b/tests/test_interface_fanci_pyci.py
@@ -193,6 +193,13 @@ def test_compute_overlap_double_deriv():
 
 ################# compute jacobian tests ###################################
 
+# compute masked jacobian tests
+# Mock the following: 
+# self.ci_op
+# compute overlap
+# compute overlap derivative 
+# that simplifies the testing procedure. 
+
 
 ################# optimize tests ###################################
 

--- a/tests/test_interface_fanci_pyci.py
+++ b/tests/test_interface_fanci_pyci.py
@@ -1,6 +1,7 @@
 """ Test for fanpy.interface.fanci.pyci """
 
 import numpy as np
+import pytest
 
 from fanpy.interface.fanci.pyci import ProjectedSchrodingerPyCI
 import pyci
@@ -86,3 +87,8 @@ def test_compute_overlap():
     olp_size = len(occ_indices) 
     assert overlap.shape == (olp_size,)
     assert np.allclose(overlap, np.ones(olp_size))
+
+def test_compute_overlap_type_check():
+    pyci_obj = make_test_instance()
+    with pytest.raises(ValueError):
+        pyci_obj.compute_overlap(np.array([[0, 1]]), "not_a_vector")

--- a/tests/test_interface_fanci_pyci.py
+++ b/tests/test_interface_fanci_pyci.py
@@ -58,6 +58,31 @@ def make_test_instance(**overrides):
 
 def test_compute_overlap():
     pyci_obj = make_test_instance()
-    overlap = pyci_obj.compute_overlap(np.random.rand(4), "P")
-    assert overlap[0] == 1.0
 
+    # compute overlap between the pyci wavefunction and a random vector
+    # occ indices are the p-space:
+    overlap = pyci_obj.compute_overlap(np.random.rand(4), "P")
+    olp_size = len(pyci_obj.pspace) # note p-space contains occ indices
+    assert len(overlap) == olp_size
+    assert np.allclose(overlap, np.ones(olp_size))
+
+    # compute overlap between the pyci wavefunction and a random vector
+    # occ indices are the s-space:
+    overlap = pyci_obj.compute_overlap(np.random.rand(4), "S")
+    olp_size = len(pyci_obj.sspace) # note s-space contains occ indices
+    assert len(overlap) == len(pyci_obj.sspace)
+    assert np.allclose(overlap, np.ones(olp_size))
+
+    # compute overlap between the pyci wavefunction and a random vector
+    occ_indices = np.asarray([[0, 1]]) # use DOCI occs representation
+    overlap = pyci_obj.compute_overlap(np.random.rand(4), occ_indices)
+    olp_size = len(occ_indices) 
+    assert overlap.shape == (olp_size,)
+    assert np.allclose(overlap, np.ones(olp_size))
+
+    # compute overlap between the pyci wavefunction and a random vector
+    occ_indices = np.asarray([[[0, 1], [1, 0]], [[1, 1], [0, 0]]]) # use FCI occs representation, with two sd dets
+    overlap = pyci_obj.compute_overlap(np.random.rand(4), occ_indices)
+    olp_size = len(occ_indices) 
+    assert overlap.shape == (olp_size,)
+    assert np.allclose(overlap, np.ones(olp_size))


### PR DESCRIPTION
This pull request refactors both the `legacy.py` and `pyci.py` FanCI interface modules to streamline the conversion of occupation arrays to Slater determinants. It removes the `energy` (aka variational-like) objective code, since the classes are for the projected Schrodinger equation. The PR removes unused imports and redundant code.

**Refactoring and code simplification:**

* Replaced repeated logic for converting occupation arrays to Slater determinants with a single utility function, `convert_pyci_occs_to_fanpy_sds`, in all relevant methods (`compute_overlap`, `compute_overlap_deriv`, and `compute_overlap_double_deriv`) in both `legacy.py` and `pyci.py`. [[1]](diffhunk://#diff-12bcf8faea5d22e41771f2238130299a94b06b24b400cdd05e116524097d5182L1116-R1117) [[2]](diffhunk://#diff-12bcf8faea5d22e41771f2238130299a94b06b24b400cdd05e116524097d5182L1186-R1171) [[3]](diffhunk://#diff-12bcf8faea5d22e41771f2238130299a94b06b24b400cdd05e116524097d5182L1283-R1252) [[4]](diffhunk://#diff-601fb5651b38ec9d6e7964daedee4667114b198c624c89ced219abb81d180becL304-R306) [[5]](diffhunk://#diff-601fb5651b38ec9d6e7964daedee4667114b198c624c89ced219abb81d180becL374-R360) [[6]](diffhunk://#diff-601fb5651b38ec9d6e7964daedee4667114b198c624c89ced219abb81d180becL454-L459)
* Removed the import and usage of the `slater` module in both files, as its functionality is now encapsulated in the utility function. [[1]](diffhunk://#diff-12bcf8faea5d22e41771f2238130299a94b06b24b400cdd05e116524097d5182L6-R10) [[2]](diffhunk://#diff-601fb5651b38ec9d6e7964daedee4667114b198c624c89ced219abb81d180becL2-R12)
* Removed unused imports, specifically `cma`, `minimize`, and related optimization methods. Note that these methods do not work with the Projected Schrodinger objective. They will be added to the variational interface class. The supported optimization modes are `'root'` and `'lstsq'` for the `ProjectedSchrodingerFanCI` class. [[1]](diffhunk://#diff-12bcf8faea5d22e41771f2238130299a94b06b24b400cdd05e116524097d5182L22-R22) [[2]](diffhunk://#diff-601fb5651b38ec9d6e7964daedee4667114b198c624c89ced219abb81d180becL21-R23) [[3]](diffhunk://#diff-12bcf8faea5d22e41771f2238130299a94b06b24b400cdd05e116524097d5182L1599-R1475)

**API and logic changes:**

* Simplified the `compute_objective` and `compute_jacobian` methods in `legacy.py` by removing the code paths for the `'energy'` objective type, focusing exclusively on the `'projected'` objective. [[1]](diffhunk://#diff-12bcf8faea5d22e41771f2238130299a94b06b24b400cdd05e116524097d5182L1334) [[2]](diffhunk://#diff-12bcf8faea5d22e41771f2238130299a94b06b24b400cdd05e116524097d5182L1346-L1367) [[3]](diffhunk://#diff-12bcf8faea5d22e41771f2238130299a94b06b24b400cdd05e116524097d5182L1391-L1450)
* Fixed argument handling in `compute_overlap_double_deriv` to clarify the logic for string and array inputs. [[1]](diffhunk://#diff-12bcf8faea5d22e41771f2238130299a94b06b24b400cdd05e116524097d5182L1266-L1271) [[2]](diffhunk://#diff-601fb5651b38ec9d6e7964daedee4667114b198c624c89ced219abb81d180becL454-L459)

**Documentation and comments:**

* Updated class docstrings to clarify the role of `pyci.py` as the Projected Schrodinger objective class for PyCI.
* Added or updated TODO comments for future improvements and clarifications. [[1]](diffhunk://#diff-12bcf8faea5d22e41771f2238130299a94b06b24b400cdd05e116524097d5182L277-R275) [[2]](diffhunk://#diff-12bcf8faea5d22e41771f2238130299a94b06b24b400cdd05e116524097d5182L532-R530) [[3]](diffhunk://#diff-12bcf8faea5d22e41771f2238130299a94b06b24b400cdd05e116524097d5182R581) [[4]](diffhunk://#diff-12bcf8faea5d22e41771f2238130299a94b06b24b400cdd05e116524097d5182R654) [[5]](diffhunk://#diff-12bcf8faea5d22e41771f2238130299a94b06b24b400cdd05e116524097d5182R694) [[6]](diffhunk://#diff-601fb5651b38ec9d6e7964daedee4667114b198c624c89ced219abb81d180becR185)