### PR TITLE
Merge relevant functionality from pccd_ap1rog_NEW into old PCCD imple…

### DIFF
--- a/fanpy/wfn/cc/ap1rog_generalized.py
+++ b/fanpy/wfn/cc/ap1rog_generalized.py
@@ -5,19 +5,72 @@ from fanpy.wfn.cc.pccd_ap1rog import PCCD
 
 
 class AP1roGSDGeneralized(PCCD):
-    r"""AP1roG wavefunction with single and double excitations, broken spin symmetry.
+    r"""AP1roG wavefunction with single excitations allowing broken spinsymmetry and paired-double excitations.
+    
+    NOTE: 
+    The excitation operator pool in this wavefunction consists of paired doubles 
+    inherited from PCCD together with generalized single excitations over all spin orbitals.
 
     .. math::
 
-        \left| {{\Psi }_{APG1roSD}} \right\rangle =\prod\limits_{i=1}^{N/2\;}
-        {\left( 1+\sum\limits_{a,b\in virt}^{{}}{{{t}_{i;ab}}\hat{\tau }_{i\bar{i}}^{ab}}
-        \right)}\prod\limits_{i=1}^{N/2\;}{\left( 1+\sum\limits_{a\in virt}^{{}}{{{t}_{\bar{i};a}}
-        \hat{\tau }_{i\bar{i}}^{ia}} \right)\prod\limits_{i=1}^{N/2\;}
-        {\left( 1+\sum\limits_{a\in virt}^{{}}{{{t}_{i;a}}\hat{\tau }_{i\bar{i}}^{a\bar{i}}}
-        \right)}\left| {{\Phi }_{0}} \right\rangle }
+    \left| \Psi_{\mathrm{AP1roGSDGeneralized}} \right\rangle = \prod_{\mu \in \mathcal{E}} 
+    \left( 1 + t_\mu \tilde{\tau}_\mu \right) \left| \Phi_0 \right\rangle
 
-    In this case the reference wavefunction can only be a single Slater determinant with
-    seniority 0.
+    where
+
+    .. math::
+
+    \mathcal{E} = \left\{\tau_p^q, \tau_{i\bar{i}}^{a\bar{a}} \right\}
+
+    The excitation operator pool :math:\mathcal{E} consists of
+        - generalized single excitations
+          :math:(\tau_p^q)
+        - paired double excitations
+          :math:(\tau_{i\bar{i}}^{a\bar{a}})
+
+    generated from the reference determinant.
+
+    Unlike :class:AP1roGSDSpin, the generalized single excitations are not
+    restricted to spin-conserving excitations. Consequently, this ansatz allows
+        - broken spin symmetry,
+        - spin-flip excitations,
+        - spin-contaminated determinants.
+
+    The effective single excitation operators :math:\tilde{\tau} may additionally be 
+    constrained during overlap evaluation through the s_type option implemented in the PCCD wavefunction class.
+
+
+    sen-o: Require breaking an occupied pair
+
+    .. math::
+
+        \tilde{\tau}_p^q = a_q^\dagger a_p \hat{n}_{\bar{p}}
+
+    sen-v: Forbid formation of virtual pairs
+
+    .. math::
+
+        \tilde{\tau}_p^q = a_q^\dagger a_p
+        \left( 1 - \hat{n}_{\bar{q}} \right)
+
+    sen-ov: Apply both restrictions
+
+    .. math::
+
+        \tilde{\tau}_p^q = a_q^\dagger a_p
+        \left(1 - \hat{n}_{\bar{q}} \right) \hat{n}_{\bar{p}}
+
+    free: No seniority restrictions
+
+    .. math::
+
+        \tilde{\tau}_p^q = a_q^\dagger a_p
+
+    These restrictions are enforced dynamically during excitation-operator
+    combination filtering during overlap evaluation and are not encoded
+    directly into the stored excitation operators.
+
+    The reference wavefunction must be a seniority-0 Slater determinant.
 
     Attributes
     ----------

--- a/fanpy/wfn/cc/ap1rog_spin.py
+++ b/fanpy/wfn/cc/ap1rog_spin.py
@@ -1,23 +1,73 @@
-"""APG1ro wavefunction with single and double excitations."""
+"""AP1roG wavefunction with single and double excitations."""
 
 from fanpy.tools import slater
 from fanpy.wfn.cc.pccd_ap1rog import PCCD
 
 
 class AP1roGSDSpin(PCCD):
-    r"""AP1roG wavefunction with single and double excitations, correct spin symmetry.
+    r"""AP1roG wavefunction with single and paired-double excitations, both preserving spin symmetry.
+    
+    NOTE: The excitation operator pool in this wavefunction consists of paired doubles 
+    inherited from PCCD together with spin-conserving single excitations.
 
     .. math::
 
-        \left| {{\Psi }_{APG1roSD}} \right\rangle =\prod\limits_{i=1}^{N/2\;}
-        {\left( 1+\sum\limits_{a,b\in virt}^{{}}{{{t}_{i;ab}}\hat{\tau }_{i\bar{i}}^{ab}}
-        \right)}\prod\limits_{i=1}^{N/2\;}{\left( 1+\sum\limits_{a\in virt}^{{}}{{{t}_{\bar{i};a}}
-        \hat{\tau }_{i\bar{i}}^{ia}} \right)\prod\limits_{i=1}^{N/2\;}
-        {\left( 1+\sum\limits_{a\in virt}^{{}}{{{t}_{i;a}}\hat{\tau }_{i\bar{i}}^{a\bar{i}}}
-        \right)}\left| {{\Phi }_{0}} \right\rangle }
+    \left| \Psi _{\mathrm{AP1roGSDSpin}} \right\rangle = \prod _{\mu \in \mathcal{E}} 
+        \left( 1+t_{\mu }\tilde{\tau }_{\mu }\right)| \Phi _{0} \rangle
 
