### PR TITLE
Test: interface submodule

### DIFF
--- a/fanpy/interface/fanci/alias.py
+++ b/fanpy/interface/fanci/alias.py
@@ -3,6 +3,7 @@
 """
 
 import numpy as np
+import warnings
 
 
 class Alias:
@@ -25,7 +26,14 @@ class Alias:
             Probability vector.
 
         """
-
+        # checks for pvec
+        if not isinstance(pvec, np.ndarray):
+            raise TypeError("The probability vector must be a numpy array.")
+        if not np.all((pvec >= 0.0) & (pvec <= 1.0)):
+            raise ValueError("Probability distribution must be between 0 and 1.")
+        if pvec.ndim > 1:
+            warnings.warn("Probability vector is not 1D --> flattening array.")
+            pvec = pvec.flatten()
         # Declare size of probability vector
         self.n = pvec.size
 
@@ -64,6 +72,14 @@ class Alias:
         """
 
         out = set()
+
+        # check input n 
+        # we should not be able to generate more random idx than the size of the distribution
+        if not isinstance(n, int):
+            raise TypeError("n must be an integer.")
+        if n > self.n or n < 1:
+            raise ValueError(f"Cannot generate more than {self.n} or less than 1 random index.")
+
         while len(out) < n:
             i = int(np.random.rand() * self.n)
             out.add(self.ivec[i] if np.random.rand() > self.cvec[i] else i)

--- a/fanpy/interface/fanci/pyci.py
+++ b/fanpy/interface/fanci/pyci.py
@@ -162,7 +162,7 @@ class ProjectedSchrodingerPyCI(FanCI):
         seniority: int,
         nproj: int,
         fill: str,
-        mask: list,
+        mask: np.ndarray,
         constraints: dict,
         param_selection: dict,
         norm_param,
@@ -193,8 +193,8 @@ class ProjectedSchrodingerPyCI(FanCI):
             Number of determinants in projection ("P") space.
         fill : ('excitation' | 'seniority' | None)
             Whether to fill the projection ("P") space by excitation level, by seniority, or not at all (in which case ``wfn`` must already be filled).
-        mask : list
-            List of parameters to freeze.
+        mask : np.ndarray of bools
+            List of parameters to freeze. E.g. [True, False, True] would freeze the second parameter. 
         constraints : dict
             Pairs of functions (f, dfdx) corresponding to additional constraints.
         param_selection : dict

--- a/fanpy/interface/pyci.py
+++ b/fanpy/interface/pyci.py
@@ -247,7 +247,7 @@ class PYCI:
             self.objective._ham = self._pyci_ham
 
         elif isinstance(new_ham, pyci.hamiltonian):
-            self.fanpy_ham(new_ham)
+            self.pyci_ham = new_ham
 
     def build_pyci_objective(self):
         """

--- a/fanpy/interface/pyci.py
+++ b/fanpy/interface/pyci.py
@@ -223,7 +223,7 @@ class PYCI:
             self.fanpy_objective.ham = self._fanpy_ham
 
         elif isinstance(new_ham, RestrictedMolecularHamiltonian):
-            self.fanpy_ham(new_ham)
+            self.fanpy_ham = new_ham
 
     @fanpy_ham.setter
     def fanpy_ham(self, new_ham):

--- a/fanpy/interface/pyci.py
+++ b/fanpy/interface/pyci.py
@@ -224,6 +224,8 @@ class PYCI:
 
         elif isinstance(new_ham, RestrictedMolecularHamiltonian):
             self.fanpy_ham = new_ham
+        else:
+            raise TypeError("new_ham must be pyci.hamiltonian or RestrictedMolecularHamiltonian.")
 
     @fanpy_ham.setter
     def fanpy_ham(self, new_ham):
@@ -248,6 +250,8 @@ class PYCI:
 
         elif isinstance(new_ham, pyci.hamiltonian):
             self.pyci_ham = new_ham
+        else:
+            raise TypeError("new_ham must be pyci.hamiltonian or RestrictedMolecularHamiltonian.")
 
     def build_pyci_objective(self):
         """

--- a/tests/interface_utils.py
+++ b/tests/interface_utils.py
@@ -5,6 +5,108 @@ from subprocess import call
 
 import numpy as np
 
+from fanpy.eqn.projected import BaseSchrodinger
+from fanpy.wfn.cc.standard_cc import StandardCC
+from fanpy.wfn.base import BaseWavefunction
+from fanpy.ham.base import BaseHamiltonian
+
+#################### FAKE CLASSES ######################################
+
+class FakeSchrodinger(BaseSchrodinger):
+    """fake fanpy objective for testing purposes"""
+    def __init__(self, wfn, ham):
+        super().__init__(wfn, ham)
+    def objective(self, params):
+        return 3.08
+
+class FakeCC(StandardCC):
+    """fake CC wavefunction for testing purposes
+    This is used to test the double derivative of the overlap.
+    """
+    def __init__(self, nelec, nspin):
+        super().__init__(nelec, nspin)
+
+    def get_overlap_double_derivative(self, sd):
+        double_deriv = np.ones((self.nparams, self.nparams))
+        return double_deriv
+
+class FakeWavefunction(BaseWavefunction):
+    """ A fake wavefunction for testing purposes.
+    """
+
+    def __init__(self, nelec, nspin, params):
+        """ Initialize FakeWavefunction.
+
+        Args:
+            nelec (int): Number of electrons.
+            nspin (int): Number of spin orbitals.
+        """
+        self.assign_params(params)
+        super().__init__(nelec, nspin)
+
+    def get_overlap(self, sd, deriv=None):
+        """ Get overlap with a Slater determinant.
+
+        Args:
+            sd (int): Slater determinant in integer representation. -> not used for fake implementation.
+            deriv (np.ndarray, optional): If provided, compute the derivative of the overlap.
+
+        Returns:
+            float: Overlap value.
+        """
+        if deriv is not None:
+            return np.zeros(len(deriv))
+        else:
+            return 1.0 
+        
+    def assign_params(self, params):
+        """ Assign parameters to the wavefunction.
+
+        Args:
+            params (np.ndarray): Parameters to assign.
+        """
+        self.params = params
+
+class FakeHamiltonian(BaseHamiltonian):
+    """ A fake Hamiltonian for testing purposes.
+    """
+    def __init__(self, one_int, two_int):
+        """ Initialize FakeHamiltonian.
+
+        Args:
+            one_int (np.ndarray): One-electron integrals.
+            two_int (np.ndarray): Two-electron integrals.
+        """
+        self.one_int = one_int
+        self.two_int = two_int
+        self._nspin = one_int.shape[0] * 2 # assuming one_int is square and its size corresponds to the orbital space
+    @property
+    def nspin(self):
+        """ Return the number of spin orbitals.
+
+        Returns:
+            int: Number of spin orbitals.
+        """
+        return self._nspin
+    
+    def integrate_sd_sd(self, sd1, sd2, deriv=None):
+        """ Integrate the Hamiltonian with against two Slater determinants.
+
+        Args:
+            sd1 (int): First Slater determinant in integer representation. -> not used for fake implementation.
+            sd2 (int): Second Slater determinant in integer representation. -> not used for fake implementation.
+            deriv (np.ndarray, optional): If provided, compute the derivative of the integral.
+
+        Returns:
+            float: Integral value.
+        """
+        if deriv is not None:
+            return np.zeros(len(deriv))
+        else:
+            return 1.0
+
+
+###################### HF DATA CHECKS ##################################
 
 def check_data_h2_rhf_sto6g(el_energy, nuc_nuc_energy, one_int, two_int):
     """Check data for h2 rhf sto6g calculation."""

--- a/tests/test_interface_fanci_alias.py
+++ b/tests/test_interface_fanci_alias.py
@@ -1,0 +1,62 @@
+"""Unit tests for fanpy.interface.fanci.alias"""
+
+import numpy as np
+import pytest
+
+from fanpy.interface.fanci.alias import Alias
+
+# Note: the Alias class is used in the legacy interface
+# Thus it is expected that it will be depricated in the future
+# These tests act as a sanity check for Alias, but they do not test 
+# if Alias is implemented properly.
+
+
+def test_init():
+    """Check init type checks and if Alias initializes correctly."""
+    #### INPUT CHECKS ###
+
+    # wrong data types 
+    with pytest.raises(TypeError):
+        Alias("not a pvec")
+    
+    # out of range data
+    pvec = np.asarray([2.0, 0.5])
+    with pytest.raises(ValueError):
+        Alias(pvec)
+    pvec_neg = np.asarray([-0.5, 0.2])
+    with pytest.raises(ValueError):
+        Alias(pvec_neg)
+
+    # warning if 2d array
+    pvec = np.asarray([[0.1, 0.2], [0.3, 0.5]])
+    with pytest.warns():
+        a = Alias(pvec)
+        assert a.n == 4
+
+    #### NORMAL INIT ###
+    a = Alias(np.asarray([0.3, 0.25, 0.15, 0.2, 0.1]))
+    assert a.n == 5 # check size of input vector calculated properly
+
+@pytest.mark.parametrize("n", [100, 0, -1])
+def test_call_value_checks(n):
+    """check if errors for out of range n are raised appropriately."""
+    pvec = np.asarray([0.3, 0.25, 0.15, 0.2, 0.1])
+    a = Alias(pvec)
+    with pytest.raises(ValueError):
+        a(n)
+
+def test_call_type_check():
+    """make sure we cannot pass floats to the while loop in __call__"""
+    pvec = np.asarray([0.3, 0.25, 0.15, 0.2, 0.1])
+    a = Alias(pvec)
+    with pytest.raises(TypeError):
+        a(0.1)
+
+@pytest.mark.parametrize("n", [1, 3, 5])
+def test_call(n):
+    """Check if we generate the expected amount of random idx and they are within the range"""
+    pvec = np.asarray([0.3, 0.25, 0.15, 0.2, 0.1])
+    a = Alias(pvec)
+    idx = a(n)
+    assert idx.size == n
+    assert np.all((idx >= 0) & (idx < pvec.size))

--- a/tests/test_interface_fanci_legacy.py
+++ b/tests/test_interface_fanci_legacy.py
@@ -8,6 +8,31 @@ import pyci
 
 from interface_utils import FakeCC, FakeSchrodinger, FakeHamiltonian, FakeWavefunction
 
+# todo: missing lines: based on this test only! 
+# __init__ 206, 210, 216-217, 219-220, 224, 229-230, 
+# norm constraint 282-285, 292-306, 
+# optimize 338-378, 
+# optimize stochastic 415-461, 
+# add constraint 479-482, 
+# remove constraint 494-497, 
+# freeze and unfreeze parameter 509-513, 525-529, 
+# compute objective 549-579, 
+# compute jacobian 600-652, 
+# make param constraint 675-692, 
+# make det constraint 715-732, 
+# mask function 751-763,
+# abstract compute olp, olp deriv, olp double deriv  785, 807, 829, 
+# fill wfn 850-853, 860, 874-885, 888, 892, 
+# compute olp 1118, 
+# compute olp deriv 1180, 1190-1197, 1199, 
+# compute objective 1276-1291, 
+# compute jac 1310-1317, 
+# save params 1329-1342, 
+# optimize 1412-1469, 
+# print 1472-1473, 
+# optimize stochastic 1510-1586, 
+# olp deriv chunks 1589-1601
+
 ############## Tools for testing purposes #########################
 
 

--- a/tests/test_interface_fanci_legacy.py
+++ b/tests/test_interface_fanci_legacy.py
@@ -6,30 +6,10 @@ import pytest
 from fanpy.interface.fanci.legacy import ProjectedSchrodingerFanCI
 import pyci
 
-from test_interface_pyci import FakeHamiltonian, FakeWavefunction
-
-from fanpy.eqn.projected import BaseSchrodinger
-from fanpy.wfn.cc.standard_cc import StandardCC
+from interface_utils import FakeCC, FakeSchrodinger, FakeHamiltonian, FakeWavefunction
 
 ############## Tools for testing purposes #########################
 
-class FakeSchrodinger(BaseSchrodinger):
-    """fake fanpy objective for testing purposes"""
-    def __init__(self, wfn, ham):
-        super().__init__(wfn, ham)
-    def objective(self, params):
-        return 3.08
-
-class FakeCC(StandardCC):
-    """fake CC wavefunction for testing purposes
-    This is used to test the double derivative of the overlap.
-    """
-    def __init__(self, nelec, nspin):
-        super().__init__(nelec, nspin)
-
-    def get_overlap_double_derivative(self, sd):
-        double_deriv = np.ones((self.nparams, self.nparams))
-        return double_deriv
 
 def make_test_instance(**overrides):
     """make test instance of ProjectedSchrodingerPyCI with fake fanpy objective and fake pyci hamiltonian and wavefunction

