### PR TITLE
Chore: remove objective type kwarg

### DIFF
--- a/fanpy/interface/fanci/legacy.py
+++ b/fanpy/interface/fanci/legacy.py
@@ -969,14 +969,6 @@ class ProjectedSchrodingerFanCI(ProjectedSchrodingerLegacyFanCI):
         return self._param_selection
 
     @property
-    def objective_type(self) -> str:
-        """
-        Set objective type for the FanCI problem as "projected" or "energy".
-
-        """
-        return self._objective_type
-
-    @property
     def max_memory(self) -> int:
         """
         Maximum memory available for this calculations in Megabytes.
@@ -997,7 +989,6 @@ class ProjectedSchrodingerFanCI(ProjectedSchrodingerLegacyFanCI):
         constraints: dict,
         param_selection: dict,
         norm_det,
-        objective_type: str,
         max_memory: int,
         step_print: bool,
         step_save: bool,
@@ -1031,8 +1022,6 @@ class ProjectedSchrodingerFanCI(ProjectedSchrodingerLegacyFanCI):
             Parameters selection from Fanpy objective.
         norm_det : Sequence[Tuple[int, float]]
             Indices of determinant whose overlaps to constrain, and the value to which to constrain them.
-        objective_type: str
-            Set objective type for the FanCI problem as "projected" or "energy".
         max_memory = int
             Maximum memory available for this calculations in Megabytes.
             It is utilized in specific loops to avoid potential memory leaks.
@@ -1061,7 +1050,6 @@ class ProjectedSchrodingerFanCI(ProjectedSchrodingerLegacyFanCI):
         self._step_save = step_save
         self._tmpfile = tmpfile
         self._param_selection = param_selection
-        self._objective_type = objective_type
         self._max_memory = max_memory
 
         self.print_queue = {}
@@ -1461,8 +1449,6 @@ class ProjectedSchrodingerFanCI(ProjectedSchrodingerLegacyFanCI):
             opt_kwargs.setdefault("max_nfev", 1000 * self.nactive)
             opt_kwargs.setdefault("verbose", 2)
             # opt_kwargs.setdefault("callback", self.print)
-            if self.objective_type != "projected":
-                raise ValueError("objective_type must be projected")
         elif mode == "root":
             if self.nequation != self.nactive:
                 raise ValueError("'root' does not work with over-determined system")
@@ -1591,7 +1577,6 @@ class ProjectedSchrodingerFanCI(ProjectedSchrodingerLegacyFanCI):
                 mask=mask,
                 constraints=constraints,
                 param_selection=self.param_selection,
-                objective_type=self.objective_type,
                 max_memory=self.max_memory,
                 step_print=self.step_print,
                 step_save=self.step_save,

--- a/fanpy/interface/fanci/pyci.py
+++ b/fanpy/interface/fanci/pyci.py
@@ -98,14 +98,6 @@ class ProjectedSchrodingerPyCI(FanCI):
         return self._param_selection
 
     @property
-    def objective_type(self) -> str:
-        """
-        Set objective type for the FanCI problem as "projected" or "energy".
-
-        """
-        return self._objective_type
-
-    @property
     def max_memory(self) -> int:
         """
         Maximum memory available for this calculations in Megabytes.
@@ -175,7 +167,6 @@ class ProjectedSchrodingerPyCI(FanCI):
         param_selection: dict,
         norm_param,
         norm_det,
-        objective_type: str,
         max_memory: int,
         step_print: bool,
         step_save: bool,
@@ -212,8 +203,6 @@ class ProjectedSchrodingerPyCI(FanCI):
             Indices of parameters whose values to constrain, and the value to which to constrain them.
         norm_det : Sequence[Tuple[int, float]]
             Indices of determinant whose overlaps to constrain, and the value to which to constrain them.