-    In this case the reference wavefunction can only be a single Slater determinant with
-    seniority 0.
+    where, 
+
+    .. math::
+    
+    \mathcal{E} = \left\{\tau_i^a,\tau_{\bar{i}}^{\bar{a}},\tau_{i\bar{i}}^{a\bar{a}}\right\}
+        
+    The excitation operator pool :math:\mathcal{E} consists of
+        - spin-conserving single excitations
+        :math:(\tau_i^a,\tau_{\bar{i}}^{\bar{a}})
+        - paired double excitations
+        :math:(\tau_{i\bar{i}}^{a\bar{a}})
+    generated from the reference determinant.
+    
+    The effective single excitation operators :math:\tilde{\tau} may additionally be 
+    constrained during overlap evaluation through the s_type option implemented in the PCCD wavefunction class.
+
+    sen-o  : Require breaking an occupied pair 
+    
+    .. math::
+
+        \tilde{\tau}_i^a = a_a^\dagger a_i \, \hat{n}_{\bar{i}}, 
+        \qquad 
+        \tilde{\tau}_{\bar{i}}^{\bar{a}} = a_{\bar{a}}^\dagger a_{\bar{i}} \, \hat{n}_i 
+
+    sen-v  : Forbid formation of virtual pairs
+
+    .. math::
+
+        \tilde{\tau}_i^a = a_a^\dagger a_i \left(1 - \hat{n}_{\bar{a}}\right), 
+        \qquad
+        \tilde{\tau}_{\bar{i}}^{\bar{a}} = a_{\bar{a}}^\dagger a_{\bar{i}} \left(1 - \hat{n}_a\right)
+
+    sen-ov : Apply both above restrictions
+
+    .. math::
+
+        \tilde{\tau}_i^a = a_a^\dagger a_i \left(1 - \hat{n}_{\bar{a}} \right) \hat{n}_{\bar{i}}, 
+        \qquad 
+        \tilde{\tau}_{\bar{i}}^{\bar{a}} = a_{\bar{a}}^\dagger a_{\bar{i}} 
+            \left(1 - \hat{n}_a \right) \hat{n}_i
+
+    free : No seniority restrictions
+
+    .. math::
+
+        \tilde{\tau}_i^a = a_a^\dagger a_i, 
+        \qquad 
+        \tilde{\tau}_{\bar{i}}^{\bar{a}} = a_{\bar{a}}^\dagger a_{\bar{i}} \]
+
+    These restrictions are enforced dynamically during excitation-operator combination filtering 
+    during overlap evaluation and are not encoded directly into the stored excitation operators.
+
+    The reference wavefunction can only be a single Slater determinant with seniority-0.
 
     Attributes
     ----------
@@ -143,6 +193,10 @@ class AP1roGSDSpin(PCCD):
         spin-orbitals to create.
         [a1, a2, ..., aN, c1, c2, ..., cN]
 