--- a/tests/test_interface_fanci_legacy.py
+++ b/tests/test_interface_fanci_legacy.py
@@ -9,13 +9,19 @@ import pyci
 
 from interface_utils import FakeCC, FakeSchrodinger, FakeHamiltonian, FakeWavefunction
 
+# NOTE: we are not testing the ProjectedSchrodingerLegacyFanCI class here, as it is equivalent to the fanci class in pyci. 
+# the legacy interface will be depricated after some time, since it fulfills the same role as the non-legacy interface
 
 ############## Tools for testing purposes #########################
 
 
 def make_test_instance(**overrides):
-    """make test instance of ProjectedSchrodingerPyCI with fake fanpy objective and fake pyci hamiltonian and wavefunction
-    This helps set up a class that requires a lot of parameters.
+    """Build a ProjectedSchrodingerPyCI test instance with fake dependencies.
+    
+    Parameters
+    ----------
+    overrides : dict
+        override kwargs for the PyCI objetive. 
     """
     # build Fake fanpy objective
     wfn = FakeWavefunction(2, 4, np.ones(4))
@@ -54,6 +60,7 @@ def make_test_instance(**overrides):
 
 ################# init tests ###################################
 def test_init():
+    """Validate initialization and default normalization constraints."""
     # errors
     ham = "non_pyci_hamiltonian"
     with pytest.raises(TypeError):
@@ -74,6 +81,7 @@ def test_init():
 ################# compute overlap tests ###################################
 
 def test_compute_overlap():
+    """Ensure overlap rejects inputs that are not vector-like."""
     pyci_obj = make_test_instance()
 
     # compute overlap between the pyci wavefunction and a random vector
@@ -105,6 +113,7 @@ def test_compute_overlap():
     assert np.allclose(overlap, np.ones(olp_size))
 
 def test_compute_overlap_type_check():
+    """Ensure overlap rejects inputs that are not vector-like."""
     pyci_obj = make_test_instance()
     with pytest.raises(ValueError):
         pyci_obj.compute_overlap(np.array([[0, 1]]), "not_a_vector")
@@ -113,6 +122,7 @@ def test_compute_overlap_type_check():
 ################# compute overlap deriv tests ###################################
 
 def test_compute_overlap_deriv():
+    """Verify overlap derivative shapes and values for supported inputs."""
     pyci_obj = make_test_instance()
     # compute overlap derivatives between the pyci wavefunction and a random vector
     overlap_deriv = pyci_obj.compute_overlap_deriv(np.random.rand(4), "P")
@@ -131,6 +141,7 @@ def test_compute_overlap_deriv():
     assert np.allclose(overlap_deriv, np.zeros(overlap_deriv.shape))
 
 def test_compute_overlap_deriv_type_check():
+    """Ensure overlap derivatives reject non-vector inputs."""
     pyci_obj = make_test_instance()
     with pytest.raises(ValueError):
         pyci_obj.compute_overlap_deriv(np.array([[0, 1]]), "not_a_vector")
@@ -138,6 +149,8 @@ def test_compute_overlap_deriv_type_check():
 ################# compute overlap double derivtests ###################################
 
 def test_compute_overlap_double_deriv_errors():
+    """Verify double-derivative error paths for invalid and unsupported inputs."""
+
     pyci_obj = make_test_instance()
     with pytest.raises(ValueError):
         pyci_obj.compute_overlap_double_deriv(np.random.rand(4), "not_a_vector")
@@ -146,6 +159,7 @@ def test_compute_overlap_double_deriv_errors():
         pyci_obj.compute_overlap_double_deriv(np.random.rand(4), "P")
 
 def test_compute_overlap_double_deriv():
+    """Verify double overlap derivative shapes and values for CC wavefunctions."""
 
     # build python objective with CC wfn
     wfn = FakeCC(nelec=2, nspin=4)

--- a/tests/test_interface_fanci_legacy.py
+++ b/tests/test_interface_fanci_legacy.py
@@ -2,36 +2,13 @@
 
 import numpy as np
 import pytest
+from unittest.mock import patch 
 
-from fanpy.interface.fanci.legacy import ProjectedSchrodingerFanCI
+from fanpy.interface.fanci.legacy import ProjectedSchrodingerFanCI, ProjectedSchrodingerLegacyFanCI
 import pyci
 
 from interface_utils import FakeCC, FakeSchrodinger, FakeHamiltonian, FakeWavefunction
 
-# todo: missing lines: based on this test only! 
-# __init__ 206, 210, 216-217, 219-220, 224, 229-230, 
-# norm constraint 282-285, 292-306, 
-# optimize 338-378, 
-# optimize stochastic 415-461, 
-# add constraint 479-482, 
-# remove constraint 494-497, 
-# freeze and unfreeze parameter 509-513, 525-529, 
-# compute objective 549-579, 
-# compute jacobian 600-652, 
-# make param constraint 675-692, 
-# make det constraint 715-732, 
-# mask function 751-763,
-# abstract compute olp, olp deriv, olp double deriv  785, 807, 829, 
-# fill wfn 850-853, 860, 874-885, 888, 892, 
-# compute olp 1118, 
-# compute olp deriv 1180, 1190-1197, 1199, 
-# compute objective 1276-1291, 
-# compute jac 1310-1317, 
-# save params 1329-1342, 
-# optimize 1412-1469, 
-# print 1472-1473, 
-# optimize stochastic 1510-1586, 
-# olp deriv chunks 1589-1601
 
 ############## Tools for testing purposes #########################
 
@@ -62,7 +39,7 @@ def make_test_instance(**overrides):
         "seniority": wfn.seniority,
         "nproj": 1,
         "fill": "excitation",
-        "mask": np.ones(wfn.params.shape, dtype=int),
+        "mask": np.ones(wfn.params.shape[0]+1, dtype=bool),
         "constraints": {},
         "param_selection": obj.indices_component_params,
         "norm_param": None,
@@ -194,18 +171,184 @@ def test_compute_overlap_double_deriv():
 
 ################# compute objective tests ###################################
 
+def test_compute_objective():
+    """Check that objective evaluation delegates to the PyCI implementation."""
+    pyci_obj = make_test_instance()
+
+    params = np.random.rand(pyci_obj.nactive)
+    mock_result = np.ones(pyci_obj.nactive) * 42.0
+
+    # patch the compute objective method from PyCI to return a fixed value. 
+    # we just need to check if we call the correct method with the parameters
+    # the rest is up to PyCI
+    with patch.object(ProjectedSchrodingerLegacyFanCI, "compute_objective", return_value=mock_result) as mock_method:
+        result = pyci_obj.compute_objective(params)
+        mock_method.assert_called_once_with(params)
+    
+    assert np.allclose(result, mock_result)
+
+def test_compute_objective_step_save(tmp_path):
+    """Verify objective evaluation saves the wavefunction parameters when enabled."""
+    outfile = tmp_path / "output"
+    pyci_obj = make_test_instance(step_save=True, tmpfile=outfile)
+    new_params = np.random.rand(pyci_obj.nactive)
+    _ = pyci_obj.compute_objective(new_params)
+
+    # default filename is <user specified name>_wfnClassName.npy
+    filename = tmp_path / "output_FakeWavefunction.npy"
+    saved_wfn_params = np.load(filename)
+
+    # compare saved wfn params to input of objective 
+    # NOTE: new_params[-1] is the energy
+    assert np.allclose(saved_wfn_params, new_params[:-1]) 
 
 ################# compute jacobian tests ###################################
 
-# compute masked jacobian tests
-# Mock the following: 
-# self.ci_op
-# compute overlap
-# compute overlap derivative 
-# that simplifies the testing procedure. 
+def test_compute_jacobian():
+    """Check that Jacobian evaluation delegates to the PyCI implementation."""
+    pyci_obj = make_test_instance()
+    params = np.random.rand(pyci_obj.nactive)
+    mock_result = np.ones((pyci_obj.nactive, pyci_obj.nproj)) * 42.0 # this is likely the wrong dimension. Just checking here that 2D arrays work. 
+
+    # patch the compute jacobian method from PyCI to return a fixed value (mock result). 
+    # we just need to check if we call the correct method with the parameters
+    # the rest is up to PyCI
+    with patch.object(ProjectedSchrodingerLegacyFanCI, "compute_jacobian", return_value=mock_result) as mock_method:
+        result = pyci_obj.compute_jacobian(params)
+        mock_method.assert_called_once_with(params)
+    
+    assert np.allclose(result, mock_result)
+
+# the last index of the mask corresponds to the energy, so we check both cases where E is active or inactive. 
+@pytest.mark.parametrize("mask", [np.asarray([1, 0, 1, 0, 0], dtype=bool), np.asarray([1, 0, 1, 0, 1], dtype=bool)])
+def test_compute_masked_jacobian(mask):
+    """Verify masked Jacobians match sliced unmasked Jacobians.
+        
+    Parameters
+    ----------
+    mask : np.ndarray with dtype bool
+        List of parameters to freeze. E.g. [True, False, True] would freeze the second parameter. 
+    """
+    pyci_obj = make_test_instance() # wfn has four params
+
+    pyci_obj_masked = make_test_instance(mask=mask)
+    x = np.random.rand(5)
+    jac = pyci_obj.compute_jacobian(x)
+    print("DEBUG >>> normal jac shape: ", jac.shape)
+    masked_jac = pyci_obj_masked.compute_jacobian(x)
+    cols = [i for i in range(len(mask)) if mask[i]]
+    jac_sliced = jac[:, cols]
+    print(jac)
+    assert masked_jac.shape[1] == sum(mask)
+    assert np.allclose(jac_sliced, masked_jac) # todo this is not checking a ton, as olp deriv is 0. Only energy is -1. Having a check similar to this with an actual H might be useful 
+
+def test_compute_jac_step_save(tmp_path):
+    """Verify Jacobian evaluation also persists wavefunction parameters when enabled."""
+    outfile = tmp_path / "output"
+    pyci_obj = make_test_instance(step_save=True, tmpfile=outfile)
+    new_params = np.random.rand(pyci_obj.nactive)
+    _ = pyci_obj.compute_jacobian(new_params)
+
+    # default filename is <user specified name>_wfnClassName.npy
+    filename = tmp_path / "output_FakeWavefunction.npy"
+    saved_wfn_params = np.load(filename)
+
+    # compare saved wfn params to input of objective 
+    # NOTE: new_params[-1] is the energy
+    assert np.allclose(saved_wfn_params, new_params[:-1])
 
 
 ################# optimize tests ###################################
 
+# NOTE: none of these tests check if we get sensible results, the point here is to check that we can run optimizers successfully with different modes and parameter masks
+
+@pytest.mark.parametrize("mask", [np.ones(5, dtype=int), np.asarray([1, 0, 1, 0, 0], dtype=bool), np.asarray([1, 0, 1, 0, 1], dtype=bool)])
+def test_optimize_lstsq(mask):
+    """ Check if optimize method runs without errors and energy is one of the keys.
+    
+    Parameters
+    ----------
+    mask : np.ndarray with dtype bool
+        List of parameters to freeze. E.g. [True, False, True] would freeze the second parameter. 
+    """
+    pyci_obj = make_test_instance(mask=mask)
+    initial_guess = np.random.rand(pyci_obj.fanpy_wfn.nparams+1)
+    results = pyci_obj.optimize(initial_guess, mode="lstsq")
+    assert "energy" in results.keys()
+
+def test_optimize_root():
+    """ Check if optimize method runs without errors and energy is one of the keys"""
+    # set up objective with less wfn params. We cannot generate 5 or more projections
+    # changing the FakeWavefunction in setup step is more complicated with hardcoded 4 params. 
+    wfn = FakeWavefunction(2, 4, np.ones(3))
+    ham = FakeHamiltonian(np.ones((2, 2)), np.ones((2, 2, 2, 2)))
+    obj = FakeSchrodinger(wfn, ham)
+    mask = np.ones(wfn.nparams + 1, dtype=bool) # determines nactive in PyCI object
+    param_sel = obj.indices_component_params # parameter selection based on fanpy objective
+
+    pyci_obj = make_test_instance(fanpy_objective=obj, nproj=wfn.nparams + 1, mask=mask, param_selection=param_sel)
+
+    # initial guess
+    x0 = np.random.rand(pyci_obj.nactive)
+
+    results = pyci_obj.optimize(x0, mode='root')
+
+    assert "energy" in results.keys()
+
+def test_optimize_errors():
+    """Ensure optimize rejects invalid modes and incompatible parameter shapes."""
+    pyci_obj = make_test_instance()
+    initial_guess = np.random.rand(pyci_obj.nactive)
+    with pytest.raises(ValueError):
+        pyci_obj.optimize(initial_guess, "not a mode")
+    with pytest.raises(ValueError): # default is an overdetermined system
+        pyci_obj.optimize(initial_guess, "root")
+    wrong_params = np.random.rand(pyci_obj.nactive+10)
+    with pytest.raises(ValueError):
+        pyci_obj.optimize(wrong_params, "lstsq")
+
+def test_optimize_norm_const():
+    """Verify optimization succeeds when normalization constraint is generated with default kwargs."""
+    # NOTE: by default constraints is None, which generates the norm constraint as long as norm det is also None
+    pyci_obj = make_test_instance(constraints=None)
+
+    initial_guess = np.random.rand(pyci_obj.nactive)
+    results = pyci_obj.optimize(initial_guess, mode='lstsq')
+    assert "energy" in results.keys()
+
+def test_optimize_use_jac():
+    """Verify optimization succeeds when the Jacobian path is enabled."""
+    pyci_obj = make_test_instance(constraints=None)
+
+    initial_guess = np.random.rand(pyci_obj.nactive)
+    results = pyci_obj.optimize(initial_guess, mode='lstsq', use_jac=True)
+    assert "energy" in results.keys()
+
+################# optimize stochastic tests ###################################
+
+# todo: this test fails because stochastic optimizer has bugs in it. It has not been updated to the new interface class, so the re-initialization does not work. Additionally, there are other bugs in the code as well. 
+@pytest.mark.xfail()
+def test_optimize_stochasitc_lstsq():
+    """ Check if optimize method runs without errors and energy is one of the keys"""
+    mask = np.ones(5, dtype=int)
+    pyci_obj = make_test_instance(mask=mask)
+    initial_guess = np.random.rand(pyci_obj.fanpy_wfn.nparams+1)
+    results = pyci_obj.optimize_stochastic(nsamp=3, x0=initial_guess, mode="lstsq", fill = pyci_obj.fill)
+    assert "energy" in results.keys()
 
 ################# utility methods tests ###################################
+
+@pytest.mark.parametrize("freeze_idx", [[2], [1, 3, 4], [0, 1, 2, 3, 4]])
+def test_freeze_parameters(freeze_idx):
+    """Verify parameter freezing and unfreezing update the active mask."""
+    pyci_obj = make_test_instance()
+    mask = np.ones(pyci_obj.nparam, dtype=bool)
+    freeze_idx = [2]
+    pyci_obj.freeze_parameter(freeze_idx)
+    # manually update mask
+    mask[freeze_idx] = np.zeros(len(freeze_idx), dtype=bool)
+    assert np.all(np.equal(mask, pyci_obj.mask))
+
+    # unfreeze parameters:
+    pyci_obj.unfreeze_parameter(freeze_idx)
+    assert np.all(np.equal(np.ones(pyci_obj.nparam, dtype=bool), pyci_obj.mask)) # all parameters are unfrozen --> mask is all 1

--- a/tests/test_interface_fanci_legacy.py
+++ b/tests/test_interface_fanci_legacy.py
@@ -248,7 +248,6 @@ def test_compute_masked_jacobian(mask):
     pyci_obj_masked = make_test_instance(mask=mask)
     x = np.random.rand(5)
     jac = pyci_obj.compute_jacobian(x)
-    print("DEBUG >>> normal jac shape: ", jac.shape)
     masked_jac = pyci_obj_masked.compute_jacobian(x)
     cols = [i for i in range(len(mask)) if mask[i]]
     jac_sliced = jac[:, cols]

--- a/tests/test_interface_fanci_pyci.py
+++ b/tests/test_interface_fanci_pyci.py
@@ -5,8 +5,6 @@ import pytest
 from unittest.mock import patch 
 
 from fanpy.interface.fanci.pyci import ProjectedSchrodingerPyCI
-from fanpy.eqn.projected import ProjectedSchrodinger
-from fanpy.tools.sd_list import sd_list
 import pyci
 
 from interface_utils import FakeHamiltonian, FakeWavefunction, FakeSchrodinger, FakeCC
@@ -266,7 +264,17 @@ def test_optimize_norm_const():
     results = pyci_obj.optimize(initial_guess, mode='lstsq')
     assert "energy" in results.keys()
 
+################# optimize stochastic tests ###################################
 
+# todo: this test fails because stochastic optimizer has bugs in it. It has not been updated to the new interface class, so the re-initialization does not work. Additionally, there are other bugs in the code as well. 
+@pytest.mark.xfail()
+def test_optimize_stochasitc_lstsq(mask):
+    """ Check if optimize method runs without errors and energy is one of the keys"""
+    mask = np.ones(5, dtype=int)
+    pyci_obj = make_test_instance(mask=mask)
+    initial_guess = np.random.rand(pyci_obj.fanpy_wfn.nparams+1)
+    results = pyci_obj.optimize_stochastic(nsamp=3, x0=initial_guess, mode="lstsq", fill = pyci_obj.fill)
+    assert "energy" in results.keys()
 
 ################# utility methods tests ###################################
 

--- a/tests/test_interface_fanci_pyci.py
+++ b/tests/test_interface_fanci_pyci.py
@@ -278,3 +278,16 @@ def test_optimize_stochasitc_lstsq(mask):
 
 ################# utility methods tests ###################################
 
+@pytest.mark.parametrize("freeze_idx", [[2], [1, 3, 4], [0, 1, 2, 3, 4]])
+def test_freeze_parameters(freeze_idx):
+    pyci_obj = make_test_instance()
+    mask = np.ones(pyci_obj.nparam, dtype=bool)
+    freeze_idx = [2]
+    pyci_obj.freeze_parameter(freeze_idx)
+    # manually update mask
+    mask[freeze_idx] = np.zeros(len(freeze_idx), dtype=bool)
+    assert np.all(np.equal(mask, pyci_obj.mask))
+
+    # unfreeze parameters:
+    pyci_obj.unfreeze_parameter(freeze_idx)
+    assert np.all(np.equal(np.ones(pyci_obj.nparam, dtype=bool), pyci_obj.mask)) # all parameters are unfrozen --> mask is all 1

--- a/tests/test_interface_fanci_pyci.py
+++ b/tests/test_interface_fanci_pyci.py
@@ -6,30 +6,9 @@ import pytest
 from fanpy.interface.fanci.pyci import ProjectedSchrodingerPyCI
 import pyci
 
-from test_interface_pyci import FakeHamiltonian, FakeWavefunction
-
-from fanpy.eqn.projected import BaseSchrodinger
-from fanpy.wfn.cc.standard_cc import StandardCC
+from interface_utils import FakeHamiltonian, FakeWavefunction, FakeSchrodinger, FakeCC
 
 ############## Tools for testing purposes #########################
-
-class FakeSchrodinger(BaseSchrodinger):
-    """fake fanpy objective for testing purposes"""
-    def __init__(self, wfn, ham):
-        super().__init__(wfn, ham)
-    def objective(self, params):
-        return 3.08
-
-class FakeCC(StandardCC):
-    """fake CC wavefunction for testing purposes
-    This is used to test the double derivative of the overlap.
-    """
-    def __init__(self, nelec, nspin):
-        super().__init__(nelec, nspin)
-
-    def get_overlap_double_derivative(self, sd):
-        double_deriv = np.ones((self.nparams, self.nparams))
-        return double_deriv
 
 def make_test_instance(**overrides):
     """make test instance of ProjectedSchrodingerPyCI with fake fanpy objective and fake pyci hamiltonian and wavefunction

