### PR TITLE
Bug: constraints in PyCI interface

### DIFF
--- a/fanpy/interface/pyci.py
+++ b/fanpy/interface/pyci.py
@@ -1,5 +1,7 @@
 from fanpy.ham.restricted_chemical import RestrictedMolecularHamiltonian
 from fanpy.eqn.projected import ProjectedSchrodinger
+from fanpy.eqn.constraints.norm import NormConstraint
+from fanpy.interface.pyci_utils import ConstraintAdapter
 from fanpy.tools.sd_list import sd_list
 
 import numpy as np
@@ -25,7 +27,6 @@ class PYCI:
         energy_nuc,
         norm_det=None,
         norm_param=None,
-        constraints=None,
         mask=None,
         max_memory=8192,
         legacy_fanci=False,
@@ -45,8 +46,6 @@ class PYCI:
             Determinant normalization from FanCI PyCI objective.
         norm_param : (optional)
             Parameters normalization from FanCI PyCI objective.
-        constraints : (optional)
-            Constraints conditions from FanCI PyCI objective.
         mask : Sequence[int] or Sequence[bool], optional
             List of parameters to freeze. If the list contains ints, then each element corresponds
             to a frozen parameter. If the list contains bools, then each element indicates whether
@@ -101,7 +100,6 @@ class PYCI:
         # Define default parameters to buld FanCI object
         self.norm_det = norm_det
         self.norm_param = norm_param
-        self.constraints = constraints
         self.max_memory = max_memory
 
         # Build list of indices for objective parameters
@@ -272,7 +270,7 @@ class PYCI:
                 nproj=self.nproj,
                 fill=self.fill,
                 mask=self.mask,
-                constraints=self.constraints,
+                constraints=None,
                 param_selection=self.param_selection,
                 norm_det=self.norm_det,
                 max_memory=self.max_memory,
@@ -294,7 +292,7 @@ class PYCI:
                 nproj=self.nproj,
                 fill=self.fill,
                 mask=self.mask,
-                constraints=self.constraints,
+                constraints=None,
                 param_selection=self.param_selection,
                 norm_param=self.norm_param,
                 norm_det=self.norm_det,
@@ -304,6 +302,20 @@ class PYCI:
                 tmpfile=self.tmpfile,
                 **self.kwargs,
             )