-        objective_type: str
-            Set objective type for the FanCI problem as "projected" or "energy".
         max_memory = int
             Maximum memory available for this calculations in Megabytes.
             It is utilized in specific loops to avoid potential memory leaks.
@@ -245,7 +234,6 @@ class ProjectedSchrodingerPyCI(FanCI):
         self._step_save = step_save
         self._tmpfile = tmpfile
         self._param_selection = param_selection
-        self._objective_type = objective_type
         self._max_memory = max_memory
 
         self.print_queue = {}
@@ -789,8 +777,6 @@ class ProjectedSchrodingerPyCI(FanCI):
             opt_kwargs.setdefault("max_nfev", 1000 * self.nactive)
             opt_kwargs.setdefault("verbose", 2)
             # opt_kwargs.setdefault("callback", self.print)
-            if self.objective_type != "projected":
-                raise ValueError("objective_type must be projected")
         elif mode == "root":
             if self.nequation != self.nactive:
                 raise ValueError("'root' does not work with over-determined system")
@@ -919,7 +905,6 @@ class ProjectedSchrodingerPyCI(FanCI):
                 mask=mask,
                 constraints=constraints,
                 param_selection=self.param_selection,
-                objective_type=self.objective_type,
                 max_memory=self.max_memory,
                 step_print=self.step_print,
                 step_save=self.step_save,

--- a/fanpy/interface/pyci.py
+++ b/fanpy/interface/pyci.py
@@ -88,7 +88,6 @@ class PYCI:
         self.tmpfile = fanpy_objective.tmpfile
         self.param_selection = fanpy_objective.indices_component_params
 
-        self.objective_type = "projected"  # TODO: Should it follow fanpy_objective type?
         self.kwargs = kwargs
 
         # Build PyCI Hamiltonian Object
@@ -272,7 +271,6 @@ class PYCI:
                 constraints=self.constraints,
                 param_selection=self.param_selection,
                 norm_det=self.norm_det,
-                objective_type=self.objective_type,
                 max_memory=self.max_memory,
                 step_print=self.step_print,
                 step_save=self.step_save,
@@ -296,7 +294,6 @@ class PYCI:
                 param_selection=self.param_selection,
                 norm_param=self.norm_param,
                 norm_det=self.norm_det,
-                objective_type=self.objective_type,
                 max_memory=self.max_memory,
                 step_print=self.step_print,
                 step_save=self.step_save,

--- a/fanpy/wfn/utils.py
+++ b/fanpy/wfn/utils.py
@@ -171,7 +171,7 @@ def convert_to_fanci(
     tmpfile=None,
     param_selection=None,
     mask=None,
-    objective_type=None,
+    objective_type=None, #TODO: FanCI classes in interface no longer take objective_type as kwarg. Convert to fanci must be updated with GeneratedFanCI class
     constraints=None,
     norm_det=None,
     max_memory=8192,

--- a/tests/test_interface_fanci_legacy.py
+++ b/tests/test_interface_fanci_legacy.py
@@ -62,7 +62,6 @@ def make_test_instance(**overrides):
         "param_selection": obj.indices_component_params,
         "norm_param": None,
         "norm_det": None,
-        "objective_type": "projected",
         "max_memory": 8000,
         "step_print": False,
         "step_save": False,

--- a/tests/test_interface_fanci_pyci.py
+++ b/tests/test_interface_fanci_pyci.py
@@ -62,7 +62,6 @@ def make_test_instance(**overrides):
         "param_selection": obj.indices_component_params,
         "norm_param": None,
         "norm_det": None,
-        "objective_type": "projected",
         "max_memory": 8000,
         "step_print": False,
         "step_save": False,


### PR DESCRIPTION
The `objective_type` keyword argument was used in the old interface to determine if we want to use a projected or variational objective. This is redundant in the new interface, as it is only for the projected objective. The `objective_type` kwarg was hard coded in `fanpy/interface/pyci.py` to `projected` for this reason. I have removed the keyword argument as it is redundant.