--- a/tests/test_interface_fanci_pyci.py
+++ b/tests/test_interface_fanci_pyci.py
@@ -5,6 +5,8 @@ import pytest
 from unittest.mock import patch 
 
 from fanpy.interface.fanci.pyci import ProjectedSchrodingerPyCI
+from fanpy.eqn.projected import ProjectedSchrodinger
+from fanpy.tools.sd_list import sd_list
 import pyci
 
 from interface_utils import FakeHamiltonian, FakeWavefunction, FakeSchrodinger, FakeCC
@@ -201,6 +203,7 @@ def test_compute_jacobian():
     
     assert np.allclose(result, mock_result)
 
+# the last index of the mask corresponds to the energy, so we check both cases where E is active or inactive. 
 @pytest.mark.parametrize("mask", [np.asarray([1, 0, 1, 0, 0], dtype=bool), np.asarray([1, 0, 1, 0, 1], dtype=bool)])
 def test_compute_masked_jacobian(mask):
     pyci_obj = make_test_instance() # wfn has four params
@@ -218,6 +221,51 @@ def test_compute_masked_jacobian(mask):
 
 
 ################# optimize tests ###################################
+
+# NOTE: none of these tests check if we get sensible results, the point here is to check that we can run optimizers successfully with different modes and parameter masks
+
+@pytest.mark.parametrize("mask", [np.ones(5, dtype=int), np.asarray([1, 0, 1, 0, 0], dtype=bool), np.asarray([1, 0, 1, 0, 1], dtype=bool)])
+def test_optimize_lstsq(mask):
+    """ Check if optimize method runs without errors and energy is one of the keys"""
+    pyci_obj = make_test_instance(mask=mask)
+    initial_guess = np.random.rand(pyci_obj.fanpy_wfn.nparams+1)
+    results = pyci_obj.optimize(initial_guess, mode="lstsq")
+    assert "energy" in results.keys()
+
+def test_optimize_root():
+    """ Check if optimize method runs without errors and energy is one of the keys"""
+    # set up objective with less wfn params. We cannot generate 5 or more projections
+    # changing the FakeWavefunction in setup step is more complicated with hardcoded 4 params. 
+    wfn = FakeWavefunction(2, 4, np.ones(3))
+    ham = FakeHamiltonian(np.ones((2, 2)), np.ones((2, 2, 2, 2)))
+    obj = FakeSchrodinger(wfn, ham)
+    mask = np.ones(wfn.nparams + 1, dtype=bool) # determines nactive in PyCI object
+    param_sel = obj.indices_component_params # parameter selection based on fanpy objective
+
+    pyci_obj = make_test_instance(fanpy_objective=obj, nproj=wfn.nparams + 1, mask=mask, param_selection=param_sel)
+
+    # initial guess
+    x0 = np.random.rand(pyci_obj.nactive)
+
+    results = pyci_obj.optimize(x0, mode='root')
+
+    assert "energy" in results.keys()
+
+def test_optimize_errors():
+    pyci_obj = make_test_instance()
+    initial_guess = np.random.rand(pyci_obj.nactive)
+    with pytest.raises(ValueError):
+        pyci_obj.optimize(initial_guess, "not a mode")
+    with pytest.raises(ValueError): # default is an overdetermined system
+        pyci_obj.optimize(initial_guess, "root")
+
+def test_optimize_norm_const():
+    pyci_obj = make_test_instance(constraints=None)
+
+    initial_guess = np.random.rand(pyci_obj.nactive)
+    results = pyci_obj.optimize(initial_guess, mode='lstsq')
+    assert "energy" in results.keys()
+
 
 
 ################# utility methods tests ###################################