+        # add constraints from fanpy objective. 
+        for const in self.fanpy_objective.constraints:
+            if isinstance(const, NormConstraint):
+                # use normalization constraint from PyCI objective:
+                # check if normalization constraint has been built
+                if "<\\Phi|\\Psi> - 1>" in self.objective.constraints:
+                    continue
+                else: 
+                    self.note("Normalization constraint has not been built by PyCI because norm_det was specified")
+            else: 
+                const_name = const.__class__.__name__
+                adapted_const = ConstraintAdapter(const)
+                self.objective.add_constraint(const_name, adapted_const.objective, adapted_const.gradient)
+        
 
     def update_objective(self, new_ham):
         """
@@ -326,6 +338,12 @@ class PYCI:
             energy_nuc = self.energy_nuc
 
         # Create new Fanpy objective
+        # todo: we need two different types of constraints. One for Fanpy, the other for PyCI. 
+        new_constraints = []
+        for const in self.fanpy_objective.constraints:
+            if hasattr(const, "ham"): # update consts with ham attribute
+                const.ham = new_ham
+            new_constraints.append(const)          
         new_fanpy_objective = fanpy_objective_class(
             self.fanpy_wfn,
             new_ham,
@@ -339,7 +357,7 @@ class PYCI:
             eqn_weights=self.fanpy_objective.eqn_weights,
             energy_type=self.fanpy_objective.energy_type,
             energy=self.fanpy_objective.energy.params,
-            constraints=self.constraints,
+            constraints=new_constraints,
         )
 
         # Build FanCI objective as PyCI interface
@@ -348,7 +366,6 @@ class PYCI:
             energy_nuc,
             norm_det=self.norm_det,
             norm_param=self.norm_param,
-            constraints=self.constraints,
             mask=self.mask,
             max_memory=self.max_memory,
             legacy_fanci=self.legacy_fanci,

--- a/fanpy/interface/pyci_utils.py
+++ b/fanpy/interface/pyci_utils.py
@@ -1,0 +1,62 @@
+""" Adapter for Fanpy constraints"""
+
+import numpy as np
+
+from fanpy.eqn.base import BaseSchrodinger
+
+
+class ConstraintAdapter:
+    """ Constraints in Fanpy only take the wavefunction parameters as inputs, however PyCI passes the wfn parameters and the Energy.
+    This class serves as an adapter for the energy and normalization constraints in Fanpy. 
+    """
+
+    def __init__(self, constraint):
+        """ Constructor for Constraint Adapter 
+
+        Parameters
+        ----------
+        constraint : BaseSchrodinger
+            Constraint for an objective. E.g.: normalization or energy constraint. 
+        """
+        
+        if not isinstance(constraint, BaseSchrodinger):
+            raise TypeError("Constraint must be a child of the BaseSchrodinger class.")
+        self.constraint = constraint
+
+    def objective(self, x):
+        """ Calculate the value for the constraint. This truncates x and passes it to the objective of the Fanpy constraint.
+
+        Parameters
+        ----------
+        x : np.ndarray
+            Input data for the constraint. x[:-1] corresponds to wfn parameters and x[-1] is the energy parameter. 
+
+        Returns
+        -------
+        obj_value : float
+            objective value from the constraint. 
+        """
+
+        return self.constraint.objective(x[:-1])
+    
+    def gradient(self, x):
+        """ Calculate the gradient for the constraint. This truncates x and passes it to the objective of the Fanpy constraint.
+
+        Parameters
+        ----------
+        x : np.ndarray
+            Input data for the constraint. x[:-1] corresponds to wfn parameters and x[-1] is the energy parameter. 
+
+        Returns
+        -------
+        grad : np.ndarray
+            gradient of the constraint. This is padded with a 0 for the derivative w.r.t. the energy
+        """
+
+        wfn_grad = self.constraint.gradient(x[:-1]) # dim 1 x wfn params 
+        e_grad = np.zeros(1) # gradient w.r.t. E is 0, since it does not enter the Fanpy constraint 
+        grad = np.hstack((wfn_grad, e_grad))
+        return grad
+
+
+    

--- a/tests/test_interface_pyci.py
+++ b/tests/test_interface_pyci.py
@@ -1,12 +1,15 @@
 import pytest
 import numpy as np
 import pyci
+from unittest.mock import patch 
 
 from utils import find_datafile
 
 from fanpy.interface.pyci import PYCI
 from fanpy.eqn.projected import ProjectedSchrodinger
 from fanpy.eqn.energy_oneside import EnergyOneSideProjection
+from fanpy.eqn.constraints.norm import NormConstraint
+from fanpy.eqn.constraints.energy import EnergyConstraint
 from fanpy.ham.restricted_chemical import RestrictedMolecularHamiltonian
 from fanpy.wfn.cc.standard_cc import StandardCC
 from fanpy.tools.sd_list import sd_list
@@ -351,3 +354,27 @@ def test_ham_setter_type_check():
         pyci_obj.fanpy_ham = "not a Hamiltonian"
     with pytest.raises(TypeError):
         pyci_obj.pyci_ham = "not a Hamiltonian"
+
+def test_constraints_init():
+    setup_data = PyCITestSetup()
+    norm_const = NormConstraint(setup_data.wfn)
+    e_const = EnergyConstraint(setup_data.wfn, setup_data.ham)
+    fanpy_obj = ProjectedSchrodinger(setup_data.wfn, setup_data.ham, constraints=[norm_const, e_const])
+    pyci_obj = PYCI(fanpy_obj, 0.0)
+    n_pyci_consts = len(pyci_obj.objective.constraints)
+    assert n_pyci_consts == 2
+    with patch.object(EnergyConstraint, "objective", return_value = 3.08 ) as mock_method:
+        x = np.random.rand(pyci_obj.objective.nactive)
+        res = pyci_obj.objective.compute_objective(x)
+        
+        # check if we call the method at least once
+        # we do not check how many times we call the objective method,
+        # as it depends on pyci
+        assert mock_method.call_count > 0 
+
+        # make sure we get expected return value
+        assert res[-1] == 3.08 # last element is the energy constraint
+
+        # check if we passed the expected elements of x
+        adapted_x = x[:-1]
+        assert np.allclose(mock_method.call_args[0][0], adapted_x)

--- a/tests/test_interface_pyci.py
+++ b/tests/test_interface_pyci.py
@@ -356,6 +356,7 @@ def test_ham_setter_type_check():
         pyci_obj.pyci_ham = "not a Hamiltonian"
 
 def test_constraints_init():
+    """ Check if constraints are set up properly"""
     setup_data = PyCITestSetup()
     norm_const = NormConstraint(setup_data.wfn)
     e_const = EnergyConstraint(setup_data.wfn, setup_data.ham)
@@ -363,6 +364,7 @@ def test_constraints_init():
     pyci_obj = PYCI(fanpy_obj, 0.0)
     n_pyci_consts = len(pyci_obj.objective.constraints)
     assert n_pyci_consts == 2
+    # check for compute objective 
     with patch.object(EnergyConstraint, "objective", return_value = 3.08 ) as mock_method:
         x = np.random.rand(pyci_obj.objective.nactive)
         res = pyci_obj.objective.compute_objective(x)
@@ -380,6 +382,7 @@ def test_constraints_init():
         assert np.allclose(mock_method.call_args[0][0], adapted_x)
 
 def test_ham_update():
+    """ Make sure the hamiltonian gets updated in constraints that have a ham attribute."""
     setup_data = PyCITestSetup()
     norm_const = NormConstraint(setup_data.wfn)
     e_const = EnergyConstraint(setup_data.wfn, setup_data.ham)

--- a/tests/test_interface_pyci.py
+++ b/tests/test_interface_pyci.py
@@ -378,3 +378,23 @@ def test_constraints_init():
         # check if we passed the expected elements of x
         adapted_x = x[:-1]
         assert np.allclose(mock_method.call_args[0][0], adapted_x)
+
+def test_ham_update():
+    setup_data = PyCITestSetup()
+    norm_const = NormConstraint(setup_data.wfn)
+    e_const = EnergyConstraint(setup_data.wfn, setup_data.ham)
+    fanpy_obj = ProjectedSchrodinger(setup_data.wfn, setup_data.ham, constraints=[norm_const, e_const])
+    pyci_obj = PYCI(fanpy_obj, 0.0)
+
+    norb = setup_data.ham.one_int.shape[0]
+    one_int = np.random.rand(norb, norb)
+    two_int = np.random.rand(norb, norb, norb, norb)
+    new_ham = FakeHamiltonian(one_int, two_int)
+    pyci_obj.update_objective(new_ham)
+    assert len(pyci_obj.fanpy_objective.constraints) == 2
+    # NOTE: this assumes that energy constraint is the second in the list.
+    # this is because we set up the constraints to be [norm, e] for the fanpy obj in this test case
+    new_energy_const = pyci_obj.fanpy_objective.constraints[1] 
+    assert type(new_energy_const.ham) == type(new_ham)
+    assert np.allclose(new_energy_const.ham.one_int, new_ham.one_int)
+    assert np.allclose(new_energy_const.ham.two_int, new_ham.two_int)

--- a/tests/test_interface_pyci_utils.py
+++ b/tests/test_interface_pyci_utils.py
@@ -1,0 +1,85 @@
+""" Test for PyCI utils"""
+
+import numpy as np
+import pytest
+
+from fanpy.interface.pyci_utils import ConstraintAdapter
+from fanpy.eqn.base import BaseSchrodinger
+from fanpy.eqn.constraints.energy import EnergyConstraint
+from interface_utils import FakeHamiltonian, FakeWavefunction
+
+class FakeConstraint(BaseSchrodinger):
+    """ Fake constraint class for testing purposes"""
+    def __init__(self):
+        pass
+
+    def objective(self, x):
+        """ Returns lenght of input as the objective. 
+         Parameters
+         ----------
+         x : np.ndarray
+            input array that should only contain wfn params
+        
+        Returns
+        -------
+        result : int
+            length of input array
+        """
+        
+        result = len(x)
+        return result
+    
+    def gradient(self, x):
+        """ fake gradient for testing purposes. 
+        
+        Parameters
+        ----------
+        x : np.ndarray
+            input array that should only contain wfn params
+        
+        Returns
+        -------
+        result : np.ndarray
+            Ones array of length of the input array. 
+        """
+
+        return np.ones(len(x))
+    
+def test_init_check():
+    with pytest.raises(TypeError):
+        ConstraintAdapter("not a constraint")
+    
+def test_objective():
+    """ Make sure objective gets correct number of parameters"""
+    fake_const = FakeConstraint()
+    adapted_const = ConstraintAdapter(fake_const)
+    x = np.ones(5)
+    assert adapted_const.objective(x) == len(x) - 1
+
+def test_gradient():
+    """ Check gradient dimension and energy padding. """
+    fake_const = FakeConstraint()
+    adapted_const = ConstraintAdapter(fake_const)
+    x = np.ones(5)
+    adapted_grad = adapted_const.gradient(x)
+    assert adapted_grad[-1] == 0
+    assert np.allclose(adapted_grad[:-1], np.ones(4))
+
+def test_integration():
+    """ Make sure Constraint adapter works with Energy constraint. """
+    params = np.ones(6)
+    fake_wfn = FakeWavefunction(4, 8, params)
+    one_int = np.ones((4, 4))
+    two_int = np.ones((4, 4, 4, 4))
+    fake_ham = FakeHamiltonian(one_int, two_int)
+    e_const = EnergyConstraint(fake_wfn, fake_ham)
+    e_const_adapted = ConstraintAdapter(e_const)
+
+    # check if objective runs
+    obj = e_const_adapted.objective(np.ones(len(params)+1))
+
+    # check if gradient runs
+    grad = e_const_adapted.gradient(np.ones(len(params)+1))
+    assert np.allclose(grad.shape, (len(params)+1, ))
+    assert grad[-1] == 0
+


### PR DESCRIPTION
This pull request fixes the constraint passing within the Fanpy-PyCI interface. 

**Constraint Handling and Adapter Pattern:**

* Introduced a new `ConstraintAdapter` class in `fanpy/interface/pyci_utils.py` to bridge the difference between Fanpy and PyCI constraint signatures. PyCI objectives define x as `[wfn_params, energy]`, while the Fanpy constraints need an input of `[wfn_params]` [[1]](diffhunk://#diff-b29f71d9551144f23e9d9fc9a67f655c61bde49c5749cdd838aee48bac6f4b8fR1-R62) [[2]](diffhunk://#diff-d37f13320b9572ebb3e1930693d3b89a09533fb82d7e5fe8801444aee4ae95cdR305-R318)
* Refactored constraint passing in the PyCI interface to ensure constraints are correctly adapted and added to the objective. [[1]](diffhunk://#diff-d37f13320b9572ebb3e1930693d3b89a09533fb82d7e5fe8801444aee4ae95cdL271-R273) [[2]](diffhunk://#diff-d37f13320b9572ebb3e1930693d3b89a09533fb82d7e5fe8801444aee4ae95cdL293-R295) [[3]](diffhunk://#diff-d37f13320b9572ebb3e1930693d3b89a09533fb82d7e5fe8801444aee4ae95cdR305-R318) [[4]](diffhunk://#diff-d37f13320b9572ebb3e1930693d3b89a09533fb82d7e5fe8801444aee4ae95cdR341-R346) [[5]](diffhunk://#diff-d37f13320b9572ebb3e1930693d3b89a09533fb82d7e5fe8801444aee4ae95cdL338-R360) [[6]](diffhunk://#diff-d37f13320b9572ebb3e1930693d3b89a09533fb82d7e5fe8801444aee4ae95cdL347)
* The normalization constraint is built within the PyCI objective.  

**Testing Improvements:**

* added tests for constraint adapter
* added test cases for constraints in `test_interface_pyci.py` 