+
+        This method constructs only a static pool of excitation operators derived from 
+        the reference determinant. The overlap routines later generate compatible combinations 
+        of these excitation operators during determinant connections.
         """
         if indices is not None:
             raise TypeError(

--- a/fanpy/wfn/cc/apg1ro_d.py
+++ b/fanpy/wfn/cc/apg1ro_d.py
@@ -5,16 +5,66 @@ from fanpy.wfn.cc.pccd_ap1rog import PCCD
 
 
 class APG1roD(PCCD):
-    r"""APG1ro wavefunction with only double excitations.
+    r"""APG1ro wavefunction with generalized double excitations.
+
+    NOTE:
+    The excitation operator pool in this wavefunction consists exclusively
+    of double excitations that always annihilate paired occupied electron pairs 
+    :math: `(i, \bar{i})`, while the created virtual spin orbitals 
+    :math: `(p, q)` are unrestricted for their spin and spatial part.
 
     .. math::
 
-        \[\left| {{\Psi }_{APG1roD}} \right\rangle =\prod\limits_{i=1}^{N/2\;}
-        {\left( 1+\sum\limits_{a,b\in virt}^{{}}
-        {{{t}_{i;ab}}\hat{\tau }_{i\bar{i}}^{ab}} \right)}\left| {{\Phi }_{0}} \right\rangle \]
+    \left| \Psi_{\mathrm{APG1roD}} \right\rangle 
+    = \prod_{\mu \in \mathcal{E}}
+    \left(1 + t_\mu \tau_\mu \right) \left| \Phi_0 \right\rangle
 
-    In this case the reference wavefunction can only be a single Slater determinant with
-    seniority 0.
+    where
+
+    .. math::
+
+    \mathcal{E} = \left\{\tau_{i\bar{i}}^{pq} \right\}
+
+    The excitation operator pool :math:\mathcal{E} consists of generalized
+    double excitations that
+        - annihilate paired occupied orbitals
+          :math:(i\bar{i})
+        - create electrons in arbitrary virtual spin orbitals
+          :math:(pq)
+
+    generated from the reference determinant.
+
+    Consequently, the ansatz includes both
+        - pair-preserving double excitations
+
+        .. math::
+
+        \tau_{i\bar{i}}^{a\bar{a}}
+
+        - and pair-breaking double excitations
+
+        .. math::
+
+        \tau_{i\bar{i}}^{ab}
+
+        where :math:b \neq \bar{a}.
+
+    Unlike AP1roG/PCCD, the virtual excitation space is not restricted to
+    paired spin complements. Consequently, this ansatz may break spin symmetry
+    and generate spin-contaminated determinants.
+
+    Although this class inherits the s_type infrastructure from PCCD,
+    the seniority-filtering conditions do not affect the present ansatz
+    because the excitation operator pool contains only double excitations.
+
+    This method constructs only a static pool of excitation operators
+    derived from the reference determinant.
+
+    The overlap routines later generate compatible combinations of these
+    excitation operators during determinant connections.
+
+    The reference wavefunction must be a seniority-0 Slater determinant.
+
 
     Attributes
     ----------

--- a/fanpy/wfn/cc/apg1ro_sd.py
+++ b/fanpy/wfn/cc/apg1ro_sd.py
@@ -5,19 +5,94 @@ from fanpy.wfn.cc.apg1ro_d import APG1roD
 
 
 class APG1roSD(APG1roD):
-    r"""APG1ro wavefunction with single and double excitations.
+    r"""APG1ro wavefunction with generalized single and double excitations.
+
+    NOTE:
+    The excitation operator pool in this wavefunction consists of
+    generalized single excitations together with generalized double
+    excitations inherited from APG1roD.
+
+    .. math::
+    \left| \Psi_{\mathrm{APG1roSD}} \right\rangle = 
+    \prod_{\mu \in \mathcal{E}} 
+    \left(1 + t_\mu \tilde{\tau}_\mu \right) \left| \Phi_0 \right\rangle
+
+    where
 
     .. math::
 
-        \left| {{\Psi }_{APG1roSD}} \right\rangle =\prod\limits_{i=1}^{N/2\;}
-        {\left( 1+\sum\limits_{a,b\in virt}^{{}}{{{t}_{i;ab}}\hat{\tau }_{i\bar{i}}^{ab}}
-        \right)}\prod\limits_{i=1}^{N/2\;}{\left( 1+\sum\limits_{a\in virt}^{{}}{{{t}_{\bar{i};a}}
-        \hat{\tau }_{i\bar{i}}^{ia}} \right)\prod\limits_{i=1}^{N/2\;}
-        {\left( 1+\sum\limits_{a\in virt}^{{}}{{{t}_{i;a}}\hat{\tau }_{i\bar{i}}^{a\bar{i}}}
-        \right)}\left| {{\Phi }_{0}} \right\rangle }
+    \mathcal{E} = \left\{\tau_p^q, \tau_{i\bar{i}}^{rs} \right\}
 
-    In this case the reference wavefunction can only be a single Slater determinant with
-    seniority 0.
+    The excitation operator pool :math:\mathcal{E} consists of
+        - generalized single excitations
+          :math:(\tau_p^q)
+        - generalized double excitations
+          :math:(\tau_{i\bar{i}}^{rs})
+
+    generated from the reference determinant.
+
+    The generalized doubles always annihilate paired occupied spin
+    complements :math:(i,\bar{i}), while allowing generalized creation
+    into arbitrary virtual spin orbitals :math:(r,s).
+
+    Consequently, the ansatz includes both
+        - pair-preserving double excitations
+        .. math::
+        \tau_{i\bar{i}}^{a\bar{a}}
+
+        - and pair-breaking double excitations
+        .. math::
+        \tau_{i\bar{i}}^{ab}
+        where :math:b \neq \bar{a}.
+
+    Unlike AP1roGSDSpin, the generalized single excitations are not
+    restricted to spin-conserving excitations. Consequently, this ansatz allows
+        - broken spin symmetry,
+        - spin-flip excitations,
+        - and spin-contaminated determinants.
+
+    The effective single excitation operators :math:\tilde{\tau} may
+    additionally be constrained during overlap evaluation through the
+    s_type option implemented in the PCCD wavefunction class.
+
+    sen-o: Require breaking an occupied pair
+
+    .. math::
+
+        \tilde{\tau}_p^q = a_q^\dagger a_p \hat{n}_{\bar{p}}
+
+    sen-v: Forbid formation of virtual pairs
+
+    .. math::
+
+        \tilde{\tau}_p^q =
+        a_q^\dagger a_p \left(1 - \hat{n}_{\bar{q}} \right)
+
+    sen-ov: Apply both restrictions
+
+    .. math::
+
+        \tilde{\tau}_p^q = a_q^\dagger a_p \left(1 - \hat{n}_{\bar{q}} \right)
+        \hat{n}_{\bar{p}}
+
+    free: No seniority restrictions
+
+    .. math::
+
+        \tilde{\tau}_p^q = a_q^\dagger a_p
+
+    These restrictions are enforced dynamically during excitation-operator
+    combination filtering during overlap evaluation and are not encoded
+    directly into the stored excitation operators.
+
+    This method constructs only a static pool of excitation operators
+    derived from the reference determinant.
+
+    The overlap routines later generate compatible combinations of these
+    excitation operators during determinant connections.
+
+    The reference wavefunction must be a seniority-0 Slater determinant.
+
 
     Attributes
     ----------

--- a/fanpy/wfn/cc/apset1rog_d.py
+++ b/fanpy/wfn/cc/apset1rog_d.py
@@ -5,18 +5,60 @@ from fanpy.wfn.cc.pccd_ap1rog import PCCD
 
 
 class APset1roGD(PCCD):
-    r"""APset1roG wavefunction with only double excitations.
+    r"""APset1roG wavefunction with set-restricted double excitations.
+
+    NOTE:
+    The excitation operator pool in this wavefunction consists exclusively
+    of double excitations that annihilate paired occupied spin orbitals
+    while creating electrons into two disjoint sets of virtual spin orbitals.
 
     .. math::
 
-        \left| {{\Psi }_{APset1roGD}} \right\rangle =\prod\limits_{i=1}^{N/2\;}
-        {\left( 1+\sum\limits_{\begin{smallmatrix}a\in A \\ b\in B \\ A\bigcap B=\varnothing
-        \end{smallmatrix}}^{{}}{{{t}_{i;ab}}\hat{\tau }_{i\bar{i}}^{ab}}
-        \right)}\left| {{\Phi }_{0}} \right\rangle
+    \left| \Psi_{\mathrm{APset1roGD}} \right\rangle
+    =  \prod_{\mu \in \mathcal{E}}
+    \left( 1 + t_\mu \tau_\mu \right)
+    \left| \Phi_0 \right\rangle
 
+    where
 
-    In this case the reference wavefunction can only be a single Slater determinant with
-    seniority 0.
+    .. math::
+
+    \mathcal{E} = \left\{\tau_{i\bar{i}}^{ab}
+    \; \middle| \; a \in A,\; b \in B,\; A \cap B = \varnothing
+    \right\}
+
+    The excitation operator pool :math:\mathcal{E} consists of generalized
+    double excitations that
+        - annihilate paired occupied spin complements
+          :math:(i,\bar{i})
+        - create electrons into two disjoint sets of virtual spin orbitals
+          :math:(A,B)
+    generated from the reference determinant.
+
+    By default,
+    :math:A corresponds to virtual alpha spin orbitals,
+    :math:B corresponds to virtual beta spin orbitals,
+    thereby preserving spin projection symmetry.
+
+    Custom disjoint virtual sets may also be supplied through the
+    indices argument of :meth:assign_exops.
+
+    Unlike APG1roD, the virtual excitation space is constrained through
+    the disjoint-set structure :math:A \cap B = \varnothing, preventing
+    both created electrons from occupying the same virtual spin orbital set.
+
+    Although this class inherits the s_type infrastructure from PCCD,
+    the seniority-filtering conditions do not affect the present ansatz
+    because the excitation operator pool contains only double excitations.
+
+    This method constructs only a static pool of excitation operators
+    derived from the reference determinant.
+
+    The overlap routines later generate compatible combinations of these
+    excitation operators during determinant connections.
+
+    The reference wavefunction must be a seniority-0 Slater determinant.
+
 
     Attributes
     ----------

--- a/fanpy/wfn/cc/apset1rog_sd.py
+++ b/fanpy/wfn/cc/apset1rog_sd.py
@@ -5,22 +5,102 @@ from fanpy.wfn.cc.apset1rog_d import APset1roGD
 
 
 class APset1roGSD(APset1roGD):
-    r"""APset1roG wavefunction with single and double excitations.
+    r"""AAPset1roG wavefunction with set-restricted single and double excitations.
+
+    NOTE:
+    The excitation operator pool in this wavefunction consists of
+    set-restricted spin-conserving single excitations together with
+    set-restricted double excitations inherited from APset1roGD.
 
     .. math::
 
-        \left| {{\Psi }_{APset1roGSD}} \right\rangle =\prod\limits_{i=1}^{N/2\;}
-        {\left( 1+\sum\limits_{\begin{smallmatrix}a\in A \\b\in B\\A\bigcap B=\varnothing
-        \end{smallmatrix}}^{{}}{{{t}_{i;ab}}\hat{\tau }_{i\bar{i}}^{ab}}
-        \right)}\prod\limits_{i=1}^{N/2\;}{\left( 1+\sum\limits_{b\in B}^{{}}{{{t}_{\bar{i};b}}
-        \hat{\tau }_{i\bar{i}}^{ib}} \right)\prod\limits_{i=1}^{N/2\;}
-        {\left( 1+\sum\limits_{a\in A}^{{}}{{{t}_{i;a}}\hat{\tau }_{i\bar{i}}^{a\bar{i}}}
-        \right)}\left| {{\Phi }_{0}} \right\rangle }
+    \left| \Psi_{\mathrm{APset1roGSD}} \right\rangle
+    = \prod_{\mu \in \mathcal{E}} 
+    \left(1 + t_\mu \tilde{\tau}_\mu \right)
+    \left| \Phi_0 \right\rangle
 
+    where
 
-    In this case the reference wavefunction can only be a single Slater determinant with
-    seniority 0.
+    .. math::
 
+    \mathcal{E} =
+    \left\{ \tau_i^a, \tau_{\bar{i}}^{b}, \tau_{i\bar{i}}^{ab} 
+    \; \middle| \; a \in A,\; b \in B,\; A \cap B = \varnothing
+    \right\}
+
+    The excitation operator pool :math:\mathcal{E} consists of
+        - set-restricted spin-conserving single excitations
+        :math:(\tau_i^a,\tau_{\bar{i}}^{b})
+
+        - set-restricted double excitations
+        :math:(\tau_{i\bar{i}}^{ab})
+
+    generated from the reference determinant.
+
+    The generalized doubles always annihilate paired occupied spin
+    complements :math:(i,\bar{i}), while creating electrons into two
+    disjoint sets of virtual spin orbitals :math:(A,B).
+
+    By default,
+    :math:A corresponds to virtual alpha spin orbitals,
+    :math:B corresponds to virtual beta spin orbitals,
+    thereby preserving spin projection symmetry.
+
+    Custom disjoint virtual sets may also be supplied through the
+    indices argument of :meth:assign_exops.
+
+    The effective single excitation operators :math:\tilde{\tau} may
+    additionally be constrained during overlap evaluation through the
+    s_type option implemented in the PCCD wavefunction class.
+
+    sen-o: Require breaking an occupied pair
+
+    .. math::
+
+        \tilde{\tau}_i^a = a_a^\dagger a_i \hat{n}_{\bar{i}}
+        \qquad
+        \tilde{\tau}_{\bar{i}}^{b} = a_b^\dagger a_{\bar{i}} \hat{n}_i
+
+    sen-v: Forbid formation of virtual pairs
+
+    .. math::
+
+        \tilde{\tau}_i^a = a_a^\dagger a_i \left(1 - \hat{n}_{\bar{a}} \right)
+        \qquad
+        \tilde{\tau}_{\bar{i}}^{b} = a_b^\dagger a_{\bar{i}}
+        \left(1 - \hat{n}_{\bar{b}} \right)
+
+    sen-ov: Apply both restrictions
+
+    .. math::
+
+        \tilde{\tau}_i^a = a_a^\dagger a_i
+        \left(1 - \hat{n}_{\bar{a}} \right) \hat{n}_{\bar{i}}
+        \qquad
+        \tilde{\tau}_{\bar{i}}^{b} = a_b^\dagger a_{\bar{i}}
+        \left(1 - \hat{n}_{\bar{b}}\right) \hat{n}_i
+
+    free: No seniority restrictions
+
+    .. math::
+
+        \tilde{\tau}_i^a = a_a^\dagger a_i
+        \qquad
+        \tilde{\tau}_{\bar{i}}^{b} =  a_b^\dagger a_{\bar{i}}
+
+    These restrictions are enforced dynamically during excitation-operator
+    combination filtering during overlap evaluation and are not encoded
+    directly into the stored excitation operators.
+
+    This method constructs only a static pool of excitation operators
+    derived from the reference determinant.
+
+    The overlap routines later generate compatible combinations of these
+    excitation operators during determinant connections.
+
+    The reference wavefunction must be a seniority-0 Slater determinant.
+
+    
     Attributes
     ----------
     nelec : int

--- a/fanpy/wfn/cc/pccd_ap1rog.py
+++ b/fanpy/wfn/cc/pccd_ap1rog.py
@@ -45,6 +45,17 @@ class PCCD(BaseCC):
         dictionary, the keys are tuples with the indices of annihilation and creation
         operators, and the values are the excitation operators that allow to excite from the
         annihilation to the creation operators.
+    s_type : str
+        Option indicating how the single excitations are allowed to affect the seniority
+        of the occupied and/or virtual spaces.
+        free: no restrictions imposed.
+        sen-o: single excitations must break an occupied pair.
+               (only excite from spin-orbital i if its complement is occupied)
+        sen-v: single excitations cannot form a pair.
+                (only excite to a virtual spin-orbital a if its complement is empty)
+        sen-ov: single excitations must break an occupied pair and cannot form extra pairs
+                (only excite from spin-orbital i if its complement is occupied and only excite to a virtual spin-orbital a if its complement is empty)
+
 
     Properties
     ----------
@@ -101,7 +112,10 @@ class PCCD(BaseCC):
     generate_possible_exops(self, a_inds, c_inds):
         Assign the excitation operators that can excite from the given indices to be annihilated
         to the given indices to be created.
-
+    assign_s_type(self, s_type):
+        Assign the s_type option.
+    _olp_double_derivative(self, sd): int
+        Returns double derivative of overlap for a given sd
     """
 
     def __init__(
@@ -115,6 +129,7 @@ class PCCD(BaseCC):
         params=None,
         exop_combinations=None,
         refresh_exops=None,
+        s_type="sen-o",
     ):
         """Initialize the wavefunction.
 
@@ -152,6 +167,7 @@ class PCCD(BaseCC):
         super().__init__(
             nelec, nspin, memory=memory, params=params, exop_combinations=exop_combinations, refresh_exops=refresh_exops
         )
+        self.assign_s_type(s_type=s_type)
         self.assign_ranks(ranks=ranks)
         self.assign_exops(indices=indices)
         self.assign_refwfn(refwfn=refwfn)
@@ -224,6 +240,10 @@ class PCCD(BaseCC):
         spin-orbitals to create.
         [a1, a2, ..., aN, c1, c2, ..., cN]
 
+        # For pCCD: Pair excitations only; no single excitations are generated.
+        # Consequently, s_type-based seniority filtering is inactive for
+        # the standard PCCD excitation space.
+
         """
         if indices is not None:
             raise TypeError(
@@ -279,6 +299,41 @@ class PCCD(BaseCC):
             # TODO: check that refwfn has the right number of spin-orbs
             self.refwfn = refwfn
 
+    def assign_s_type(self, s_type):
+        """Assign the seniority option for single excitations.
+        Notes
+        -----
+        For doubles-only wavefunctions, these seniority restrictions
+        do not affect the overlap evaluation because the excitation operator
+        space contains only pair-double excitations and no singles.
+        The restrictions become relevant only when single excitations are
+        included in the excitation operator space.
+
+        Parameters
+        ----------
+        s_type : str
+        Option indicating how the single excitations are allowed to affect the seniority
+        of the occupied and/or virtual spaces.
+        free: no restrictions imposed.
+        sen-o: single excitations must break an occupied pair.
+               (only excite from spin-orbital i if its complement is occupied)
+        sen-v: single excitations cannot form a pair.
+                (only excite to a virtual spin-orbital a if its complement is empty)
+        sen-ov: single excitations must break an occupied pair and cannot form extra pairs
+
+        Raises
+        ------
+        ValueError
+            If s_type is none of 'free', 'sen-o', 'sen-v', 'sen-ov'.
+
+        """
+        allowed = ["free", "sen-o", "sen-v", "sen-ov"]
+
+        if s_type not in allowed:
+            raise ValueError("Invalid s_type")
+
+        self.s_type = s_type
+
     def _olp(self, sd):
         r"""Calculate the matrix element of the CC operator between the Slater determinants.
 
@@ -325,59 +380,199 @@ class PCCD(BaseCC):
             indices_multi = self.exop_combinations[tuple(a_inds + c_inds)]
             # FIXME: filter out rows whose excitation operators does not have annihilator that is
             # doubly occupied
-            occ_indices = set(slater.occ_indices(sd))
-            # print(indices_multi)
-            for exc_order in indices_multi:
-                indices_sign = indices_multi[exc_order]
-                selected_rows = []
-                for row_ind, row in enumerate(indices_sign):
-                    # occupied orbitals but have its spin composite also occupied
-                    # AND its composite CANNOT participate in other excitation operators
-                    trash = set([])
-                    skip_row = False
-                    for exop in (self.ind_exops[i] for i in row[:-1]):
-                        if len(exop) == 2:
-                            if exop[0] in trash:
-                                # skip
-                                skip_row = True
-                                break
-                            if exop[0] < self.nspatial:
-                                if exop[0] + self.nspatial not in occ_indices:
-                                    # skip
-                                    skip_row = True
-                                    break
-                                else:
-                                    # add to trash
-                                    trash.add(exop[0])
-                                    trash.add(exop[0] + self.nspatial)
-                            if exop[0] >= self.nspatial:
-                                if exop[0] - self.nspatial not in occ_indices:
-                                    # skip
-                                    skip_row = True
-                                    break
-                                else:
-                                    # add to trash
-                                    trash.add(exop[0])
-                                    trash.add(exop[0] - self.nspatial)
-                        # FIXME: not sure
-                        else:
-                            for j in exop[: len(exop) // 2]:
-                                if j in trash:
-                                    # skip
-                                    skip_row = True
-                                    break
-                                else:
-                                    trash.add(j)
-                            if skip_row:
-                                break
+            occ_indices = set(slater.occ_indices(sd2))
+        
+            # ------------------------------------------------------------------------------       
+            # NOTE:
+            # The seniority filtering options (s_type = "sen-o", "sen-v", "sen-ov")
+            # only affect excitation operators that contain single excitations
+            # (i.e. len(exop) == 2).
+            #
+            # Pure PCCD/AP1roG defines only pair-double excitation operators:
+            #     [i, i_bar, a, a_bar]
+            # which have len(exop) == 4 and automatically preserve seniority.
+            #
+            # Therefore, for standard PCCD wavefunctions, the s_type logic is
+            # effectively dormant unless single excitations are introduced into
+            # the excitation operator space.
+            # ------------------------------------------------------------------------------
 
-                    if not skip_row:
-                        selected_rows.append(row_ind)
+            # "Break occupied pairs"
+            if self.s_type == "sen-o":
+                for exc_order in indices_multi:
+                    indices_sign = indices_multi[exc_order]
+                    selected_rows = []
+                    for row_ind, row in enumerate(indices_sign):
+                        # occupied orbitals but have its spin composite also occupied
+                        # AND its composite CANNOT participate in other excitation operators
+                        trash = set([])
+                        skip_row = False
+                        for exop in (self.ind_exops[i] for i in row[:-1]):
+                            if len(exop) == 2:
+                                if exop[0] in trash:
+                                    # skip
+                                    skip_row = True
+                                    break
+                                if exop[0] < self.nspatial:
+                                    if exop[0] + self.nspatial not in occ_indices:
+                                        # skip
+                                        skip_row = True
+                                        break
+                                    else:
+                                        # add to trash
+                                        trash.add(exop[0])
+                                        trash.add(exop[0] + self.nspatial)
+                                if exop[0] >= self.nspatial:
+                                    if exop[0] - self.nspatial not in occ_indices:
+                                        # skip
+                                        skip_row = True
+                                        break
+                                    else:
+                                        # add to trash
+                                        trash.add(exop[0])
+                                        trash.add(exop[0] - self.nspatial)
+                            # FIXME: not sure
+                            else:
+                                for j in exop[: len(exop) // 2]:
+                                    if j in trash:
+                                        # skip
+                                        skip_row = True
+                                        break
+                                    else:
+                                        trash.add(j)
+                                if skip_row:
+                                    break
 
-                indices_multi[exc_order] = indices_sign[selected_rows]
-                # FIXME:
-                # print(selected_rows)
-                # print(indices_multi[exc_order])
+                        if not skip_row:
+                            selected_rows.append(row_ind)
+                    indices_multi[exc_order] = indices_sign[selected_rows]
+                    # FIXME:
+                    # print(selected_rows)
+                    # print(indices_multi[exc_order])
+            # "Don't form virtual pairs"
+            elif self.s_type == "sen-v":
+                for exc_order in indices_multi:
+                    indices_sign = indices_multi[exc_order]
+                    selected_rows = []
+                    for row_ind, row in enumerate(indices_sign):
+                        # occupied orbitals but have its spin composite also occupied
+                        # AND its composite CANNOT participate in other excitation operators
+                        trash = set([])
+                        skip_row = False
+                        for exop in (self.ind_exops[i] for i in row[:-1]):
+                            if len(exop) == 2:
+                                if exop[1] in trash:
+                                    # skip
+                                    skip_row = True
+                                    break
+                                if exop[1] < self.nspatial:
+                                    if exop[1] + self.nspatial in occ_indices:
+                                        # skip
+                                        skip_row = True
+                                        break
+                                    else:
+                                        # add to trash
+                                        trash.add(exop[1])
+                                        trash.add(exop[1] + self.nspatial)
+                                if exop[1] >= self.nspatial:
+                                    if exop[1] - self.nspatial in occ_indices:
+                                        # skip
+                                        skip_row = True
+                                        break
+                                    else:
+                                        # add to trash
+                                        trash.add(exop[1])
+                                        trash.add(exop[1] - self.nspatial)
+                            # FIXME: not sure
+                            else:
+                                for j in exop[len(exop) // 2 :]:
+                                    if j in trash:
+                                        # skip
+                                        skip_row = True
+                                        break
+                                    else:
+                                        trash.add(j)
+                                if skip_row:
+                                    break
+
+                        if not skip_row:
+                            selected_rows.append(row_ind)
+
+                    indices_multi[exc_order] = indices_sign[selected_rows]
+                    # FIXME:
+                    # print(selected_rows)
+                    # print(indices_multi[exc_order])
+            # "Break occupied pairs AND don't form virtual pairs"
+            elif self.s_type == "sen-ov":
+                for exc_order in indices_multi:
+                    indices_sign = indices_multi[exc_order]
+                    selected_rows = []
+                    for row_ind, row in enumerate(indices_sign):
+                        # occupied orbitals but have its spin composite also occupied
+                        # AND its composite CANNOT participate in other excitation operators
+                        trash = set([])
+                        skip_row = False
+                        for exop in (self.ind_exops[i] for i in row[:-1]):
+                            if len(exop) == 2:
+                                if exop[0] in trash or exop[1] in trash:
+                                    # skip
+                                    skip_row = True
+                                    break
+                                if exop[0] < self.nspatial:
+                                    if exop[0] + self.nspatial not in occ_indices:
+                                        # skip
+                                        skip_row = True
+                                        break
+                                    else:
+                                        # add to trash
+                                        trash.add(exop[0])
+                                        trash.add(exop[0] + self.nspatial)
+                                if exop[0] >= self.nspatial:
+                                    if exop[0] - self.nspatial not in occ_indices:
+                                        # skip
+                                        skip_row = True
+                                        break
+                                    else:
+                                        # add to trash
+                                        trash.add(exop[0])
+                                        trash.add(exop[0] - self.nspatial)
+                                if exop[1] < self.nspatial:
+                                    if exop[1] + self.nspatial in occ_indices:
+                                        # skip
+                                        skip_row = True
+                                        break
+                                    else:
+                                        # add to trash
+                                        trash.add(exop[1])
+                                        trash.add(exop[1] + self.nspatial)
+                                if exop[1] >= self.nspatial:
+                                    if exop[1] - self.nspatial in occ_indices:
+                                        # skip
+                                        skip_row = True
+                                        break
+                                    else:
+                                        # add to trash
+                                        trash.add(exop[1])
+                                        trash.add(exop[1] - self.nspatial)
+                            # FIXME: not sure
+                            else:
+                                for j in exop:
+                                    if j in trash:
+                                        # skip
+                                        skip_row = True
+                                        break
+                                    else:
+                                        trash.add(j)
+                                if skip_row:
+                                    break
+
+                        if not skip_row:
+                            selected_rows.append(row_ind)
+
+                    indices_multi[exc_order] = indices_sign[selected_rows]
+                    # FIXME:
+                    # print(selected_rows)
+                    # print(indices_multi[exc_order])
 
             amplitudes = self.product_amplitudes_multi(indices_multi)
             # print(amplitudes)
@@ -433,7 +628,14 @@ class PCCD(BaseCC):
             indices_multi = self.exop_combinations[tuple(a_inds + c_inds)]
             # FIXME: filter out rows whose excitation operators do not have annihilator that is
             # doubly occupied
-            occ_indices = set(slater.occ_indices(sd2))
+
+            # NOTE:
+            # Retaining the original pccd_ap1rog_NEW implementation using
+            # `occ_indices(sd)` here (rather than `sd2`).
+            # The correct determinant to use for occupancy filtering during
+            # excitation validation requires further investigation
+            occ_indices = set(slater.occ_indices(sd))
+
             for exc_order in indices_multi:
                 indices_sign = indices_multi[exc_order]
                 selected_rows = []
@@ -508,3 +710,128 @@ class PCCD(BaseCC):
             return val
         else:
             return temp_olp(sd, self.refwfn)
+
+
+    def _olp_double_derivative(self, sd):
+        """Calculate the double derivative of the overlap with the Slater determinant.
+
+        .. math::
+
+        H_{ab} = \frac{\partial^2}{\partial t_a \partial t_b}
+            \left[ \langle \mathrm{SD} \mid \Psi_{\mathrm{CC}} \rangle \right]
+
+        Parameters
+        ----------
+        sd : int
+            Occupation vector of the left Slater determinant given as a bitstring.
+        
+        Returns
+        -------
+        olp double derivative: 2D numpy array with Hessian elements :math:`H_{ab}`.
+
+        """
+
+        def temp_olp_double_deriv(sd1, sd2):
+            if sd1 == sd2:
+                return np.zeros((self.nparams, self.nparams))
+            # FIXME: this should definitely be vectorized
+            c_inds, a_inds = slater.diff_orbs(sd1, sd2)
+            if isinstance(a_inds, np.ndarray):
+                a_inds = a_inds.tolist()
+            if isinstance(c_inds, np.ndarray):
+                c_inds = c_inds.tolist()
+            # NOTE: Indices of the annihilation (a_inds) and creation (c_inds) operators
+            # that need to be applied to sd2 to turn it into sd1
+
+            # get sign
+            sign = slater.sign_excite(sd2, a_inds, c_inds)
+
+            val = np.zeros(self.nparams)
+            if tuple(a_inds + c_inds) not in self.exop_combinations:
+                self.generate_possible_exops(a_inds, c_inds)
+
+            # FIXME: sometimes exop contains virtual orbitals in annihilators may need to explicitly
+            # excite
+            indices_multi = self.exop_combinations[tuple(a_inds + c_inds)]
+            # FIXME: filter out rows whose excitation operators do not have annihilator that is
+            # doubly occupied
+
+            # NOTE:
+            # Retaining the original pccd_ap1rog_NEW implementation 
+            # of the whole _olp_double_deriv function alogn with
+            # `occ_indices(sd)` line.
+            # The correct determinant to use (`sd` or `sd2`) for occupancy filtering during
+            # excitation validation requires further investigation
+            oocc_indices = set(slater.occ_indices(sd))
+
+            for exc_order in indices_multi:
+                indices_sign = indices_multi[exc_order]
+                selected_rows = []
+                for row_ind, row in enumerate(indices_sign):
+                    # occupied orbitals but have its spin composite also occupied
+                    # AND its composite CANNOT participate in other excitation operators
+                    trash = set([])
+                    skip_row = False
+                    for exop in (self.ind_exops[i] for i in row[:-1]):
+                        if len(exop) == 2:
+                            # skip because annihilator was used in a single excitation as the
+                            # opposite spin
+                            if exop[0] in trash:
+                                # skip
+                                skip_row = True
+                                break
+                            if exop[0] < self.nspatial:
+                                # skip because corresponding beta orbital is not occupied
+                                if exop[0] + self.nspatial not in occ_indices:
+                                    # skip
+                                    skip_row = True
+                                    break
+                                # this annihilator and its beta component cannot be used again
+                                else:
+                                    # add to trash
+                                    trash.add(exop[0])
+                                    trash.add(exop[0] + self.nspatial)
+                            if exop[0] >= self.nspatial:
+                                # skip because corresponding alpha orbital is not occupied
+                                if exop[0] - self.nspatial not in occ_indices:
+                                    # skip
+                                    skip_row = True
+                                    break
+                                # this annihilator and its alpha component cannot be used again
+                                else:
+                                    # add to trash
+                                    trash.add(exop[0])
+                                    trash.add(exop[0] - self.nspatial)
+                        # FIXME: not sure
+                        else:
+                            for j in exop[: len(exop) // 2]:
+                                # skip because annihilator was used before as part of a single
+                                # excitation or its opposite spin component
+                                if j in trash:
+                                    # skip
+                                    skip_row = True
+                                    break
+                                # not necessary because same orbital is not annihilated multiple
+                                # times by construction
+                                else:
+                                    trash.add(j)
+                            if skip_row:
+                                break
+
+                    if not skip_row:
+                        selected_rows.append(row_ind)
+
+                indices_multi[exc_order] = indices_sign[selected_rows]
+
+            hessian = self.product_amplitudes_multi_double_derivative(indices_multi)
+            val = sign * hessian
+            return val
+
+        if isinstance(self.refwfn, CIWavefunction):
+            val = np.zeros(self.nparams, self.nparams)
+            for refsd in self.refwfn.sd_vec:
+                val += temp_olp_double_deriv(sd, refsd) * self.refwfn.get_overlap(refsd)
+            return val
+        else:
+            return temp_olp_double_deriv(sd, self.refwfn)
+

--- a/tests/test_wfn_cc_pccd_ap1rog.py
+++ b/tests/test_wfn_cc_pccd_ap1rog.py
@@ -1,5 +1,6 @@
 """Test fanpy.wavefunction.cc.pccd_ap1rog."""
 import pytest
+import numpy as np
 from fanpy.tools import slater
 from fanpy.wfn.cc.pccd_ap1rog import PCCD
 
@@ -64,3 +65,130 @@ def test_assign_refwfn():
         test.assign_refwfn(0b11000011)
     test.assign_refwfn()
     assert test.refwfn == (0b00110011)
+
+
+def test_assign_refwfn_sen_0_check():
+    """Test seniority-0 check in PCCD.assign_refwfn."""
+    test = TempPCCD()
+    test.assign_nelec(4)
+    test.assign_nspin(16)
+    with pytest.raises(ValueError):
+        test.assign_refwfn(0b11000011)
+    with pytest.raises(ValueError):
+        test.assign_refwfn(0b0000010100000011)
+    test.assign_refwfn()
+    assert test.refwfn == (0b0000001100000011)
+
+
+def test_assign_s_type():
+    """Test PCCD.assign_s_type."""
+    test = TempPCCD()
+
+    test.assign_s_type("free")
+    assert test.s_type == "free"
+
+    test.assign_s_type("sen-o")
+    assert test.s_type == "sen-o"
+
+    test.assign_s_type("sen-v")
+    assert test.s_type == "sen-v"
+
+    test.assign_s_type("sen-ov")
+    assert test.s_type == "sen-ov"
+
+
+def test_assign_s_type_invalid():
+    """Test invalid s_type."""
+    test = TempPCCD()
+
+    with pytest.raises(ValueError):
+        test.assign_s_type("bad-option")
+
+
+def test_init_s_type():
+    """Test initialization of s_type."""
+    test = PCCD(4, 8, s_type="sen-v")
+    assert test.s_type == "sen-v"
+
+
+def tests_type_effct_on_pCCD_overlap():
+    """Test s_type effect on pCCD overlap.
+    pCCD doesn't have singles so it shouldn't enter 
+    into the sen-x logics of singles.
+    """
+
+    sd = 0b10100011
+
+    test_free = PCCD(4, 8, s_type="free")
+    test_seno = PCCD(4, 8, s_type="sen-o")
+
+    olp_free = test_free.get_overlap(sd)
+    olp_seno = test_seno.get_overlap(sd)
+
+    assert olp_free == olp_seno
+
+
+def test_olp_double_derivative_shape():
+    """Test overlap Hessian shape."""
+
+    test = PCCD(4, 8)
+
+    hess = test._olp_double_derivative(test.refwfn)
+
+    assert hess.shape == (test.nparams, test.nparams)
+
+
+def test_olp_double_derivative_symmetric():
+    """Test overlap Hessian symmetry."""
+
+    test = PCCD(4, 8)
+
+    sd = 0b11001100
+
+    hess = test._olp_double_derivative(sd)
+
+    assert np.allclose(hess, hess.T)
+
+
+def test_olp_double_derivative_zero_diagonal():
+    """Test Hessian diagonal vanishes."""
+
+    test = PCCD(4, 8)
+
+    sd = 0b11001100
+
+    hess = test._olp_double_derivative(sd)
+
+    assert np.allclose(np.diag(hess), 0)
+
+
+def test_olp_double_derivative_finite_difference():
+    """Test overlap Hessian with finite differences."""
+
+    test = PCCD(4, 8)
+
+    sd = 0b11001100
+
+    h = 1e-7
+
+    analytic = test._olp_double_derivative(sd)
+
+    numerical = np.zeros_like(analytic)
+
+    orig = test.params.copy()
+
+    for j in range(test.nparams):
+
+        test.params = orig.copy()
+        test.params[j] += h
+        plus = test._olp_deriv(sd)
+
+        test.params = orig.copy()
+        test.params[j] -= h
+        minus = test._olp_deriv(sd)
+
+        numerical[:, j] = (plus - minus) / (2 * h)
+
+    test.params = orig
+
+    assert np.allclose(analytic, numerical, atol=1e-5)


### PR DESCRIPTION
 **Consolidating the legacy CC/geminal wavefunction implementations with their corresponding _NEW variants**.

The primary goal of this PR is to:

1. Copy missing functionality from _NEW implementations into the canonical/legacy implementations,
2. Verify that the merged implementation preserves existing functionality,
3. Resolve inconsistencies between old and _NEW implementations where needed,
4. Improve documentation and mathematical consistency,
5. Eventually, remove the duplicated _NEW files once consolidation is complete.

This PR focuses mainly on review, consolidation, documentation cleanup, and targeted testing additions where functionality differences existed.

---
## Main Changes in Files

### `pccd_ap1rog.py`

Merged functionality from `_NEW` into the canonical implementation, including:

* `s_type` functionality and overlap filtering logic,
* `_olp_double_derivative`,
* associated documentation updates,
* and new tests for the merged functionality.

The seniority-0 reference-wavefunction check from `_NEW` was **not** adopted because it incorrectly used slicing over `:nspatial` instead of `nelec // 2`.

### Important Note

The `_NEW` implementation of `_olp_deriv` and `_olp_double_derivative` uses:

```python id="jlwmu5"
occ_indices(sd)
```

rather than:

```python id="xjlwm7"
occ_indices(sd2)
```

This behavior was preserved for now because the implementation was used in calculations associated with the paper results. Further investigation is still needed to confirm whether this behavior is theoretically correct.

---

### `ap1rog_spin.py`

### `ap1rog_generalized.py`

### `apg1ro_d.py`

### `apg1ro_sd.py`

### `apset1rog_d.py`

### `apset1rog_sd.py`

No functional differences were found between the canonical and `_NEW` implementations (aside from parent import filenames, which were left unchanged since only old files are modified to accommodate the functionalities from their _NEW variants).

For these files:
* Wavefunction equations and docstrings were corrected and modernized,
* Excitation-operator structure and overlap-generation workflow were clarified,
* Mathematical notation was updated to better reflect the actual implementation.

No new tests were added for these files because no functionality changes were introduced during the merge review. Additional tests can be included to improve test coverage through a separate branch.

---

## Additional Notes

A major focus of this PR was improving consistency between:

* the mathematical ansatz described in the docstrings,
* the excitation operators actually generated in code,
* and the overlap/filtering workflow implemented in the CC infrastructure.

Older layered operator expressions- a series of parentheses for doubles and single operators- could lead to confusion on the ordering of operators. So, those were replaced with excitation-pool formulations that more accurately reflect the implementation behavior.