--- a/tests/test_interface_fanci_pyci.py
+++ b/tests/test_interface_fanci_pyci.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 import pytest
+from unittest.mock import patch 
 
 from fanpy.interface.fanci.pyci import ProjectedSchrodingerPyCI
 import pyci
@@ -36,7 +37,7 @@ def make_test_instance(**overrides):
         "seniority": wfn.seniority,
         "nproj": 1,
         "fill": "excitation",
-        "mask": np.ones(wfn.params.shape, dtype=int),
+        "mask": np.ones(wfn.params.shape[0]+1, dtype=bool),
         "constraints": {},
         "param_selection": obj.indices_component_params,
         "norm_param": None,
@@ -168,15 +169,52 @@ def test_compute_overlap_double_deriv():
 
 ################# compute objective tests ###################################
 
+def test_compute_objective():
+    pyci_obj = make_test_instance()
+
+    params = np.random.rand(pyci_obj.nactive)
+    mock_result = np.ones(pyci_obj.nactive) * 42.0
+
+    # patch the compute objective method from PyCI to return a fixed value. 
+    # we just need to check if we call the correct method with the parameters
+    # the rest is up to PyCI
+    with patch.object(pyci.fanci.FanCI, "compute_objective", return_value=mock_result) as mock_method:
+        result = pyci_obj.compute_objective(params)
+        mock_method.assert_called_once_with(params)
+    
+    assert np.allclose(result, mock_result)
+
 
 ################# compute jacobian tests ###################################
 
-# compute masked jacobian tests
-# Mock the following: 
-# self.ci_op
-# compute overlap
-# compute overlap derivative 
-# that simplifies the testing procedure. 
+def test_compute_jacobian():
+    pyci_obj = make_test_instance()
+    params = np.random.rand(pyci_obj.nactive)
+    mock_result = np.ones((pyci_obj.nactive, pyci_obj.nproj)) * 42.0 # this is likely the wrong dimension. Just checking here that 2D arrays work. 
+
+    # patch the compute jacobian method from PyCI to return a fixed value (mock result). 
+    # we just need to check if we call the correct method with the parameters
+    # the rest is up to PyCI
+    with patch.object(pyci.fanci.FanCI, "compute_jacobian", return_value=mock_result) as mock_method:
+        result = pyci_obj.compute_jacobian(params)
+        mock_method.assert_called_once_with(params)
+    
+    assert np.allclose(result, mock_result)
+
+@pytest.mark.parametrize("mask", [np.asarray([1, 0, 1, 0, 0], dtype=bool), np.asarray([1, 0, 1, 0, 1], dtype=bool)])
+def test_compute_masked_jacobian(mask):
+    pyci_obj = make_test_instance() # wfn has four params
+
+    pyci_obj_masked = make_test_instance(mask=mask)
+    x = np.random.rand(5)
+    jac = pyci_obj.compute_jacobian(x)
+    print("DEBUG >>> normal jac shape: ", jac.shape)
+    masked_jac = pyci_obj_masked.compute_jacobian(x)
+    cols = [i for i in range(len(mask)) if mask[i]]
+    jac_sliced = jac[:, cols]
+    print(jac)
+    assert masked_jac.shape[1] == sum(mask)
+    assert np.allclose(jac_sliced, masked_jac) # todo this is checking a ton, as olp deriv is 0. Only energy is -1. Having a check similar to this with an actual H might be useful 
 
 
 ################# optimize tests ###################################

--- a/tests/test_interface_fanci_pyci.py
+++ b/tests/test_interface_fanci_pyci.py
@@ -184,6 +184,19 @@ def test_compute_objective():
     
     assert np.allclose(result, mock_result)
 
+def test_step_save(tmp_path):
+    outfile = tmp_path / "output"
+    pyci_obj = make_test_instance(step_save=True, tmpfile=outfile)
+    new_params = np.random.rand(pyci_obj.nactive)
+    _ = pyci_obj.compute_objective(new_params)
+
+    # default filename is <user specified name>_wfnClassName.npy
+    filename = tmp_path / "output_FakeWavefunction.npy"
+    saved_wfn_params = np.load(filename)
+
+    # compare saved wfn params to input of objective 
+    # NOTE: new_params[-1] is the energy
+    assert np.allclose(saved_wfn_params, new_params[:-1]) 
 
 ################# compute jacobian tests ###################################
 
@@ -215,8 +228,21 @@ def test_compute_masked_jacobian(mask):
     jac_sliced = jac[:, cols]
     print(jac)
     assert masked_jac.shape[1] == sum(mask)
-    assert np.allclose(jac_sliced, masked_jac) # todo this is checking a ton, as olp deriv is 0. Only energy is -1. Having a check similar to this with an actual H might be useful 
+    assert np.allclose(jac_sliced, masked_jac) # todo this is not checking a ton, as olp deriv is 0. Only energy is -1. Having a check similar to this with an actual H might be useful 
 
+def test_compute_jac_step_save(tmp_path):
+    outfile = tmp_path / "output"
+    pyci_obj = make_test_instance(step_save=True, tmpfile=outfile)
+    new_params = np.random.rand(pyci_obj.nactive)
+    _ = pyci_obj.compute_jacobian(new_params)
+
+    # default filename is <user specified name>_wfnClassName.npy
+    filename = tmp_path / "output_FakeWavefunction.npy"
+    saved_wfn_params = np.load(filename)
+
+    # compare saved wfn params to input of objective 
+    # NOTE: new_params[-1] is the energy
+    assert np.allclose(saved_wfn_params, new_params[:-1]) 
 
 ################# optimize tests ###################################
 
@@ -256,12 +282,22 @@ def test_optimize_errors():
         pyci_obj.optimize(initial_guess, "not a mode")
     with pytest.raises(ValueError): # default is an overdetermined system
         pyci_obj.optimize(initial_guess, "root")
+    wrong_params = np.random.rand(pyci_obj.nactive+10)
+    with pytest.raises(ValueError):
+        pyci_obj.optimize(wrong_params, "lstsq")
 
 def test_optimize_norm_const():
     pyci_obj = make_test_instance(constraints=None)
 
     initial_guess = np.random.rand(pyci_obj.nactive)
     results = pyci_obj.optimize(initial_guess, mode='lstsq')
+    assert "energy" in results.keys()
+
+def test_optimize_use_jac():
+    pyci_obj = make_test_instance(constraints=None)
+
+    initial_guess = np.random.rand(pyci_obj.nactive)
+    results = pyci_obj.optimize(initial_guess, mode='lstsq', use_jac=True)
     assert "energy" in results.keys()
 
 ################# optimize stochastic tests ###################################

--- a/tests/test_interface_fanci_pyci.py
+++ b/tests/test_interface_fanci_pyci.py
@@ -12,8 +12,12 @@ from interface_utils import FakeHamiltonian, FakeWavefunction, FakeSchrodinger, 
 ############## Tools for testing purposes #########################
 
 def make_test_instance(**overrides):
-    """make test instance of ProjectedSchrodingerPyCI with fake fanpy objective and fake pyci hamiltonian and wavefunction
-    This helps set up a class that requires a lot of parameters.
+    """Build a ProjectedSchrodingerPyCI test instance with fake dependencies.
+    
+    Parameters
+    ----------
+    overrides : dict
+        override kwargs for the PyCI objetive. 
     """
     # build Fake fanpy objective
     wfn = FakeWavefunction(2, 4, np.ones(4))
@@ -52,6 +56,7 @@ def make_test_instance(**overrides):
 
 ################# init tests ###################################
 def test_init():
+    """Validate initialization and default normalization constraints."""
     # errors
     ham = "non_pyci_hamiltonian"
     with pytest.raises(TypeError):
@@ -72,6 +77,7 @@ def test_init():
 ################# compute overlap tests ###################################
 
 def test_compute_overlap():
+    """Verify overlap values for p-space, s-space, and explicit determinants."""
     pyci_obj = make_test_instance()
 
     # compute overlap between the pyci wavefunction and a random vector
@@ -103,6 +109,7 @@ def test_compute_overlap():
     assert np.allclose(overlap, np.ones(olp_size))
 
 def test_compute_overlap_type_check():
+    """Ensure overlap rejects inputs that are not vector-like."""
     pyci_obj = make_test_instance()
     with pytest.raises(ValueError):
         pyci_obj.compute_overlap(np.array([[0, 1]]), "not_a_vector")
@@ -111,6 +118,7 @@ def test_compute_overlap_type_check():
 ################# compute overlap deriv tests ###################################
 
 def test_compute_overlap_deriv():
+    """Verify overlap derivative shapes and values for supported inputs."""
     pyci_obj = make_test_instance()
     # compute overlap derivatives between the pyci wavefunction and a random vector
     overlap_deriv = pyci_obj.compute_overlap_deriv(np.random.rand(4), "P")
@@ -129,6 +137,7 @@ def test_compute_overlap_deriv():
     assert np.allclose(overlap_deriv, np.zeros(overlap_deriv.shape))
 
 def test_compute_overlap_deriv_type_check():
+    """Ensure overlap derivatives reject non-vector inputs."""
     pyci_obj = make_test_instance()
     with pytest.raises(ValueError):
         pyci_obj.compute_overlap_deriv(np.array([[0, 1]]), "not_a_vector")
@@ -136,6 +145,7 @@ def test_compute_overlap_deriv_type_check():
 ################# compute overlap double derivtests ###################################
 
 def test_compute_overlap_double_deriv_errors():
+    """Verify double-derivative error paths for invalid and unsupported inputs."""
     pyci_obj = make_test_instance()
     with pytest.raises(ValueError):
         pyci_obj.compute_overlap_double_deriv(np.random.rand(4), "not_a_vector")
@@ -144,6 +154,7 @@ def test_compute_overlap_double_deriv_errors():
         pyci_obj.compute_overlap_double_deriv(np.random.rand(4), "P")
 
 def test_compute_overlap_double_deriv():
+    """Verify double overlap derivative shapes and values for CC wavefunctions."""
 
     # build python objective with CC wfn
     wfn = FakeCC(nelec=2, nspin=4)
@@ -170,6 +181,7 @@ def test_compute_overlap_double_deriv():
 ################# compute objective tests ###################################
 
 def test_compute_objective():
+    """Check that objective evaluation delegates to the PyCI implementation."""
     pyci_obj = make_test_instance()
 
     params = np.random.rand(pyci_obj.nactive)
@@ -184,7 +196,8 @@ def test_compute_objective():
     
     assert np.allclose(result, mock_result)
 
-def test_step_save(tmp_path):
+def test_compute_objective_step_save(tmp_path):
+    """Verify objective evaluation saves the wavefunction parameters when enabled."""
     outfile = tmp_path / "output"
     pyci_obj = make_test_instance(step_save=True, tmpfile=outfile)
     new_params = np.random.rand(pyci_obj.nactive)
@@ -201,6 +214,7 @@ def test_step_save(tmp_path):
 ################# compute jacobian tests ###################################
 
 def test_compute_jacobian():
+    """Check that Jacobian evaluation delegates to the PyCI implementation."""
     pyci_obj = make_test_instance()
     params = np.random.rand(pyci_obj.nactive)
     mock_result = np.ones((pyci_obj.nactive, pyci_obj.nproj)) * 42.0 # this is likely the wrong dimension. Just checking here that 2D arrays work. 
@@ -217,6 +231,13 @@ def test_compute_jacobian():
 # the last index of the mask corresponds to the energy, so we check both cases where E is active or inactive. 
 @pytest.mark.parametrize("mask", [np.asarray([1, 0, 1, 0, 0], dtype=bool), np.asarray([1, 0, 1, 0, 1], dtype=bool)])
 def test_compute_masked_jacobian(mask):
+    """Verify masked Jacobians match sliced unmasked Jacobians.
+        
+    Parameters
+    ----------
+    mask : np.ndarray with dtype bool
+        List of parameters to freeze. E.g. [True, False, True] would freeze the second parameter. 
+    """
     pyci_obj = make_test_instance() # wfn has four params
 
     pyci_obj_masked = make_test_instance(mask=mask)
@@ -231,6 +252,7 @@ def test_compute_masked_jacobian(mask):
     assert np.allclose(jac_sliced, masked_jac) # todo this is not checking a ton, as olp deriv is 0. Only energy is -1. Having a check similar to this with an actual H might be useful 
 
 def test_compute_jac_step_save(tmp_path):
+    """Verify Jacobian evaluation also persists wavefunction parameters when enabled."""
     outfile = tmp_path / "output"
     pyci_obj = make_test_instance(step_save=True, tmpfile=outfile)
     new_params = np.random.rand(pyci_obj.nactive)
@@ -250,7 +272,13 @@ def test_compute_jac_step_save(tmp_path):
 
 @pytest.mark.parametrize("mask", [np.ones(5, dtype=int), np.asarray([1, 0, 1, 0, 0], dtype=bool), np.asarray([1, 0, 1, 0, 1], dtype=bool)])
 def test_optimize_lstsq(mask):
-    """ Check if optimize method runs without errors and energy is one of the keys"""
+    """ Check if optimize method runs without errors and energy is one of the keys.
+    
+    Parameters
+    ----------
+    mask : np.ndarray with dtype bool
+        List of parameters to freeze. E.g. [True, False, True] would freeze the second parameter. 
+    """
     pyci_obj = make_test_instance(mask=mask)
     initial_guess = np.random.rand(pyci_obj.fanpy_wfn.nparams+1)
     results = pyci_obj.optimize(initial_guess, mode="lstsq")
@@ -276,6 +304,7 @@ def test_optimize_root():
     assert "energy" in results.keys()
 
 def test_optimize_errors():
+    """Ensure optimize rejects invalid modes and incompatible parameter shapes."""
     pyci_obj = make_test_instance()
     initial_guess = np.random.rand(pyci_obj.nactive)
     with pytest.raises(ValueError):
@@ -287,6 +316,8 @@ def test_optimize_errors():
         pyci_obj.optimize(wrong_params, "lstsq")
 
 def test_optimize_norm_const():
+    """Verify optimization succeeds when normalization constraint is generated with default kwargs."""
+    # NOTE: by default constraints is None, which generates the norm constraint as long as norm det is also None
     pyci_obj = make_test_instance(constraints=None)
 
     initial_guess = np.random.rand(pyci_obj.nactive)
@@ -294,6 +325,7 @@ def test_optimize_norm_const():
     assert "energy" in results.keys()
 
 def test_optimize_use_jac():
+    """Verify optimization succeeds when the Jacobian path is enabled."""
     pyci_obj = make_test_instance(constraints=None)
 
     initial_guess = np.random.rand(pyci_obj.nactive)
@@ -304,7 +336,7 @@ def test_optimize_use_jac():
 
 # todo: this test fails because stochastic optimizer has bugs in it. It has not been updated to the new interface class, so the re-initialization does not work. Additionally, there are other bugs in the code as well. 
 @pytest.mark.xfail()
-def test_optimize_stochasitc_lstsq(mask):
+def test_optimize_stochasitc_lstsq():
     """ Check if optimize method runs without errors and energy is one of the keys"""
     mask = np.ones(5, dtype=int)
     pyci_obj = make_test_instance(mask=mask)
@@ -316,6 +348,7 @@ def test_optimize_stochasitc_lstsq(mask):
 
 @pytest.mark.parametrize("freeze_idx", [[2], [1, 3, 4], [0, 1, 2, 3, 4]])
 def test_freeze_parameters(freeze_idx):
+    """Verify parameter freezing and unfreezing update the active mask."""
     pyci_obj = make_test_instance()
     mask = np.ones(pyci_obj.nparam, dtype=bool)
     freeze_idx = [2]

--- a/tests/test_interface_pyci.py
+++ b/tests/test_interface_pyci.py
@@ -5,6 +5,7 @@ from utils import find_datafile
 
 from fanpy.interface.pyci import PYCI
 from fanpy.eqn.projected import ProjectedSchrodinger
+from fanpy.eqn.energy_oneside import EnergyOneSideProjection
 from fanpy.ham.restricted_chemical import RestrictedMolecularHamiltonian
 from fanpy.wfn.cc.standard_cc import StandardCC
 from fanpy.tools.sd_list import sd_list
@@ -227,3 +228,12 @@ def test_behavior_regression_small_system(legacy_fanci):
     results = interface.objective.optimize(x0=x0)
     assert results["cost"] < initial_cost # optimization should reduce cost
     assert not np.allclose(results['energy'], expected_obj[-1], atol=10**-3) # energy should be different from initial objective value
+
+
+def test_projected_check():
+    """make sure we cannot initialize PYCI class with an objective that is not the projected schrodinger equation"""
+    setup_data = PyCITestSetup()
+    objective = EnergyOneSideProjection(setup_data.wfn, setup_data.ham)
+    with pytest.raises(TypeError):
+        PYCI(objective, 0.0)
+    

--- a/tests/test_interface_pyci.py
+++ b/tests/test_interface_pyci.py
@@ -341,3 +341,13 @@ def test_fanpy_ham_setter():
     assert np.allclose(pyci_obj.pyci_ham.two_mo, two_int)
     assert np.allclose(pyci_obj.fanpy_ham.one_int, one_int)
     assert np.allclose(pyci_obj.fanpy_ham.two_int, two_int)
+
+def test_ham_setter_type_check():
+    setup_data = PyCITestSetup() # ham params initialized to zeros
+    fanpy_obj = ProjectedSchrodinger(setup_data.wfn, setup_data.ham)
+    pyci_obj = PYCI(fanpy_obj, 0.0)
+
+    with pytest.raises(TypeError):
+        pyci_obj.fanpy_ham = "not a Hamiltonian"
+    with pytest.raises(TypeError):
+        pyci_obj.pyci_ham = "not a Hamiltonian"

--- a/tests/test_interface_pyci.py
+++ b/tests/test_interface_pyci.py
@@ -255,3 +255,39 @@ def test_fill_seniority():
     interface = PYCI(fanpy_objective, 0.0)
     assert interface.nproj == len(pspace)
     assert isinstance(interface.pspace_wfn, pyci.doci_wfn)
+
+def test_update_objective_fanpy_ham():
+    setup_data = PyCITestSetup() # ham params initialized to zeros
+    fanpy_obj = ProjectedSchrodinger(setup_data.wfn , setup_data.ham)
+    pyci_obj = PYCI(fanpy_obj, 0.0)
+
+    one_int =  np.random.rand(2, 2)
+    two_int = np.random.rand(2, 2, 2, 2)
+    new_ham = RestrictedMolecularHamiltonian(one_int, two_int)
+    pyci_obj.update_objective(new_ham)
+
+    # check if Fanpy ham got updated
+    assert np.allclose(pyci_obj.fanpy_ham.one_int, one_int)
+    assert np.allclose(pyci_obj.fanpy_ham.two_int, two_int)
+
+    # check if PyCI ham got updated
+    assert np.allclose(pyci_obj.pyci_ham.one_mo, one_int)
+    assert np.allclose(pyci_obj.pyci_ham.two_mo, two_int)
+
+def test_update_objective_pyci_ham():
+    setup_data = PyCITestSetup() # ham params initialized to zeros
+    fanpy_obj = ProjectedSchrodinger(setup_data.wfn, setup_data.ham)
+    pyci_obj = PYCI(fanpy_obj, 0.0)
+
+    one_int =  np.random.rand(2, 2)
+    two_int = np.random.rand(2, 2, 2, 2)
+    new_ham = pyci.hamiltonian(0.0, one_int, two_int)
+    pyci_obj.update_objective(new_ham)
+
+    # check if Fanpy ham got updated
+    assert np.allclose(pyci_obj.fanpy_ham.one_int, one_int)
+    assert np.allclose(pyci_obj.fanpy_ham.two_int, two_int)
+
+    # check if PyCI ham got updated
+    assert np.allclose(pyci_obj.pyci_ham.one_mo, one_int)
+    assert np.allclose(pyci_obj.pyci_ham.two_mo, two_int)

--- a/tests/test_interface_pyci.py
+++ b/tests/test_interface_pyci.py
@@ -291,3 +291,53 @@ def test_update_objective_pyci_ham():
     # check if PyCI ham got updated
     assert np.allclose(pyci_obj.pyci_ham.one_mo, one_int)
     assert np.allclose(pyci_obj.pyci_ham.two_mo, two_int)
+
+def test_pyci_ham_setter():
+    setup_data = PyCITestSetup() # ham params initialized to zeros
+    fanpy_obj = ProjectedSchrodinger(setup_data.wfn, setup_data.ham)
+    pyci_obj = PYCI(fanpy_obj, 0.0)
+
+    # setting it with pyci ham
+    one_int =  np.random.rand(2, 2)
+    two_int = np.random.rand(2, 2, 2, 2)
+    new_ham = pyci.hamiltonian(0.0, one_int, two_int)
+    pyci_obj.pyci_ham = new_ham
+    assert np.allclose(pyci_obj.pyci_ham.one_mo, one_int)
+    assert np.allclose(pyci_obj.pyci_ham.two_mo, two_int)
+    assert np.allclose(pyci_obj.fanpy_ham.one_int, one_int)
+    assert np.allclose(pyci_obj.fanpy_ham.two_int, two_int)
+
+    # setting it with fanpy ham
+    one_int =  np.ones((2, 2))
+    two_int = np.ones((2, 2, 2, 2))
+    new_ham = RestrictedMolecularHamiltonian(one_int, two_int)
+    pyci_obj.pyci_ham = new_ham
+    assert np.allclose(pyci_obj.pyci_ham.one_mo, one_int)
+    assert np.allclose(pyci_obj.pyci_ham.two_mo, two_int)
+    assert np.allclose(pyci_obj.fanpy_ham.one_int, one_int)
+    assert np.allclose(pyci_obj.fanpy_ham.two_int, two_int)
+
+def test_fanpy_ham_setter():
+    setup_data = PyCITestSetup() # ham params initialized to zeros
+    fanpy_obj = ProjectedSchrodinger(setup_data.wfn, setup_data.ham)
+    pyci_obj = PYCI(fanpy_obj, 0.0)
+
+    # setting it with pyci ham
+    one_int =  np.random.rand(2, 2)
+    two_int = np.random.rand(2, 2, 2, 2)
+    new_ham = pyci.hamiltonian(0.0, one_int, two_int)
+    pyci_obj.fanpy_ham = new_ham
+    assert np.allclose(pyci_obj.pyci_ham.one_mo, one_int)
+    assert np.allclose(pyci_obj.pyci_ham.two_mo, two_int)
+    assert np.allclose(pyci_obj.fanpy_ham.one_int, one_int)
+    assert np.allclose(pyci_obj.fanpy_ham.two_int, two_int)
+
+    # setting it with fanpy ham
+    one_int =  np.ones((2, 2))
+    two_int = np.ones((2, 2, 2, 2))
+    new_ham = RestrictedMolecularHamiltonian(one_int, two_int)
+    pyci_obj.fanpy_ham = new_ham
+    assert np.allclose(pyci_obj.pyci_ham.one_mo, one_int)
+    assert np.allclose(pyci_obj.pyci_ham.two_mo, two_int)
+    assert np.allclose(pyci_obj.fanpy_ham.one_int, one_int)
+    assert np.allclose(pyci_obj.fanpy_ham.two_int, two_int)

--- a/tests/test_interface_pyci.py
+++ b/tests/test_interface_pyci.py
@@ -1,5 +1,6 @@
 import pytest
 import numpy as np
+import pyci
 
 from utils import find_datafile
 
@@ -101,6 +102,10 @@ def test_pspace_trimming(legacy_fanci):
     # interface setup
     interface = PYCI(eqn, setup_data.e_nuc, legacy_fanci=legacy_fanci)
     assert interface.nproj == len(pspace_restr)
+
+    # check that pspace wfn is pyci 
+    # FakeWavefunction has seniority = None
+    assert isinstance(interface.pspace_wfn, pyci.fullci_wfn)
 
 @pytest.mark.parametrize("legacy_fanci", [True, False])
 def test_mask(legacy_fanci):
@@ -237,3 +242,16 @@ def test_projected_check():
     with pytest.raises(TypeError):
         PYCI(objective, 0.0)
     
+def test_fill_seniority():
+    from fanpy.wfn.geminal.apig import APIG
+    sen_o_wfn = APIG(4, 8)
+    one_int = np.random.rand(4, 4)
+    two_int = np.random.rand(4, 4, 4, 4)
+    test_ham = RestrictedMolecularHamiltonian(
+        one_int, two_int
+    )
+    pspace = sd_list(4, 8, num_limit=None, exc_orders=[1, 2], spin=0, seniority=0)
+    fanpy_objective = ProjectedSchrodinger(sen_o_wfn, test_ham, energy_type="compute", pspace = pspace)
+    interface = PYCI(fanpy_objective, 0.0)
+    assert interface.nproj == len(pspace)
+    assert isinstance(interface.pspace_wfn, pyci.doci_wfn)

--- a/tests/test_interface_pyci.py
+++ b/tests/test_interface_pyci.py
@@ -4,13 +4,12 @@ import numpy as np
 from utils import find_datafile
 
 from fanpy.interface.pyci import PYCI
-from fanpy.wfn.base import BaseWavefunction
 from fanpy.eqn.projected import ProjectedSchrodinger
 from fanpy.ham.restricted_chemical import RestrictedMolecularHamiltonian
-from fanpy.ham.base import BaseHamiltonian
 from fanpy.wfn.cc.standard_cc import StandardCC
 from fanpy.tools.sd_list import sd_list
 from fanpy.tools.performance import current_memory
+from interface_utils import FakeWavefunction, FakeHamiltonian
 
 
 @pytest.mark.parametrize("legacy_fanci", [True, False])
@@ -55,80 +54,6 @@ def test_norm_constraint_chunking(legacy_fanci):
     # compare jacobians
     assert np.allclose(jac_constraint, jac_constraint_chunk)
 
-class FakeWavefunction(BaseWavefunction):
-    """ A fake wavefunction for testing purposes.
-    """
-
-    def __init__(self, nelec, nspin, params):
-        """ Initialize FakeWavefunction.
-
-        Args:
-            nelec (int): Number of electrons.
-            nspin (int): Number of spin orbitals.
-        """
-        self.assign_params(params)
-        super().__init__(nelec, nspin)
-
-    def get_overlap(self, sd, deriv=None):
-        """ Get overlap with a Slater determinant.
-
-        Args:
-            sd (int): Slater determinant in integer representation. -> not used for fake implementation.
-            deriv (np.ndarray, optional): If provided, compute the derivative of the overlap.
-
-        Returns:
-            float: Overlap value.
-        """
-        if deriv is not None:
-            return np.zeros(len(deriv))
-        else:
-            return 1.0 
-        
-    def assign_params(self, params):
-        """ Assign parameters to the wavefunction.
-
-        Args:
-            params (np.ndarray): Parameters to assign.
-        """
-        self.params = params
-
-class FakeHamiltonian(BaseHamiltonian):
-    """ A fake Hamiltonian for testing purposes.
-    """
-    def __init__(self, one_int, two_int):
-        """ Initialize FakeHamiltonian.
-
-        Args:
-            one_int (np.ndarray): One-electron integrals.
-            two_int (np.ndarray): Two-electron integrals.
-        """
-        self.one_int = one_int
-        self.two_int = two_int
-        self._nspin = one_int.shape[0] * 2 # assuming one_int is square and its size corresponds to the orbital space
-    @property
-    def nspin(self):
-        """ Return the number of spin orbitals.
-
-        Returns:
-            int: Number of spin orbitals.
-        """
-        return self._nspin
-    
-    def integrate_sd_sd(self, sd1, sd2, deriv=None):
-        """ Integrate the Hamiltonian with against two Slater determinants.
-
-        Args:
-            sd1 (int): First Slater determinant in integer representation. -> not used for fake implementation.
-            sd2 (int): Second Slater determinant in integer representation. -> not used for fake implementation.
-            deriv (np.ndarray, optional): If provided, compute the derivative of the integral.
-
-        Returns:
-            float: Integral value.
-        """
-        if deriv is not None:
-            return np.zeros(len(deriv))
-        else:
-            return 1.0
 
 class PyCITestSetup:
     """ A test setup for PyCI interface. It sets up the Restricted Hamiltonian and a fake wavefunction.


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes to the `fanpy.interface.fanci.alias` and related PyCI interface code, with a strong focus on input validation, type safety, and enhanced test coverage. The most significant changes include stricter type and value checks in the `Alias` class, improvements to interface consistency, and the addition of comprehensive unit tests for legacy, pyci and alias functionality.

**Input validation and error handling improvements:**

* Added explicit type and value checks in the `Alias` class constructor and `__call__` method to ensure probability vectors are numpy arrays, within the valid range, and 1D (with flattening and warning if not). The `__call__` method now checks that `n` is an integer within valid bounds.
* Improved error handling in the `fanpy_ham` and `pyci_ham` property setters in `fanpy/interface/pyci.py` to raise clear `TypeError`s when input types are invalid. 

**Interface and documentation consistency:**

* Updated the `mask` parameter in `fanpy/interface/fanci/pyci.py` from a `list` to a `np.ndarray` of bools, with updated docstrings to clarify its usage for freezing parameters.
* Fixed a bug in test instance creation for PyCI objects by ensuring the `mask` is correctly sized and of boolean type.

**Testing enhancements:**

* Added a new test module `tests/test_interface_fanci_alias.py` with comprehensive unit tests for the `Alias` class, covering input validation, warnings, and output correctness.
* Refactored and expanded tests in `tests/test_interface_fanci_legacy.py` and  `tests/test_interface_fanci_pyci.py`
* Added a `tests/interface_utils.py` module with reusable fake classes for testing, improving test isolation and maintainability.

** Note on test coverage ** 
* `legacy.py` does not cover the ProjectedSchrodingerLegacyFanci class individually. This is because this class is equivalent to the `pyci` `FanCI` class. 
* `pyscf_tools.py` has a lower test coverage because the localization function is not well documented, and may have a bug in it. Therefore, we are just testing the easiest case for localization. 
* `legacy.py` & `pyci.py`: we are testing the most common inputs for the objective class. There are no additional masks, `norm_det` is set to the default, etc. These are features, we do not actively use, so testing them later should suffice. Especially since the test coverage now is significantly higher. 