### PR TITLE
tests for FANPT

### DIFF
--- a/tests/test_fanpt.py
+++ b/tests/test_fanpt.py
@@ -1,11 +1,16 @@
 import numpy as np
 import pyci
+from fanpy.wfn.utils import convert_to_fanci
 from fanpy.wfn.geminal.ap1rog import AP1roG
 from fanpy.ham.restricted_chemical import RestrictedMolecularHamiltonian
 from scipy.special import comb
 import scipy.linalg
 import pytest
 from utils import find_datafile
+from fanpy.eqn.projected import ProjectedSchrodinger
+from fanpy.tools.sd_list import sd_list
+from scipy.special import comb
+import fanpy.interface as interface
 
 # Initialize Hamiltonian
 def reduce_to_fock(two_int):
@@ -33,7 +38,7 @@ def reduce_to_fock(two_int):
 
     return fock_two_int
 
-@pytest.mark.skip(reason="This test fails and is being worked on (Issue 23).")
+
 def test_fock_energy():
     """Test that Fock operator and Hamiltonian operator gives same energy for ground state HF."""
     nelec = 6
@@ -44,32 +49,31 @@ def test_fock_energy():
     nspin = one_int.shape[0] * 2
 
     wfn = AP1roG(nelec, nspin, params=None, memory='6gb')
-    nproj = int(comb(nspin // 2, nelec - nelec // 2) * comb(nspin // 2, nelec // 2))
-
+    nproj = 35 
     orig = RestrictedMolecularHamiltonian(one_int, two_int, update_prev_params=True)
-    pyci_ham_orig = pyci.hamiltonian(0, orig.one_int, orig.two_int)
-    # fixme: convert to fanci should be switched to the new interface
-    # This test is being skipped, so it is not an issue that we do not import convert to fanci. 
-    fanci_wfn_orig = convert_to_fanci(wfn, pyci_ham_orig, seniority=wfn.seniority, param_selection=None, nproj=nproj, objective_type='projected')
-    integrals_orig = np.zeros(fanci_wfn_orig._nproj, dtype=pyci.c_double)
-    olps_orig = fanci_wfn_orig.compute_overlap(fanci_wfn_orig.active_params, 'S')[:fanci_wfn_orig._nproj]
-    fanci_wfn_orig._ci_op(olps_orig, out=integrals_orig)
+    pspace = sd_list(nelec, nspin, num_limit=None, exc_orders=[1, 2, 3, 4, 5, 6], spin=0)
+    objective = ProjectedSchrodinger(wfn, orig, energy_type="compute", pspace=pspace)
+    pyci_interface = interface.pyci.PYCI(objective, 2.9182427095417482, max_memory=64000, legacy_fanci=False)
+    pyci_interface.objective_type = "projected"
+    pyci_interface.build_pyci_objective()
+    integrals_orig = np.zeros(nproj, dtype=pyci.c_double)
+    olps_orig = pyci_interface.objective.compute_overlap(objective.active_params, 'S')[:nproj]
+    pyci_interface.objective._ci_op(olps_orig, out=integrals_orig)
     energy_val_orig = np.sum(integrals_orig * olps_orig) / np.sum(olps_orig ** 2)
 
     fock_two_int = reduce_to_fock(two_int)
     fock = RestrictedMolecularHamiltonian(one_int, fock_two_int, update_prev_params=True)
-    pyci_ham_fock = pyci.hamiltonian(0, fock.one_int, fock.two_int)
-    # fixme: convert to fanci should be switched to the new interface
-    # This test is being skipped, so it is not an issue that we do not import convert to fanci. 
-    fanci_wfn_fock = convert_to_fanci(wfn, pyci_ham_fock, seniority=wfn.seniority, param_selection=None, nproj=nproj, objective_type='projected')
-    integrals_fock = np.zeros(fanci_wfn_fock._nproj, dtype=pyci.c_double)
-    olps_fock = fanci_wfn_fock.compute_overlap(fanci_wfn_fock.active_params, 'S')[:fanci_wfn_fock._nproj]
-    fanci_wfn_fock._ci_op(olps_fock, out=integrals_fock)
+    objective_fock = ProjectedSchrodinger(wfn, fock, energy_type="compute", pspace=pspace)
+    pyci_interface_fock = interface.pyci.PYCI(objective_fock, 2.9182427095417482, max_memory=64000, legacy_fanci=False)
+    pyci_interface_fock.objective_type = "projected"
+    pyci_interface_fock.build_pyci_objective()
+    integrals_fock = np.zeros(nproj, dtype=pyci.c_double)
+    olps_fock = pyci_interface_fock.objective.compute_overlap(objective_fock.active_params, 'S')[:nproj]
+    pyci_interface_fock.objective._ci_op(olps_fock, out=integrals_fock)
     energy_val_fock = np.sum(integrals_fock * olps_fock) / np.sum(olps_fock ** 2)
 
     assert np.allclose(energy_val_orig, energy_val_fock)
 
-@pytest.mark.skip(reason="This test fails and is being worked on (Issue 23).")
 def test_fock_objective():
     """Test that Fock operator with HF ground state satisfies projected Schrodinger equation."""
     nelec = 6
@@ -81,23 +85,23 @@ def test_fock_objective():
 
     wfn = AP1roG(nelec, nspin, params=None, memory='6gb')
     nproj = int(comb(nspin // 2, nelec - nelec // 2) * comb(nspin // 2, nelec // 2))
-
+    nproj=35
     fock_two_int = reduce_to_fock(two_int)
     fock = RestrictedMolecularHamiltonian(one_int, fock_two_int, update_prev_params=True)
-    pyci_ham_fock = pyci.hamiltonian(0, fock.one_int, fock.two_int)
-    # fixme: convert to fanci should be switched to the new interface
-    # This test is being skipped, so it is not an issue that we do not import convert to fanci. 
-    fanci_wfn_fock = convert_to_fanci(wfn, pyci_ham_fock, seniority=wfn.seniority, param_selection=None, nproj=nproj, objective_type='projected')
-    integrals_fock = np.zeros(fanci_wfn_fock._nproj, dtype=pyci.c_double)
-    olps_fock = fanci_wfn_fock.compute_overlap(fanci_wfn_fock.active_params, 'S')[:fanci_wfn_fock._nproj]
-    fanci_wfn_fock._ci_op(olps_fock, out=integrals_fock)
+    pspace = sd_list(nelec, nspin, num_limit=None, exc_orders=[1, 2, 3, 4, 5, 6], spin=0)
+    objective_fock = ProjectedSchrodinger(wfn, fock, energy_type="compute", pspace=pspace)
+    pyci_interface_fock = interface.pyci.PYCI(objective_fock, 2.9182427095417482, max_memory=64000, legacy_fanci=False)
+    pyci_interface_fock.objective_type = "projected"
+    pyci_interface_fock.build_pyci_objective()
+    integrals_fock = np.zeros(nproj, dtype=pyci.c_double)
+    olps_fock = pyci_interface_fock.objective.compute_overlap(objective_fock.active_params, 'S')[:nproj]
+    pyci_interface_fock.objective._ci_op(olps_fock, out=integrals_fock)
     energy_val_fock = np.sum(integrals_fock * olps_fock) / np.sum(olps_fock ** 2)
 
-    assert np.allclose(np.sum(np.abs(fanci_wfn_fock.compute_objective(np.hstack([fanci_wfn_fock.active_params, energy_val_fock])))), 0)
+    assert np.allclose(np.sum(np.abs(pyci_interface_fock.objective.compute_objective(np.hstack([objective_fock.active_params, energy_val_fock])))), 0)
 
 ############################################################
 # check orbital rotation invariance
-@pytest.mark.skip(reason="This test fails and is being worked on (Issue 23).")
 def test_fock_rotation():
     """Test that Fock operator invariance to orbital rotation."""
     nelec = 6
@@ -106,19 +110,18 @@ def test_fock_rotation():
     two_int_file = find_datafile('data/data_beh2_r3.0_hf_sto6g_twoint.npy')
     two_int = np.load(two_int_file)
     nspin = one_int.shape[0] * 2
-
+    #original before orb rot
     wfn = AP1roG(nelec, nspin, params=None, memory='6gb')
-    nproj = int(comb(nspin // 2, nelec - nelec // 2) * comb(nspin // 2, nelec // 2))
-
-    # original before orbital rotation
+    nproj = 35 
     orig = RestrictedMolecularHamiltonian(one_int, two_int, update_prev_params=True)
-    pyci_ham_orig = pyci.hamiltonian(0, orig.one_int, orig.two_int)
-    # fixme: convert to fanci should be switched to the new interface
-    # This test is being skipped, so it is not an issue that we do not import convert to fanci. 
-    fanci_wfn_orig = convert_to_fanci(wfn, pyci_ham_orig, seniority=wfn.seniority, param_selection=None, nproj=nproj, objective_type='projected')
-    integrals_orig = np.zeros(fanci_wfn_orig._nproj, dtype=pyci.c_double)
-    olps_orig = fanci_wfn_orig.compute_overlap(fanci_wfn_orig.active_params, 'S')[:fanci_wfn_orig._nproj]
-    fanci_wfn_orig._ci_op(olps_orig, out=integrals_orig)
+    pspace = sd_list(nelec, nspin, num_limit=None, exc_orders=[1, 2, 3, 4, 5, 6], spin=0)
+    objective = ProjectedSchrodinger(wfn, orig, energy_type="compute", pspace=pspace)
+    pyci_interface = interface.pyci.PYCI(objective, 2.9182427095417482, max_memory=64000, legacy_fanci=False)
+    pyci_interface.objective_type = "projected"
+    pyci_interface.build_pyci_objective()
+    integrals_orig = np.zeros(nproj, dtype=pyci.c_double)
+    olps_orig = pyci_interface.objective.compute_overlap(objective.active_params, 'S')[:nproj]
+    pyci_interface.objective._ci_op(olps_orig, out=integrals_orig)
     energy_val_orig = np.sum(integrals_orig * olps_orig) / np.sum(olps_orig ** 2)
 
     # random orbital rotation of occupied
@@ -138,28 +141,34 @@ def test_fock_rotation():
 
     # check that fock and hamiltonian gives same energy for initial state hf ground state
     orbrot = RestrictedMolecularHamiltonian(one_int, two_int, update_prev_params=True)
-    pyci_ham_orbrot = pyci.hamiltonian(0, orbrot.one_int, orbrot.two_int)
-    # fixme: convert to fanci should be switched to the new interface
-    # This test is being skipped, so it is not an issue that we do not import convert to fanci. 
-    fanci_wfn_orbrot = convert_to_fanci(wfn, pyci_ham_orbrot, seniority=wfn.seniority, param_selection=None, nproj=nproj, objective_type='projected')
-    integrals_orbrot = np.zeros(fanci_wfn_orbrot._nproj, dtype=pyci.c_double)
-    olps_orbrot = fanci_wfn_orbrot.compute_overlap(fanci_wfn_orbrot.active_params, 'S')[:fanci_wfn_orbrot._nproj]
-    fanci_wfn_orbrot._ci_op(olps_orbrot, out=integrals_orbrot)
+    pspace = sd_list(nelec, nspin, num_limit=None, exc_orders=[1, 2, 3, 4, 5, 6], spin=0)
+    objective_orbrot = ProjectedSchrodinger(wfn, orbrot, energy_type="compute", pspace=pspace)
+    pyci_interface_orbrot = interface.pyci.PYCI(objective_orbrot, 2.9182427095417482, max_memory=64000, legacy_fanci=False)
+    pyci_interface_orbrot.objective_type = "projected"
+    pyci_interface_orbrot.build_pyci_objective()
+    integrals_orbrot = np.zeros(nproj, dtype=pyci.c_double)
+    olps_orbrot = pyci_interface_orbrot.objective.compute_overlap(objective_orbrot.active_params, 'S')[:nproj]
+    pyci_interface_orbrot.objective._ci_op(olps_orbrot, out=integrals_orbrot)
     energy_val_orbrot = np.sum(integrals_orbrot * olps_orbrot) / np.sum(olps_orbrot ** 2)
 
-    fock_two_int = reduce_to_fock(two_int)
-    fock = RestrictedMolecularHamiltonian(one_int, fock_two_int, update_prev_params=True)
-    pyci_ham_fock = pyci.hamiltonian(0, fock.one_int, fock.two_int)
-    # fixme: convert to fanci should be switched to the new interface
-    # This test is being skipped, so it is not an issue that we do not import convert to fanci. 
-    fanci_wfn_fock = convert_to_fanci(wfn, pyci_ham_fock, seniority=wfn.seniority, param_selection=None, nproj=nproj, objective_type='projected')
-    integrals_fock = np.zeros(fanci_wfn_fock._nproj, dtype=pyci.c_double)
-    olps_fock = fanci_wfn_fock.compute_overlap(fanci_wfn_fock.active_params, 'S')[:fanci_wfn_fock._nproj]
-    fanci_wfn_fock._ci_op(olps_fock, out=integrals_fock)
+    
+    # original before orbital rotation
+    nproj=35
+    fock = RestrictedMolecularHamiltonian(one_int, two_int, update_prev_params=True)
+    pspace = sd_list(nelec, nspin, num_limit=None, exc_orders=[1, 2, 3, 4, 5, 6], spin=0)
+    objective_fock = ProjectedSchrodinger(wfn, fock, energy_type="compute", pspace=pspace)
+    pyci_interface_fock = interface.pyci.PYCI(objective_fock, 2.9182427095417482, max_memory=64000, legacy_fanci=False)
+    pyci_interface_fock.objective_type = "projected"
+    pyci_interface_fock.build_pyci_objective()
+    integrals_fock = np.zeros(nproj, dtype=pyci.c_double)
+    olps_fock = pyci_interface_fock.objective.compute_overlap(objective_fock.active_params, 'S')[:nproj]
+    pyci_interface_fock.objective._ci_op(olps_fock, out=integrals_fock)
     energy_val_fock = np.sum(integrals_fock * olps_fock) / np.sum(olps_fock ** 2)
+
+
+
+
     assert np.allclose(energy_val_orig, energy_val_fock)
     assert np.allclose(energy_val_orbrot, energy_val_fock)
 
-    # check that objective values are all zero for fock operator
-    assert np.allclose(np.sum(np.abs(fanci_wfn_fock.compute_objective(np.hstack([fanci_wfn_fock.active_params, energy_val_fock])))), 0)
 

--- a/tests/test_fanpt.py
+++ b/tests/test_fanpt.py
@@ -1,6 +1,5 @@
 import numpy as np
 import pyci
-from fanpy.wfn.utils import convert_to_fanci
 from fanpy.wfn.geminal.ap1rog import AP1roG
 from fanpy.ham.restricted_chemical import RestrictedMolecularHamiltonian
 from scipy.special import comb

--- a/tests/test_fanpt.py
+++ b/tests/test_fanpt.py
@@ -53,7 +53,6 @@ def test_fock_energy():
     pspace = sd_list(nelec, nspin, num_limit=None, exc_orders=[1, 2, 3, 4, 5, 6], spin=0)
     objective = ProjectedSchrodinger(wfn, orig, energy_type="compute", pspace=pspace)
     pyci_interface = interface.pyci.PYCI(objective, 2.9182427095417482, max_memory=64000, legacy_fanci=False)
-    pyci_interface.objective_type = "projected"
     pyci_interface.build_pyci_objective()
     integrals_orig = np.zeros(nproj, dtype=pyci.c_double)
     olps_orig = pyci_interface.objective.compute_overlap(objective.active_params, 'S')[:nproj]
@@ -64,7 +63,6 @@ def test_fock_energy():
     fock = RestrictedMolecularHamiltonian(one_int, fock_two_int, update_prev_params=True)
     objective_fock = ProjectedSchrodinger(wfn, fock, energy_type="compute", pspace=pspace)
     pyci_interface_fock = interface.pyci.PYCI(objective_fock, 2.9182427095417482, max_memory=64000, legacy_fanci=False)
-    pyci_interface_fock.objective_type = "projected"
     pyci_interface_fock.build_pyci_objective()
     integrals_fock = np.zeros(nproj, dtype=pyci.c_double)
     olps_fock = pyci_interface_fock.objective.compute_overlap(objective_fock.active_params, 'S')[:nproj]
@@ -90,7 +88,6 @@ def test_fock_objective():
     pspace = sd_list(nelec, nspin, num_limit=None, exc_orders=[1, 2, 3, 4, 5, 6], spin=0)
     objective_fock = ProjectedSchrodinger(wfn, fock, energy_type="compute", pspace=pspace)
     pyci_interface_fock = interface.pyci.PYCI(objective_fock, 2.9182427095417482, max_memory=64000, legacy_fanci=False)
-    pyci_interface_fock.objective_type = "projected"
     pyci_interface_fock.build_pyci_objective()
     integrals_fock = np.zeros(nproj, dtype=pyci.c_double)
     olps_fock = pyci_interface_fock.objective.compute_overlap(objective_fock.active_params, 'S')[:nproj]
@@ -116,7 +113,6 @@ def test_fock_rotation():
     pspace = sd_list(nelec, nspin, num_limit=None, exc_orders=[1, 2, 3, 4, 5, 6], spin=0)
     objective = ProjectedSchrodinger(wfn, orig, energy_type="compute", pspace=pspace)
     pyci_interface = interface.pyci.PYCI(objective, 2.9182427095417482, max_memory=64000, legacy_fanci=False)
-    pyci_interface.objective_type = "projected"
     pyci_interface.build_pyci_objective()
     integrals_orig = np.zeros(nproj, dtype=pyci.c_double)
     olps_orig = pyci_interface.objective.compute_overlap(objective.active_params, 'S')[:nproj]
@@ -143,7 +139,6 @@ def test_fock_rotation():
     pspace = sd_list(nelec, nspin, num_limit=None, exc_orders=[1, 2, 3, 4, 5, 6], spin=0)
     objective_orbrot = ProjectedSchrodinger(wfn, orbrot, energy_type="compute", pspace=pspace)
     pyci_interface_orbrot = interface.pyci.PYCI(objective_orbrot, 2.9182427095417482, max_memory=64000, legacy_fanci=False)
-    pyci_interface_orbrot.objective_type = "projected"
     pyci_interface_orbrot.build_pyci_objective()
     integrals_orbrot = np.zeros(nproj, dtype=pyci.c_double)
     olps_orbrot = pyci_interface_orbrot.objective.compute_overlap(objective_orbrot.active_params, 'S')[:nproj]
@@ -157,7 +152,6 @@ def test_fock_rotation():
     pspace = sd_list(nelec, nspin, num_limit=None, exc_orders=[1, 2, 3, 4, 5, 6], spin=0)
     objective_fock = ProjectedSchrodinger(wfn, fock, energy_type="compute", pspace=pspace)
     pyci_interface_fock = interface.pyci.PYCI(objective_fock, 2.9182427095417482, max_memory=64000, legacy_fanci=False)
-    pyci_interface_fock.objective_type = "projected"
     pyci_interface_fock.build_pyci_objective()
     integrals_fock = np.zeros(nproj, dtype=pyci.c_double)
     olps_fock = pyci_interface_fock.objective.compute_overlap(objective_fock.active_params, 'S')[:nproj]

--- a/tests/test_fanpt_container_base.py
+++ b/tests/test_fanpt_container_base.py
@@ -1,164 +1,247 @@
-import numpy as np
+"""Tests for fanpy.fanpt.containers.base.FANPTContainer."""
+
 import types
+
+import numpy as np
 import pytest
 
 from fanpy.fanpt.containers.base import FANPTContainer
 
 
-# -----------------------------
-# Minimal concrete subclass so we can instantiate the abstract base
-# -----------------------------
+N_ACTIVE = 3
+N_EQUATION = 5
+N_PROJ = 4
+PARAMS = np.array([0.1, 0.2, -1.5])
+
+
 class SimpleContainer(FANPTContainer):
-    """Concrete shell: just set simple outputs so the base can run."""
+    """Minimal concrete FANPTContainer used to test the base initializer."""
+
     def der_g_lambda(self):
         self.d_g_lambda = np.zeros(self.nequation)
 
     def der2_g_lambda_wfnparams(self):
-        # keep shape simple: (nequation, max(1, nactive-1))
-        self.d2_g_lambda_wfnparams = np.zeros((self.nequation, max(1, self.nactive - 1)), order="F")
+        n_wfn_params = max(1, self.nactive - 1)
+        self.d2_g_lambda_wfnparams = np.zeros((self.nequation, n_wfn_params), order="F")
 
     def gen_coeff_matrix(self):
         self.c_matrix = np.ones((self.nequation, self.nactive))
 
 
-# -----------------------------
-# Simple fake objective & interface
-# -----------------------------
 class MiniObjective:
-    """Only the attributes/methods the base class touches."""
-    def __init__(self, *, nactive=3, nequation=5, nproj=4, mask_last=False, constraints=None):
+    """Minimal objective exposing the attributes and methods used by FANPTContainer."""
+
+    def __init__(
+        self,
+        *,
+        nactive=N_ACTIVE,
+        nequation=N_EQUATION,
+        nproj=N_PROJ,
+        mask_last=False,
+        constraints=None,
+    ):
         self.nactive = nactive
         self.nequation = nequation
         self.nproj = nproj
-        self.mask = np.zeros(nactive, dtype=bool)
-        self.mask[-1] = bool(mask_last)  # last is energy
         self.constraints = list(constraints or [])
-        self.wfn = "WAVEFUNCTION"        # required by pyci.sparse_op
-        # provide simple overlap methods if not supplied to __init__
-        self._calls = {"ovlp": 0, "d_ovlp": 0, "dd_ovlp": 0}
+        self.wfn = "WAVEFUNCTION"
+
+        self.mask = np.zeros(nactive, dtype=bool)
+        self.mask[-1] = bool(mask_last)
+
+        self.calls = {"ovlp": 0, "d_ovlp": 0, "dd_ovlp": 0}
 
     def compute_overlap(self, wfn_params, space):
-        self._calls["ovlp"] += 1
+        del wfn_params, space
+        self.calls["ovlp"] += 1
         return np.arange(1, self.nproj + 1, dtype=float)
 
     def compute_overlap_deriv(self, wfn_params, space):
-        self._calls["d_ovlp"] += 1
+        del wfn_params, space
+        self.calls["d_ovlp"] += 1
         return np.ones((self.nproj, self.nactive), order="F")
 
     def compute_overlap_double_deriv(self, wfn_params, space):
-        self._calls["dd_ovlp"] += 1
+        del wfn_params, space
+        self.calls["dd_ovlp"] += 1
         return np.zeros((self.nproj, self.nactive, self.nactive), order="F")
 
 
 class MiniInterface:
-    """Holds the objective and receives .pyci_ham"""
+    """Minimal interface object wrapping the objective."""
+
     def __init__(self, objective):
         self.objective = objective
         self.pyci_ham = None
 
 
-# -----------------------------
-# Helpers to build inputs quickly
-# -----------------------------
+def make_norm_constraint(ref_sd):
+    """Return the normalization constraint string used by FANPT."""
+    return f"<\\psi_{{{ref_sd}}}|\\Psi> - v_{{{ref_sd}}}"
+
+
 def make_inputs(*, mask_last=False, constraints=None):
-    obj = MiniObjective(mask_last=mask_last, constraints=constraints)
-    iface = MiniInterface(obj)
-    params = np.array([0.1, 0.2, -1.5])  # last is energy
-    ham0, ham1 = "H0", "H1"
-    return iface, params, ham0, ham1
+    """Build reusable FANPTContainer inputs."""
+    objective = MiniObjective(mask_last=mask_last, constraints=constraints)
+    interface = MiniInterface(objective)
+    return interface, PARAMS.copy(), "H0", "H1"
 
 
-# -----------------------------
-# Tests
-# -----------------------------
+def patch_linear_comb_ham(monkeypatch, calls=None):
+    """Patch linear_comb_ham with a deterministic fake."""
 
-def test_builds_ops_and_overlaps_when_missing(monkeypatch):
-    """If ops/overlaps are not provided, the base builds them and updates interface ham."""
-    # Replace linear_comb_ham with a tiny function and record calls
-    calls = {"linear": 0, "sparse": 0}
-    def fake_linear_comb_ham(h1, h0, a1, a0):
-        calls["linear"] += 1
-        return {"ham1": h1, "ham0": h0, "a1": a1, "a0": a0}
-    monkeypatch.setattr("fanpy.fanpt.containers.base.linear_comb_ham", fake_linear_comb_ham)
+    def fake_linear_comb_ham(ham1, ham0, coeff1, coeff0):
+        if calls is not None:
+            calls["linear"] += 1
 
-    # Replace pyci.sparse_op with a small constructor
+        return {
+            "ham1": ham1,
+            "ham0": ham0,
+            "coeff1": coeff1,
+            "coeff0": coeff0,
+        }
+
+    monkeypatch.setattr(
+        "fanpy.fanpt.containers.base.linear_comb_ham",
+        fake_linear_comb_ham,
+    )
+
+
+def patch_sparse_op(monkeypatch, calls=None, *, should_raise=False):
+    """Patch pyci.sparse_op with a deterministic fake."""
+
     class FakePyci:
         @staticmethod
         def sparse_op(ham, wfn, nproj, symmetric=False):
-            calls["sparse"] += 1
-            return types.SimpleNamespace(kind="sparse", ham=ham, wfn=wfn, nproj=nproj, symmetric=symmetric)
+            if should_raise:
+                raise AssertionError("sparse_op should not be called")
+
+            if calls is not None:
+                calls["sparse"] += 1
+
+            return types.SimpleNamespace(
+                kind="sparse",
+                ham=ham,
+                wfn=wfn,
+                nproj=nproj,
+                symmetric=symmetric,
+            )
+
     monkeypatch.setattr("fanpy.fanpt.containers.base.pyci", FakePyci)
 
-    iface, params, ham0, ham1 = make_inputs(mask_last=True)
 
-    cont = SimpleContainer(
-        fanci_interface=iface,
+def build_container(
+    interface,
+    params,
+    ham0,
+    ham1,
+    *,
+    l=0.3,
+    ref_sd=0,
+    inorm=False,
+    norm_det=None,
+    ham_ci_op=None,
+    f_pot_ci_op=None,
+    ovlp_s=None,
+    d_ovlp_s=None,
+    dd_ovlp_s=None,
+    quasi_approximation_order=2,
+):
+    """Construct the SimpleContainer with explicit defaults."""
+    return SimpleContainer(
+        fanci_interface=interface,
         params=params,
         ham0=ham0,
         ham1=ham1,
-        l=0.3,
-        ref_sd=0,
-        inorm=False,
-        norm_det=None,
-        ham_ci_op=None,
-        f_pot_ci_op=None,
+        l=l,
+        ref_sd=ref_sd,
+        inorm=inorm,
+        norm_det=norm_det,
+        ham_ci_op=ham_ci_op,
+        f_pot_ci_op=f_pot_ci_op,
+        ovlp_s=ovlp_s,
+        d_ovlp_s=d_ovlp_s,
+        dd_ovlp_s=dd_ovlp_s,
+        quasi_approximation_order=quasi_approximation_order,
+    )
+
+
+def test_builds_ops_and_overlaps_when_missing_qao2(monkeypatch):
+    """QAO2 builds operators and first-derivative overlap data, but not double derivatives."""
+    calls = {"linear": 0, "sparse": 0}
+    patch_linear_comb_ham(monkeypatch, calls)
+    patch_sparse_op(monkeypatch, calls)
+
+    interface, params, ham0, ham1 = make_inputs(mask_last=True)
+
+    container = build_container(
+        interface,
+        params,
+        ham0,
+        ham1,
         ovlp_s=None,
         d_ovlp_s=None,
         dd_ovlp_s=None,
+        quasi_approximation_order=2,
     )
 
-    # Built once for ham (l,1-l) and once for f_pot (1,-1)
-    assert calls["linear"] == 2
-    # Sparse ops created for ham and f_pot
-    assert calls["sparse"] == 2
-    # Interface ham updated
-    assert iface.pyci_ham == cont.ham
-    # Overlaps computed (once each)
-    assert iface.objective._calls == {"ovlp": 1, "d_ovlp": 1, "dd_ovlp": 1}
-    # Proxy properties & flags
-    assert cont.nactive == iface.objective.nactive
-    assert cont.nequation == iface.objective.nequation
-    assert cont.nproj == iface.objective.nproj
-    assert cont.active_energy  # mask[-1] was True
+    assert calls == {"linear": 2, "sparse": 2}
+    assert interface.pyci_ham == container.ham
+    assert interface.objective.calls == {"ovlp": 1, "d_ovlp": 1, "dd_ovlp": 0}
+
+    assert container.nactive == interface.objective.nactive
+    assert container.nequation == interface.objective.nequation
+    assert container.nproj == interface.objective.nproj
+    assert container.active_energy
+
+
+def test_builds_double_overlap_derivatives_for_qao3(monkeypatch):
+    """QAO3 computes double-overlap derivatives when they are not provided."""
+    calls = {"linear": 0, "sparse": 0}
+    patch_linear_comb_ham(monkeypatch, calls)
+    patch_sparse_op(monkeypatch, calls)
+
+    interface, params, ham0, ham1 = make_inputs(mask_last=True)
+
+    build_container(
+        interface,
+        params,
+        ham0,
+        ham1,
+        ovlp_s=None,
+        d_ovlp_s=None,
+        dd_ovlp_s=None,
+        quasi_approximation_order=3,
+    )
+
+    assert calls == {"linear": 2, "sparse": 2}
+    assert interface.objective.calls == {"ovlp": 1, "d_ovlp": 1, "dd_ovlp": 1}
 
 
 def test_uses_provided_ops_and_overlaps(monkeypatch):
-    """If ops/overlaps are provided, no sparse_op is called and overlaps aren't computed."""
-    # Count linear_comb_ham calls (should be 1: for ham with l and 1-l)
+    """Provided operators and overlaps are reused without recomputing sparse operators."""
     calls = {"linear": 0}
-    def fake_linear_comb_ham(h1, h0, a1, a0):
-        calls["linear"] += 1
-        return {"ham1": h1, "ham0": h0, "a1": a1, "a0": a0}
-    monkeypatch.setattr("fanpy.fanpt.containers.base.linear_comb_ham", fake_linear_comb_ham)
+    patch_linear_comb_ham(monkeypatch, calls)
+    patch_sparse_op(monkeypatch, should_raise=True)
 
-    # Ensure sparse_op is not called
-    class FakePyci:
-        @staticmethod
-        def sparse_op(*args, **kwargs):
-            raise AssertionError("sparse_op should not be called when ops are provided")
-    monkeypatch.setattr("fanpy.fanpt.containers.base.pyci", FakePyci)
-
-    iface, params, ham0, ham1 = make_inputs(mask_last=False)
+    interface, params, ham0, ham1 = make_inputs(mask_last=False)
 
     provided_ham_op = types.SimpleNamespace(kind="ham_op")
     provided_fpot_op = types.SimpleNamespace(kind="fpot_op")
-    # Use lists so the base's `if ovlp_s:` checks don't hit NumPy truth-value ambiguity
+
     ovlp_s = [10.0, 20.0, 30.0, 40.0]
-    d_ovlp_s = [[1.0] * iface.objective.nactive for _ in range(iface.objective.nproj)]
+    d_ovlp_s = [[1.0] * interface.objective.nactive for _ in range(interface.objective.nproj)]
     dd_ovlp_s = [
-        [[0.0] * iface.objective.nactive for _ in range(iface.objective.nactive)]
-        for _ in range(iface.objective.nproj)
+        [[0.0] * interface.objective.nactive for _ in range(interface.objective.nactive)]
+        for _ in range(interface.objective.nproj)
     ]
 
-    cont = SimpleContainer(
-        fanci_interface=iface,
-        params=params,
-        ham0=ham0,
-        ham1=ham1,
+    container = build_container(
+        interface,
+        params,
+        ham0,
+        ham1,
         l=0.25,
-        ref_sd=0,
-        inorm=False,
-        norm_det=None,
         ham_ci_op=provided_ham_op,
         f_pot_ci_op=provided_fpot_op,
         ovlp_s=ovlp_s,
@@ -166,72 +249,52 @@ def test_uses_provided_ops_and_overlaps(monkeypatch):
         dd_ovlp_s=dd_ovlp_s,
     )
 
-    # linear_comb_ham called once to build ham
     assert calls["linear"] == 1
-    # operators used as given
-    assert cont.ham_ci_op is provided_ham_op
-    assert cont.f_pot_ci_op is provided_fpot_op
-    # overlaps taken as provided (compare after NumPy conversion in assert)
-    np.testing.assert_allclose(cont.ovlp_s, ovlp_s)
-    np.testing.assert_allclose(cont.d_ovlp_s, d_ovlp_s)
-    np.testing.assert_allclose(cont.dd_ovlp_s, dd_ovlp_s)
+    assert container.ham_ci_op is provided_ham_op
+    assert container.f_pot_ci_op is provided_fpot_op
+
+    np.testing.assert_allclose(container.ovlp_s, ovlp_s)
+    np.testing.assert_allclose(container.d_ovlp_s, d_ovlp_s)
+    np.testing.assert_allclose(container.dd_ovlp_s, dd_ovlp_s)
+
+    assert interface.objective.calls == {"ovlp": 0, "d_ovlp": 0, "dd_ovlp": 0}
 
 
 def test_inorm_constraint_required(monkeypatch):
-    """If inorm=True and the exact constraint is not present, __init__ should raise KeyError."""
-    # Minimal stubs so init can run
-    monkeypatch.setattr("fanpy.fanpt.containers.base.linear_comb_ham", lambda *a, **k: {"ok": True})
-    class FakePyci:
-        @staticmethod
-        def sparse_op(*args, **kwargs):
-            return types.SimpleNamespace(kind="sparse")
-    monkeypatch.setattr("fanpy.fanpt.containers.base.pyci", FakePyci)
+    """inorm=True requires the exact normalization constraint to exist."""
+    patch_linear_comb_ham(monkeypatch)
+    patch_sparse_op(monkeypatch)
 
-    iface, params, ham0, ham1 = make_inputs(mask_last=False, constraints=[])
+    interface, params, ham0, ham1 = make_inputs(mask_last=False, constraints=[])
+
     with pytest.raises(KeyError):
-        SimpleContainer(
-            fanci_interface=iface,
-            params=params,
-            ham0=ham0,
-            ham1=ham1,
+        build_container(
+            interface,
+            params,
+            ham0,
+            ham1,
             l=0.5,
             ref_sd=2,
-            inorm=True,   # requires the exact normalization constraint string to exist
-            norm_det=None,
-            ham_ci_op=None,
-            f_pot_ci_op=None,
-            ovlp_s=None,
-            d_ovlp_s=None,
-            dd_ovlp_s=None,
+            inorm=True,
         )
 
 
 def test_property_proxies(monkeypatch):
-    """Light sanity: properties proxy and energy flag reflects mask[-1]."""
-    monkeypatch.setattr("fanpy.fanpt.containers.base.linear_comb_ham", lambda *a, **k: {"ok": True})
-    class FakePyci:
-        @staticmethod
-        def sparse_op(*args, **kwargs):
-            return types.SimpleNamespace(kind="sparse")
-    monkeypatch.setattr("fanpy.fanpt.containers.base.pyci", FakePyci)
+    """Container properties proxy objective attributes."""
+    patch_linear_comb_ham(monkeypatch)
+    patch_sparse_op(monkeypatch)
 
-    iface, params, ham0, ham1 = make_inputs(mask_last=True)  # energy active
-    cont = SimpleContainer(
-        fanci_interface=iface,
-        params=params,
-        ham0=ham0,
-        ham1=ham1,
+    interface, params, ham0, ham1 = make_inputs(mask_last=True)
+
+    container = build_container(
+        interface,
+        params,
+        ham0,
+        ham1,
         l=0.0,
-        ref_sd=0,
-        inorm=False,
-        norm_det=None,
-        ham_ci_op=None,
-        f_pot_ci_op=None,
-        ovlp_s=None,
-        d_ovlp_s=None,
-        dd_ovlp_s=None,
     )
-    assert cont.nactive == iface.objective.nactive
-    assert cont.nequation == iface.objective.nequation
-    assert cont.nproj == iface.objective.nproj
-    assert cont.active_energy  # True because mask[-1] was True
+
+    assert container.nactive == interface.objective.nactive
+    assert container.nequation == interface.objective.nequation
+    assert container.nproj == interface.objective.nproj
+    assert container.active_energy

--- a/tests/test_fanpt_container_base.py
+++ b/tests/test_fanpt_container_base.py
@@ -1,0 +1,237 @@
+import numpy as np
+import types
+import pytest
+
+from fanpy.fanpt.containers.base import FANPTContainer
+
+
+# -----------------------------
+# Minimal concrete subclass so we can instantiate the abstract base
+# -----------------------------
+class SimpleContainer(FANPTContainer):
+    """Concrete shell: just set simple outputs so the base can run."""
+    def der_g_lambda(self):
+        self.d_g_lambda = np.zeros(self.nequation)
+
+    def der2_g_lambda_wfnparams(self):
+        # keep shape simple: (nequation, max(1, nactive-1))
+        self.d2_g_lambda_wfnparams = np.zeros((self.nequation, max(1, self.nactive - 1)), order="F")
+
+    def gen_coeff_matrix(self):
+        self.c_matrix = np.ones((self.nequation, self.nactive))
+
+
+# -----------------------------
+# Simple fake objective & interface
+# -----------------------------
+class MiniObjective:
+    """Only the attributes/methods the base class touches."""
+    def __init__(self, *, nactive=3, nequation=5, nproj=4, mask_last=False, constraints=None):
+        self.nactive = nactive
+        self.nequation = nequation
+        self.nproj = nproj
+        self.mask = np.zeros(nactive, dtype=bool)
+        self.mask[-1] = bool(mask_last)  # last is energy
+        self.constraints = list(constraints or [])
+        self.wfn = "WAVEFUNCTION"        # required by pyci.sparse_op
+        # provide simple overlap methods if not supplied to __init__
+        self._calls = {"ovlp": 0, "d_ovlp": 0, "dd_ovlp": 0}
+
+    def compute_overlap(self, wfn_params, space):
+        self._calls["ovlp"] += 1
+        return np.arange(1, self.nproj + 1, dtype=float)
+
+    def compute_overlap_deriv(self, wfn_params, space):
+        self._calls["d_ovlp"] += 1
+        return np.ones((self.nproj, self.nactive), order="F")
+
+    def compute_overlap_double_deriv(self, wfn_params, space):
+        self._calls["dd_ovlp"] += 1
+        return np.zeros((self.nproj, self.nactive, self.nactive), order="F")
+
+
+class MiniInterface:
+    """Holds the objective and receives .pyci_ham"""
+    def __init__(self, objective):
+        self.objective = objective
+        self.pyci_ham = None
+
+
+# -----------------------------
+# Helpers to build inputs quickly
+# -----------------------------
+def make_inputs(*, mask_last=False, constraints=None):
+    obj = MiniObjective(mask_last=mask_last, constraints=constraints)
+    iface = MiniInterface(obj)
+    params = np.array([0.1, 0.2, -1.5])  # last is energy
+    ham0, ham1 = "H0", "H1"
+    return iface, params, ham0, ham1
+
+
+# -----------------------------
+# Tests
+# -----------------------------
+
+def test_builds_ops_and_overlaps_when_missing(monkeypatch):
+    """If ops/overlaps are not provided, the base builds them and updates interface ham."""
+    # Replace linear_comb_ham with a tiny function and record calls
+    calls = {"linear": 0, "sparse": 0}
+    def fake_linear_comb_ham(h1, h0, a1, a0):
+        calls["linear"] += 1
+        return {"ham1": h1, "ham0": h0, "a1": a1, "a0": a0}
+    monkeypatch.setattr("fanpy.fanpt.containers.base.linear_comb_ham", fake_linear_comb_ham)
+
+    # Replace pyci.sparse_op with a small constructor
+    class FakePyci:
+        @staticmethod
+        def sparse_op(ham, wfn, nproj, symmetric=False):
+            calls["sparse"] += 1
+            return types.SimpleNamespace(kind="sparse", ham=ham, wfn=wfn, nproj=nproj, symmetric=symmetric)
+    monkeypatch.setattr("fanpy.fanpt.containers.base.pyci", FakePyci)
+
+    iface, params, ham0, ham1 = make_inputs(mask_last=True)
+
+    cont = SimpleContainer(
+        fanci_interface=iface,
+        params=params,
+        ham0=ham0,
+        ham1=ham1,
+        l=0.3,
+        ref_sd=0,
+        inorm=False,
+        norm_det=None,
+        ham_ci_op=None,
+        f_pot_ci_op=None,
+        ovlp_s=None,
+        d_ovlp_s=None,
+        dd_ovlp_s=None,
+    )
+
+    # Built once for ham (l,1-l) and once for f_pot (1,-1)
+    assert calls["linear"] == 2
+    # Sparse ops created for ham and f_pot
+    assert calls["sparse"] == 2
+    # Interface ham updated
+    assert iface.pyci_ham == cont.ham
+    # Overlaps computed (once each)
+    assert iface.objective._calls == {"ovlp": 1, "d_ovlp": 1, "dd_ovlp": 1}
+    # Proxy properties & flags
+    assert cont.nactive == iface.objective.nactive
+    assert cont.nequation == iface.objective.nequation
+    assert cont.nproj == iface.objective.nproj
+    assert cont.active_energy  # mask[-1] was True
+
+
+def test_uses_provided_ops_and_overlaps(monkeypatch):
+    """If ops/overlaps are provided, no sparse_op is called and overlaps aren't computed."""
+    # Count linear_comb_ham calls (should be 1: for ham with l and 1-l)
+    calls = {"linear": 0}
+    def fake_linear_comb_ham(h1, h0, a1, a0):
+        calls["linear"] += 1
+        return {"ham1": h1, "ham0": h0, "a1": a1, "a0": a0}
+    monkeypatch.setattr("fanpy.fanpt.containers.base.linear_comb_ham", fake_linear_comb_ham)
+
+    # Ensure sparse_op is not called
+    class FakePyci:
+        @staticmethod
+        def sparse_op(*args, **kwargs):
+            raise AssertionError("sparse_op should not be called when ops are provided")
+    monkeypatch.setattr("fanpy.fanpt.containers.base.pyci", FakePyci)
+
+    iface, params, ham0, ham1 = make_inputs(mask_last=False)
+
+    provided_ham_op = types.SimpleNamespace(kind="ham_op")
+    provided_fpot_op = types.SimpleNamespace(kind="fpot_op")
+    # Use lists so the base's `if ovlp_s:` checks don't hit NumPy truth-value ambiguity
+    ovlp_s = [10.0, 20.0, 30.0, 40.0]
+    d_ovlp_s = [[1.0] * iface.objective.nactive for _ in range(iface.objective.nproj)]
+    dd_ovlp_s = [
+        [[0.0] * iface.objective.nactive for _ in range(iface.objective.nactive)]
+        for _ in range(iface.objective.nproj)
+    ]
+
+    cont = SimpleContainer(
+        fanci_interface=iface,
+        params=params,
+        ham0=ham0,
+        ham1=ham1,
+        l=0.25,
+        ref_sd=0,
+        inorm=False,
+        norm_det=None,
+        ham_ci_op=provided_ham_op,
+        f_pot_ci_op=provided_fpot_op,
+        ovlp_s=ovlp_s,
+        d_ovlp_s=d_ovlp_s,
+        dd_ovlp_s=dd_ovlp_s,
+    )
+
+    # linear_comb_ham called once to build ham
+    assert calls["linear"] == 1
+    # operators used as given
+    assert cont.ham_ci_op is provided_ham_op
+    assert cont.f_pot_ci_op is provided_fpot_op
+    # overlaps taken as provided (compare after NumPy conversion in assert)
+    np.testing.assert_allclose(cont.ovlp_s, ovlp_s)
+    np.testing.assert_allclose(cont.d_ovlp_s, d_ovlp_s)
+    np.testing.assert_allclose(cont.dd_ovlp_s, dd_ovlp_s)
+
+
+def test_inorm_constraint_required(monkeypatch):
+    """If inorm=True and the exact constraint is not present, __init__ should raise KeyError."""
+    # Minimal stubs so init can run
+    monkeypatch.setattr("fanpy.fanpt.containers.base.linear_comb_ham", lambda *a, **k: {"ok": True})
+    class FakePyci:
+        @staticmethod
+        def sparse_op(*args, **kwargs):
+            return types.SimpleNamespace(kind="sparse")
+    monkeypatch.setattr("fanpy.fanpt.containers.base.pyci", FakePyci)
+
+    iface, params, ham0, ham1 = make_inputs(mask_last=False, constraints=[])
+    with pytest.raises(KeyError):
+        SimpleContainer(
+            fanci_interface=iface,
+            params=params,
+            ham0=ham0,
+            ham1=ham1,
+            l=0.5,
+            ref_sd=2,
+            inorm=True,   # requires the exact normalization constraint string to exist
+            norm_det=None,
+            ham_ci_op=None,
+            f_pot_ci_op=None,
+            ovlp_s=None,
+            d_ovlp_s=None,
+            dd_ovlp_s=None,
+        )
+
+
+def test_property_proxies(monkeypatch):
+    """Light sanity: properties proxy and energy flag reflects mask[-1]."""
+    monkeypatch.setattr("fanpy.fanpt.containers.base.linear_comb_ham", lambda *a, **k: {"ok": True})
+    class FakePyci:
+        @staticmethod
+        def sparse_op(*args, **kwargs):
+            return types.SimpleNamespace(kind="sparse")
+    monkeypatch.setattr("fanpy.fanpt.containers.base.pyci", FakePyci)
+
+    iface, params, ham0, ham1 = make_inputs(mask_last=True)  # energy active
+    cont = SimpleContainer(
+        fanci_interface=iface,
+        params=params,
+        ham0=ham0,
+        ham1=ham1,
+        l=0.0,
+        ref_sd=0,
+        inorm=False,
+        norm_det=None,
+        ham_ci_op=None,
+        f_pot_ci_op=None,
+        ovlp_s=None,
+        d_ovlp_s=None,
+        dd_ovlp_s=None,
+    )
+    assert cont.nactive == iface.objective.nactive
+    assert cont.nequation == iface.objective.nequation
+    assert cont.nproj == iface.objective.nproj
+    assert cont.active_energy  # True because mask[-1] was True

--- a/tests/test_fanpt_container_constant_terms.py
+++ b/tests/test_fanpt_container_constant_terms.py
@@ -1,71 +1,47 @@
 import numpy as np
 import pytest
 
-from fanpy.fanpt.containers.constant_terms import FANPTConstantTerms
 from fanpy.fanpt.containers.base import FANPTContainer
+from fanpy.fanpt.containers.constant_terms import FANPTConstantTerms
 
 
 class DummyContainer(FANPTContainer):
-    r"""
-    Minimal mock implementation of a FANPT container used for unit testing.
+    r"""Minimal FANPT container mock for testing constant-term generation.
 
-    This class provides just enough structure for FANPT routines—such as
-    ``FANPTConstantTerms``—to read precomputed derivative data without requiring
-    a full FanCI or PyCI backend. It bypasses Hamiltonian construction, overlap
-    evaluation, and wavefunction logic, making it suitable for isolated and fast
-    unit tests.
-
-    Attributes
-    ----------
-    _nequation : int
-        Number of FANPT equations.
-    _nactive : int
-        Number of active wavefunction parameters.
-    active_energy : bool
-        Whether the energy is treated as an active parameter in the perturbation
-        expansion.
-    d_g_lambda : np.ndarray
-        First derivative ∂G/∂λ of the FANPT equations with respect to λ.
-        Shape: ``(nequation,)``.
-    d2_g_lambda_wfnparams : np.ndarray
-        Mixed second derivatives ∂²G/∂λ∂pₖ.
-        Shape: ``(nequation, nactive)``.
-    d2_g_e_wfnparams : np.ndarray
-        Mixed second derivatives ∂²G/∂E∂pₖ.
-        Shape: ``(nequation, nactive-1)`` if ``active_energy=True``.
-    d2_g_wfnparams2 : np.ndarray
-        Pure second derivatives ∂²G/∂pₖ∂pₗ.
-        Shape: ``(nequation, nactive, nactive)``.
-    d3_g_e_wfnparams2 : np.ndarray
-        Third derivatives ∂³G/∂E∂pₖ∂pₗ.
-        Shape: ``(nequation, nactive-1, nactive-1)`` if ``active_energy=True``.
-    d3_g_lambda_wfnparams2 : np.ndarray
-        Third derivatives ∂³G/∂λ∂pₖ∂pₗ.
-        Shape: ``(nequation, nactive, nactive)``.
+    This dummy container stores precomputed derivative arrays required by
+    ``FANPTConstantTerms`` without constructing a full FanCI/PyCI backend.
     """
 
-    def __init__(self,
-                 nequation,
-                 nactive,
-                 active_energy,
-                 d_g_lambda=None,
-                 d2_g_lambda_wfnparams=None,
-                 d2_g_e_wfnparams=None,
-                 d2_g_wfnparams2=None,
-                 d3_g_e_wfnparams2=None,
-                 d3_g_lambda_wfnparams2=None):
+    def __init__(
+        self,
+        nequation,
+        nactive,
+        active_energy,
+        d_g_lambda=None,
+        d2_g_lambda_wfnparams=None,
+        d2_g_e_wfnparams=None,
+        d2_g_wfnparams2=None,
+        d3_g_e_wfnparams2=None,
+        d3_g_lambda_wfnparams2=None,
+    ):
         self._nequation = nequation
         self._nactive = nactive
         self.active_energy = active_energy
-        self.d_g_lambda = np.array(d_g_lambda, dtype=float) 
-        self.d2_g_lambda_wfnparams = (np.array(d2_g_lambda_wfnparams, dtype=float))
-        self.d2_g_e_wfnparams = (np.array(d2_g_e_wfnparams, dtype=float))
-        self.d2_g_wfnparams2 = (np.array(d2_g_wfnparams2, dtype=float))
-        self.d3_g_e_wfnparams2 = (np.array(d3_g_e_wfnparams2, dtype=float))
-        self.d3_g_lambda_wfnparams2 = (np.array(d3_g_lambda_wfnparams2, dtype=float))
-                                       
 
-    # read-only properties like real base
+        self.d_g_lambda = self._as_array(d_g_lambda)
+        self.d2_g_lambda_wfnparams = self._as_array(d2_g_lambda_wfnparams)
+        self.d2_g_e_wfnparams = self._as_array(d2_g_e_wfnparams)
+        self.d2_g_wfnparams2 = self._as_array(d2_g_wfnparams2)
+        self.d3_g_e_wfnparams2 = self._as_array(d3_g_e_wfnparams2)
+        self.d3_g_lambda_wfnparams2 = self._as_array(d3_g_lambda_wfnparams2)
+
+    @staticmethod
+    def _as_array(value):
+        """Convert a value to a float array unless it is None."""
+        if value is None:
+            return None
+        return np.array(value, dtype=float)
+
     @property
     def nequation(self):
         return self._nequation
@@ -74,19 +50,19 @@ class DummyContainer(FANPTContainer):
     def nactive(self):
         return self._nactive
 
-    # --- abstract methods implemented as no-ops for test instantiation ---
-    def der_g_lambda(self):  
+    # Abstract methods implemented as no-ops for test instantiation.
+    def der_g_lambda(self):
         pass
 
-    def der2_g_lambda_wfnparams(self):  
+    def der2_g_lambda_wfnparams(self):
         pass
 
-    def gen_coeff_matrix(self):  
+    def gen_coeff_matrix(self):
         pass
-
 
 
 # ---------- Validation tests ----------
+
 
 def test_assign_fanpt_container_rejects_non_child():
     class NotAContainer:
@@ -95,8 +71,14 @@ def test_assign_fanpt_container_rejects_non_child():
     with pytest.raises(TypeError, match="fanpt_container must be a child of FANPTContainer"):
         FANPTConstantTerms(fanpt_container=NotAContainer(), order=1)
 
+
 def test_assign_order_type_and_value():
-    cont = DummyContainer(nequation=3, nactive=3, active_energy=False, d_g_lambda=[1, 2, 3])
+    cont = DummyContainer(
+        nequation=3,
+        nactive=3,
+        active_energy=False,
+        d_g_lambda=[1, 2, 3],
+    )
 
     with pytest.raises(TypeError, match="order must be an integer"):
         FANPTConstantTerms(cont, order=1.5)
@@ -104,131 +86,285 @@ def test_assign_order_type_and_value():
     with pytest.raises(ValueError, match="order must be non-negative"):
         FANPTConstantTerms(cont, order=-1)
 
+
 def test_assign_previous_responses_shape_and_type_checks():
-    nequation, nactive = 3, 4
-    cont = DummyContainer(nequation=nequation, nactive=nactive, active_energy=False, d_g_lambda=[0, 0, 0])
+    nequation = 3
+    nactive = 4
+
+    cont = DummyContainer(
+        nequation=nequation,
+        nactive=nactive,
+        active_energy=False,
+        d_g_lambda=[0, 0, 0],
+    )
 
     with pytest.raises(TypeError, match="previous_responses must be a numpy array"):
         FANPTConstantTerms(cont, order=2, previous_responses="not an array")
 
-    bad = np.array([1, 2], dtype=object)
+    bad_responses = np.array([1, 2], dtype=object)
     with pytest.raises(TypeError, match="elements of previous_responses must be numpy arrays"):
-        FANPTConstantTerms(cont, order=2, previous_responses=bad)
+        FANPTConstantTerms(cont, order=2, previous_responses=bad_responses)
 
     good_rows = np.array([np.zeros(nactive), np.zeros(nactive)])
-    wrong_shape = np.array([good_rows])  # (1, 2, nactive)
-    with pytest.raises(ValueError, match=r"shape of previous_responses must be \(1, {}\)".format(nactive)):
+    wrong_shape = np.array([good_rows])
+
+    with pytest.raises(
+        ValueError,
+        match=r"shape of previous_responses must be \(1, {}\)".format(nactive),
+    ):
         FANPTConstantTerms(cont, order=2, previous_responses=wrong_shape)
 
-    #correct shape passes (no exception) — also provide the needed d2 matrix
-    ok = np.array([np.zeros(nactive)])
+    valid_responses = np.array([np.zeros(nactive)])
     cont.d2_g_lambda_wfnparams = np.zeros((nequation, nactive))
-    FANPTConstantTerms(cont, order=2, previous_responses=ok)
+
+    FANPTConstantTerms(cont, order=2, previous_responses=valid_responses)
+
+
+def test_assign_quasi_approximation_order_rejects_invalid_value():
+    cont = DummyContainer(
+        nequation=3,
+        nactive=3,
+        active_energy=False,
+        d_g_lambda=[1, 2, 3],
+    )
+
+    with pytest.raises(ValueError, match="quasi_approximation_order must be 2 or 3"):
+        FANPTConstantTerms(cont, order=1, quasi_approximation_order=4)
 
 
 # ---------- Numerical behavior tests ----------
 
+
 def test_gen_constant_terms_order1_negates_d_g_lambda():
-    cont = DummyContainer(nequation=3, nactive=3, active_energy=False, d_g_lambda=[1, 2, 3])
+    d_g_lambda = np.array([1.0, 2.0, 3.0])
+
+    cont = DummyContainer(
+        nequation=3,
+        nactive=3,
+        active_energy=False,
+        d_g_lambda=d_g_lambda,
+    )
+
     ct = FANPTConstantTerms(cont, order=1)
-    np.testing.assert_allclose(ct.constant_terms, -np.array([1, 2, 3], dtype=float))
+
+    np.testing.assert_allclose(ct.constant_terms, -d_g_lambda)
 
 
 def test_gen_constant_terms_efree_order2():
-    """
-    E-free branch (active_energy=False):
-    constant_terms = -N * (d2_g_lambda_wfnparams @ prev[-1]), N=2
-    """
-    nequation, nactive = 3, 3
-    d2 = np.array([[1, 2, 3],
-                   [4, 5, 6],
-                   [7, 8, 9]], dtype=float)
-    prev = np.array([[1., 2., 3.]])  # shape (order-1, nactive)
+    r"""Test energy-free second-order constant terms.
 
-    cont = DummyContainer(nequation=nequation, nactive=nactive, active_energy=False,
-                          d2_g_lambda_wfnparams=d2, d_g_lambda=[0, 0, 0])
+    For active_energy=False,
 
-    ct = FANPTConstantTerms(cont, order=2, previous_responses=prev)
-    expected = -2.0 * d2.dot(prev[-1])
+        constant_terms = -N * d2_g_lambda_wfnparams @ previous_response
+
+    with N = 2.
+    """
+    nequation = 3
+    nactive = 3
+
+    d2_g_lambda_wfnparams = np.array(
+        [
+            [1, 2, 3],
+            [4, 5, 6],
+            [7, 8, 9],
+        ],
+        dtype=float,
+    )
+
+    previous_responses = np.array([[1.0, 2.0, 3.0]])
+
+    cont = DummyContainer(
+        nequation=nequation,
+        nactive=nactive,
+        active_energy=False,
+        d_g_lambda=[0, 0, 0],
+        d2_g_lambda_wfnparams=d2_g_lambda_wfnparams,
+    )
+
+    ct = FANPTConstantTerms(
+        cont,
+        order=2,
+        previous_responses=previous_responses,
+    )
+
+    expected = -2.0 * d2_g_lambda_wfnparams.dot(previous_responses[-1])
+
     np.testing.assert_allclose(ct.constant_terms, expected)
 
 
-def test_gen_constant_terms_eparam_order2_with_tensors():
-    """
-    Active energy (nactive=3 -> 2 wfn params + 1 energy).
-    For order=2:
-      r_vec = 2 * E1 * p1
-      const = -2 * (M @ p1) - (Me @ r_vec) - einsum(d2, p0, p0)
-    """
-    nequation, nactive = 3, 3  # 2 params + energy
-    M = np.array([[10, 11],
-                  [12, 13],
-                  [14, 15]], dtype=float)                 # d2_g_lambda_wfnparams
-    Me = np.array([[2, 3],
-                   [4, 5],
-                   [6, 7]], dtype=float)                  # d2_g_e_wfnparams
-    T2 = np.full((nequation, 2, 2), 0.5, dtype=float)     # d2_g_wfnparams2 (simple)
+def test_gen_constant_terms_eparam_order2_qao3_with_tensors():
+    r"""Test active-energy second-order QAO3 constant terms.
 
-    # previous responses: (order-1, nactive)
-    p0 = np.array([1.0, 2.0, 0.5])   # [k0, k1, E0]
-    prev = np.array([p0])
+    For order 2 and active energy,
 
-    cont = DummyContainer(
-        nequation=nequation, nactive=nactive, active_energy=True,
-        d2_g_lambda_wfnparams=M, d2_g_e_wfnparams=Me, d2_g_wfnparams2=T2, d_g_lambda=[0, 0, 0]
+        r_vec = 2 * E1 * p1
+
+        constant_terms =
+            -2 * M @ p1
+            - Me @ r_vec
+            - einsum(d2_g_wfnparams2, p1, p1)
+    """
+    nequation = 3
+    nactive = 3
+
+    d2_g_lambda_wfnparams = np.array(
+        [
+            [10, 11],
+            [12, 13],
+            [14, 15],
+        ],
+        dtype=float,
     )
 
-    ct = FANPTConstantTerms(cont, order=2, previous_responses=prev)
-
-    p1 = prev[-1][:-1]                      # same as p0 here
-    E1 = prev[-1][-1]
-    r_vec = 2.0 * E1 * p1
-    expected = -2.0 * M.dot(p1) - Me.dot(r_vec) - np.einsum("mkl,k,l->m", T2, p0[:-1], p0[:-1])
-    np.testing.assert_allclose(ct.constant_terms, expected)
-
-
-def test_gen_constant_terms_eparam_order3_with_tensors():
-    """
-    Active energy, order=3:
-      r_vec = C(3,1)*E0*p1 + C(3,2)*E1*p0 = 3*E0*p1 + 3*E1*p0
-      const = -3*(M @ p1) - (Me @ r_vec)
-              - 3*einsum(d2, p1, p0)
-              - 3*E0 * einsum(d3_e, p1, p0)
-              - 3*einsum(d3_lambda, p0, p0)
-    """
-    nequation, nactive = 3, 3
-    M = np.array([[1, 0],
-                  [0, 1],
-                  [1, 1]], dtype=float)
-    Me = np.array([[1, 2],
-                   [3, 4],
-                   [5, 6]], dtype=float)
-    T2 = np.ones((nequation, 2, 2), dtype=float) * 0.2
-    T3e = np.ones((nequation, 2, 2), dtype=float) * 0.1
-    T3l = np.ones((nequation, 2, 2), dtype=float) * 0.05
-
-    p0 = np.array([1.0, 2.0, 0.5])   # [k0, k1, E0]
-    p1 = np.array([3.0, 4.0, 0.7])   # [k0, k1, E1]
-    prev = np.array([p0, p1])        # shape (2, 3)
-
-    cont = DummyContainer(
-        nequation=nequation, nactive=nactive, active_energy=True,
-        d2_g_lambda_wfnparams=M, d2_g_e_wfnparams=Me,
-        d2_g_wfnparams2=T2, d3_g_e_wfnparams2=T3e, d3_g_lambda_wfnparams2=T3l,
-        d_g_lambda=[0, 0, 0]
+    d2_g_e_wfnparams = np.array(
+        [
+            [2, 3],
+            [4, 5],
+            [6, 7],
+        ],
+        dtype=float,
     )
 
-    ct = FANPTConstantTerms(cont, order=3, previous_responses=prev)
+    d2_g_wfnparams2 = np.full((nequation, 2, 2), 0.5, dtype=float)
 
-    k0 = p0[:-1]; k1 = p1[:-1]
-    E0 = p0[-1];  E1 = p1[-1]
-    r_vec = 3.0 * E0 * k1 + 3.0 * E1 * k0
+    response_1 = np.array([1.0, 2.0, 0.5])
+    previous_responses = np.array([response_1])
+
+    cont = DummyContainer(
+        nequation=nequation,
+        nactive=nactive,
+        active_energy=True,
+        d_g_lambda=[0, 0, 0],
+        d2_g_lambda_wfnparams=d2_g_lambda_wfnparams,
+        d2_g_e_wfnparams=d2_g_e_wfnparams,
+        d2_g_wfnparams2=d2_g_wfnparams2,
+    )
+
+    ct = FANPTConstantTerms(
+        cont,
+        order=2,
+        previous_responses=previous_responses,
+        quasi_approximation_order=3,
+    )
+
+    wfn_response_1 = response_1[:-1]
+    energy_response_1 = response_1[-1]
+
+    r_vector = 2.0 * energy_response_1 * wfn_response_1
 
     expected = (
-        -3.0 * M.dot(k1)
-        - Me.dot(r_vec)
-        - 3.0 * np.einsum("mkl,k,l->m", T2, k1, k0)
-        - 3.0 * E0 * np.einsum("mkl,k,l->m", T3e, k1, k0)
-        - 3.0 * np.einsum("mkl,k,l->m", T3l, k0, k0)
+        -2.0 * d2_g_lambda_wfnparams.dot(wfn_response_1)
+        - d2_g_e_wfnparams.dot(r_vector)
+        - np.einsum(
+            "mkl,k,l->m",
+            d2_g_wfnparams2,
+            wfn_response_1,
+            wfn_response_1,
+        )
     )
+
+    np.testing.assert_allclose(ct.constant_terms, expected)
+
+
+def test_gen_constant_terms_eparam_order3_qao3_with_tensors():
+    r"""Test active-energy third-order QAO3 constant terms.
+
+    For order 3 and active energy,
+
+        r_vec = 3 * E1 * p2 + 3 * E2 * p1
+
+        constant_terms =
+            -3 * M @ p2
+            - Me @ r_vec
+            - 3 * einsum(d2_g_wfnparams2, p2, p1)
+            - 3 * E1 * einsum(d3_g_e_wfnparams2, p2, p1)
+            - 3 * einsum(d3_g_lambda_wfnparams2, p1, p1)
+    """
+    nequation = 3
+    nactive = 3
+
+    d2_g_lambda_wfnparams = np.array(
+        [
+            [1, 0],
+            [0, 1],
+            [1, 1],
+        ],
+        dtype=float,
+    )
+
+    d2_g_e_wfnparams = np.array(
+        [
+            [1, 2],
+            [3, 4],
+            [5, 6],
+        ],
+        dtype=float,
+    )
+
+    d2_g_wfnparams2 = np.ones((nequation, 2, 2), dtype=float) * 0.2
+    d3_g_e_wfnparams2 = np.ones((nequation, 2, 2), dtype=float) * 0.1
+    d3_g_lambda_wfnparams2 = np.ones((nequation, 2, 2), dtype=float) * 0.05
+
+    response_1 = np.array([1.0, 2.0, 0.5])
+    response_2 = np.array([3.0, 4.0, 0.7])
+
+    previous_responses = np.array([response_1, response_2])
+
+    cont = DummyContainer(
+        nequation=nequation,
+        nactive=nactive,
+        active_energy=True,
+        d_g_lambda=[0, 0, 0],
+        d2_g_lambda_wfnparams=d2_g_lambda_wfnparams,
+        d2_g_e_wfnparams=d2_g_e_wfnparams,
+        d2_g_wfnparams2=d2_g_wfnparams2,
+        d3_g_e_wfnparams2=d3_g_e_wfnparams2,
+        d3_g_lambda_wfnparams2=d3_g_lambda_wfnparams2,
+    )
+
+    ct = FANPTConstantTerms(
+        cont,
+        order=3,
+        previous_responses=previous_responses,
+        quasi_approximation_order=3,
+    )
+
+    wfn_response_1 = response_1[:-1]
+    wfn_response_2 = response_2[:-1]
+
+    energy_response_1 = response_1[-1]
+    energy_response_2 = response_2[-1]
+
+    r_vector = (
+        3.0 * energy_response_1 * wfn_response_2
+        + 3.0 * energy_response_2 * wfn_response_1
+    )
+
+    expected = (
+        -3.0 * d2_g_lambda_wfnparams.dot(wfn_response_2)
+        - d2_g_e_wfnparams.dot(r_vector)
+        - 3.0
+        * np.einsum(
+            "mkl,k,l->m",
+            d2_g_wfnparams2,
+            wfn_response_2,
+            wfn_response_1,
+        )
+        - 3.0
+        * energy_response_1
+        * np.einsum(
+            "mkl,k,l->m",
+            d3_g_e_wfnparams2,
+            wfn_response_2,
+            wfn_response_1,
+        )
+        - 3.0
+        * np.einsum(
+            "mkl,k,l->m",
+            d3_g_lambda_wfnparams2,
+            wfn_response_1,
+            wfn_response_1,
+        )
+    )
+
     np.testing.assert_allclose(ct.constant_terms, expected)

--- a/tests/test_fanpt_container_constant_terms.py
+++ b/tests/test_fanpt_container_constant_terms.py
@@ -355,7 +355,7 @@ def test_gen_constant_terms_eparam_order3_qao3_with_tensors():
         * np.einsum(
             "mkl,k,l->m",
             d3_g_e_wfnparams2,
-            wfn_response_2,
+            wfn_response_1,
             wfn_response_1,
         )
         - 3.0

--- a/tests/test_fanpt_container_constant_terms.py
+++ b/tests/test_fanpt_container_constant_terms.py
@@ -1,0 +1,234 @@
+import numpy as np
+import pytest
+
+from fanpy.fanpt.containers.constant_terms import FANPTConstantTerms
+from fanpy.fanpt.containers.base import FANPTContainer
+
+
+class DummyContainer(FANPTContainer):
+    r"""
+    Minimal mock implementation of a FANPT container used for unit testing.
+
+    This class provides just enough structure for FANPT routines—such as
+    ``FANPTConstantTerms``—to read precomputed derivative data without requiring
+    a full FanCI or PyCI backend. It bypasses Hamiltonian construction, overlap
+    evaluation, and wavefunction logic, making it suitable for isolated and fast
+    unit tests.
+
+    Attributes
+    ----------
+    _nequation : int
+        Number of FANPT equations.
+    _nactive : int
+        Number of active wavefunction parameters.
+    active_energy : bool
+        Whether the energy is treated as an active parameter in the perturbation
+        expansion.
+    d_g_lambda : np.ndarray
+        First derivative ∂G/∂λ of the FANPT equations with respect to λ.
+        Shape: ``(nequation,)``.
+    d2_g_lambda_wfnparams : np.ndarray
+        Mixed second derivatives ∂²G/∂λ∂pₖ.
+        Shape: ``(nequation, nactive)``.
+    d2_g_e_wfnparams : np.ndarray
+        Mixed second derivatives ∂²G/∂E∂pₖ.
+        Shape: ``(nequation, nactive-1)`` if ``active_energy=True``.
+    d2_g_wfnparams2 : np.ndarray
+        Pure second derivatives ∂²G/∂pₖ∂pₗ.
+        Shape: ``(nequation, nactive, nactive)``.
+    d3_g_e_wfnparams2 : np.ndarray
+        Third derivatives ∂³G/∂E∂pₖ∂pₗ.
+        Shape: ``(nequation, nactive-1, nactive-1)`` if ``active_energy=True``.
+    d3_g_lambda_wfnparams2 : np.ndarray
+        Third derivatives ∂³G/∂λ∂pₖ∂pₗ.
+        Shape: ``(nequation, nactive, nactive)``.
+    """
+
+    def __init__(self,
+                 nequation,
+                 nactive,
+                 active_energy,
+                 d_g_lambda=None,
+                 d2_g_lambda_wfnparams=None,
+                 d2_g_e_wfnparams=None,
+                 d2_g_wfnparams2=None,
+                 d3_g_e_wfnparams2=None,
+                 d3_g_lambda_wfnparams2=None):
+        self._nequation = nequation
+        self._nactive = nactive
+        self.active_energy = active_energy
+        self.d_g_lambda = np.array(d_g_lambda, dtype=float) 
+        self.d2_g_lambda_wfnparams = (np.array(d2_g_lambda_wfnparams, dtype=float))
+        self.d2_g_e_wfnparams = (np.array(d2_g_e_wfnparams, dtype=float))
+        self.d2_g_wfnparams2 = (np.array(d2_g_wfnparams2, dtype=float))
+        self.d3_g_e_wfnparams2 = (np.array(d3_g_e_wfnparams2, dtype=float))
+        self.d3_g_lambda_wfnparams2 = (np.array(d3_g_lambda_wfnparams2, dtype=float))
+                                       
+
+    # read-only properties like real base
+    @property
+    def nequation(self):
+        return self._nequation
+
+    @property
+    def nactive(self):
+        return self._nactive
+
+    # --- abstract methods implemented as no-ops for test instantiation ---
+    def der_g_lambda(self):  
+        pass
+
+    def der2_g_lambda_wfnparams(self):  
+        pass
+
+    def gen_coeff_matrix(self):  
+        pass
+
+
+
+# ---------- Validation tests ----------
+
+def test_assign_fanpt_container_rejects_non_child():
+    class NotAContainer:
+        pass
+
+    with pytest.raises(TypeError, match="fanpt_container must be a child of FANPTContainer"):
+        FANPTConstantTerms(fanpt_container=NotAContainer(), order=1)
+
+def test_assign_order_type_and_value():
+    cont = DummyContainer(nequation=3, nactive=3, active_energy=False, d_g_lambda=[1, 2, 3])
+
+    with pytest.raises(TypeError, match="order must be an integer"):
+        FANPTConstantTerms(cont, order=1.5)
+
+    with pytest.raises(ValueError, match="order must be non-negative"):
+        FANPTConstantTerms(cont, order=-1)
+
+def test_assign_previous_responses_shape_and_type_checks():
+    nequation, nactive = 3, 4
+    cont = DummyContainer(nequation=nequation, nactive=nactive, active_energy=False, d_g_lambda=[0, 0, 0])
+
+    with pytest.raises(TypeError, match="previous_responses must be a numpy array"):
+        FANPTConstantTerms(cont, order=2, previous_responses="not an array")
+
+    bad = np.array([1, 2], dtype=object)
+    with pytest.raises(TypeError, match="elements of previous_responses must be numpy arrays"):
+        FANPTConstantTerms(cont, order=2, previous_responses=bad)
+
+    good_rows = np.array([np.zeros(nactive), np.zeros(nactive)])
+    wrong_shape = np.array([good_rows])  # (1, 2, nactive)
+    with pytest.raises(ValueError, match=r"shape of previous_responses must be \(1, {}\)".format(nactive)):
+        FANPTConstantTerms(cont, order=2, previous_responses=wrong_shape)
+
+    #correct shape passes (no exception) — also provide the needed d2 matrix
+    ok = np.array([np.zeros(nactive)])
+    cont.d2_g_lambda_wfnparams = np.zeros((nequation, nactive))
+    FANPTConstantTerms(cont, order=2, previous_responses=ok)
+
+
+# ---------- Numerical behavior tests ----------
+
+def test_gen_constant_terms_order1_negates_d_g_lambda():
+    cont = DummyContainer(nequation=3, nactive=3, active_energy=False, d_g_lambda=[1, 2, 3])
+    ct = FANPTConstantTerms(cont, order=1)
+    np.testing.assert_allclose(ct.constant_terms, -np.array([1, 2, 3], dtype=float))
+
+
+def test_gen_constant_terms_efree_order2():
+    """
+    E-free branch (active_energy=False):
+    constant_terms = -N * (d2_g_lambda_wfnparams @ prev[-1]), N=2
+    """
+    nequation, nactive = 3, 3
+    d2 = np.array([[1, 2, 3],
+                   [4, 5, 6],
+                   [7, 8, 9]], dtype=float)
+    prev = np.array([[1., 2., 3.]])  # shape (order-1, nactive)
+
+    cont = DummyContainer(nequation=nequation, nactive=nactive, active_energy=False,
+                          d2_g_lambda_wfnparams=d2, d_g_lambda=[0, 0, 0])
+
+    ct = FANPTConstantTerms(cont, order=2, previous_responses=prev)
+    expected = -2.0 * d2.dot(prev[-1])
+    np.testing.assert_allclose(ct.constant_terms, expected)
+
+
+def test_gen_constant_terms_eparam_order2_with_tensors():
+    """
+    Active energy (nactive=3 -> 2 wfn params + 1 energy).
+    For order=2:
+      r_vec = 2 * E1 * p1
+      const = -2 * (M @ p1) - (Me @ r_vec) - einsum(d2, p0, p0)
+    """
+    nequation, nactive = 3, 3  # 2 params + energy
+    M = np.array([[10, 11],
+                  [12, 13],
+                  [14, 15]], dtype=float)                 # d2_g_lambda_wfnparams
+    Me = np.array([[2, 3],
+                   [4, 5],
+                   [6, 7]], dtype=float)                  # d2_g_e_wfnparams
+    T2 = np.full((nequation, 2, 2), 0.5, dtype=float)     # d2_g_wfnparams2 (simple)
+
+    # previous responses: (order-1, nactive)
+    p0 = np.array([1.0, 2.0, 0.5])   # [k0, k1, E0]
+    prev = np.array([p0])
+
+    cont = DummyContainer(
+        nequation=nequation, nactive=nactive, active_energy=True,
+        d2_g_lambda_wfnparams=M, d2_g_e_wfnparams=Me, d2_g_wfnparams2=T2, d_g_lambda=[0, 0, 0]
+    )
+
+    ct = FANPTConstantTerms(cont, order=2, previous_responses=prev)
+
+    p1 = prev[-1][:-1]                      # same as p0 here
+    E1 = prev[-1][-1]
+    r_vec = 2.0 * E1 * p1
+    expected = -2.0 * M.dot(p1) - Me.dot(r_vec) - np.einsum("mkl,k,l->m", T2, p0[:-1], p0[:-1])
+    np.testing.assert_allclose(ct.constant_terms, expected)
+
+
+def test_gen_constant_terms_eparam_order3_with_tensors():
+    """
+    Active energy, order=3:
+      r_vec = C(3,1)*E0*p1 + C(3,2)*E1*p0 = 3*E0*p1 + 3*E1*p0
+      const = -3*(M @ p1) - (Me @ r_vec)
+              - 3*einsum(d2, p1, p0)
+              - 3*E0 * einsum(d3_e, p1, p0)
+              - 3*einsum(d3_lambda, p0, p0)
+    """
+    nequation, nactive = 3, 3
+    M = np.array([[1, 0],
+                  [0, 1],
+                  [1, 1]], dtype=float)
+    Me = np.array([[1, 2],
+                   [3, 4],
+                   [5, 6]], dtype=float)
+    T2 = np.ones((nequation, 2, 2), dtype=float) * 0.2
+    T3e = np.ones((nequation, 2, 2), dtype=float) * 0.1
+    T3l = np.ones((nequation, 2, 2), dtype=float) * 0.05
+
+    p0 = np.array([1.0, 2.0, 0.5])   # [k0, k1, E0]
+    p1 = np.array([3.0, 4.0, 0.7])   # [k0, k1, E1]
+    prev = np.array([p0, p1])        # shape (2, 3)
+
+    cont = DummyContainer(
+        nequation=nequation, nactive=nactive, active_energy=True,
+        d2_g_lambda_wfnparams=M, d2_g_e_wfnparams=Me,
+        d2_g_wfnparams2=T2, d3_g_e_wfnparams2=T3e, d3_g_lambda_wfnparams2=T3l,
+        d_g_lambda=[0, 0, 0]
+    )
+
+    ct = FANPTConstantTerms(cont, order=3, previous_responses=prev)
+
+    k0 = p0[:-1]; k1 = p1[:-1]
+    E0 = p0[-1];  E1 = p1[-1]
+    r_vec = 3.0 * E0 * k1 + 3.0 * E1 * k0
+
+    expected = (
+        -3.0 * M.dot(k1)
+        - Me.dot(r_vec)
+        - 3.0 * np.einsum("mkl,k,l->m", T2, k1, k0)
+        - 3.0 * E0 * np.einsum("mkl,k,l->m", T3e, k1, k0)
+        - 3.0 * np.einsum("mkl,k,l->m", T3l, k0, k0)
+    )
+    np.testing.assert_allclose(ct.constant_terms, expected)

--- a/tests/test_fanpt_container_energy_free.py
+++ b/tests/test_fanpt_container_energy_free.py
@@ -1,0 +1,185 @@
+import numpy as np
+import pytest
+
+from fanpy.fanpt.containers.energy_free import FANPTContainerEFree
+
+
+# ---- tiny helpers ----
+def make_scaling_op(factor: float):
+    """Return an op(x, out=None) that multiplies by `factor` (mimics PyCI op)."""
+    def op(x, out=None):
+        if out is None:
+            return factor * x
+        out[...] = factor * x
+    return op
+
+
+def make_jacobian_mock(matrix: np.ndarray):
+    """Return an object exposing compute_jacobian + call tracking."""
+    class _JacMock:
+        def __init__(self, ret):
+            self._ret = ret
+            self.calls = 0
+            self.last_params = None
+
+        def compute_jacobian(self, params):
+            self.calls += 1
+            self.last_params = params
+            return self._ret
+    return _JacMock(matrix)
+
+
+# ---- Simple interface ----
+class FakeObjective:
+    """Mock objective.mask to test 'energy cannot be active' check."""
+    def __init__(self, mask_last_active=False):
+        # mask[-1] == True would indicate energy active (invalid for EFree)
+        self.mask = np.array([False, False, False, mask_last_active], dtype=bool)
+
+
+class FakeFanCIInterface:
+    """Mock interface exposing .objective.mask."""
+    def __init__(self, mask_last_active=False):
+        self.objective = FakeObjective(mask_last_active)
+
+
+# ---- Lightweight dummy container ----
+class DummyEFree(FANPTContainerEFree):
+    """Minimal EFree container for tests; wires only what the methods need."""
+    def __init__(self, *,
+                 nequation=6,
+                 nproj=4,
+                 nactive=3,
+                 ref_sd=1,
+                 inorm=False,
+                 energy_value=1.25):
+        # store “read-only” counters and expose via properties
+        self._nequation = int(nequation)
+        self._nproj     = int(nproj)
+        self._nactive   = int(nactive)
+
+        # E-free: energy must not be active
+        self.active_energy = False
+
+        # normalization choices
+        self.inorm  = bool(inorm)
+        self.ref_sd = int(ref_sd)
+
+        # operators: V scales by 2, H scales by 3
+        self.f_pot_ci_op = make_scaling_op(2.0)
+        self.ham_ci_op   = make_scaling_op(3.0)
+
+        # overlaps / derivatives (Fortran order where used that way)
+        self.ovlp_s = np.arange(1, self._nproj + 1, dtype=float)  # [1,2,3,...]
+        self.d_ovlp_s = np.arange(self._nproj * self._nactive, dtype=float)\
+                            .reshape(self._nproj, self._nactive, order="F")
+
+        # jacobian provider: starts at 100 everywhere
+        J = np.full((self._nequation, self._nactive), 100.0, dtype=float)
+        self.fanci_objective = make_jacobian_mock(J)
+
+        # params & energy (energy used in inorm=False branch of gen_coeff_matrix)
+        self.params = np.zeros(self._nactive, dtype=float)  # not used directly by these tests
+        self.energy = float(energy_value)
+
+    @property
+    def nequation(self): return self._nequation
+    @property
+    def nproj(self):     return self._nproj
+    @property
+    def nactive(self):   return self._nactive
+
+
+# ---- __init__ guard: energy cannot be active in EFree ----
+def test_init_rejects_active_energy_flag():
+    iface_bad = FakeFanCIInterface(mask_last_active=True)
+    with pytest.raises(TypeError, match="energy cannot be an active parameter"):
+        FANPTContainerEFree(
+            fanci_interface=iface_bad, params=None, ham0=None, ham1=None
+        )
+
+
+
+# ---- der_g_lambda ----
+@pytest.mark.parametrize("inorm", [True, False])
+def test_der_g_lambda_efree_adjustment(inorm):
+    """
+    super(): d_g_lambda[:nproj] = 2 * ovlp_s
+    EFree:
+      if inorm=True:   subtract d_ref * ovlp_s = (2*ovlp_ref)*ovlp_s
+      if inorm=False:  subtract (d_ref * ovlp_s / ovlp_ref) = 2*ovlp_s  -> zeros
+    """
+    inst = DummyEFree(inorm=inorm, nproj=4, nactive=3, nequation=6, ref_sd=1)
+
+    inst.der_g_lambda()
+
+    super_val = 2.0 * inst.ovlp_s
+    d_ref = super_val[inst.ref_sd]
+    if inorm:
+        expected = super_val - d_ref * inst.ovlp_s
+    else:
+        expected = super_val - (d_ref * inst.ovlp_s / inst.ovlp_s[inst.ref_sd])
+
+    np.testing.assert_allclose(inst.super_d_g_lambda[:inst.nproj], super_val)
+    np.testing.assert_allclose(inst.d_g_lambda[:inst.nproj], expected)
+    np.testing.assert_allclose(inst.d_g_lambda[inst.nproj:], 0.0)
+
+
+# ---- der2_g_lambda_wfnparams ----
+@pytest.mark.parametrize("inorm", [True, False])
+def test_der2_g_lambda_wfnparams_efree(inorm):
+    inst = DummyEFree(inorm=inorm, nproj=4, nactive=3, nequation=6, ref_sd=2)
+
+    # Deterministic d_ovlp grid
+    inst.d_ovlp_s = np.arange(inst.nproj * inst.nactive, dtype=float).reshape(
+        inst.nproj, inst.nactive, order="F"
+    )
+    inst.der_g_lambda()
+    inst.der2_g_lambda_wfnparams()
+
+    super_mat = 2.0 * inst.d_ovlp_s               # (nproj, nactive)
+    super_ref = inst.super_d_g_lambda[inst.ref_sd] # = 2*ovlp_ref
+
+    if inorm:
+        expected = super_mat.copy()
+        # subtract row_ref(super) * ovlp_s (outer product over columns)
+        expected -= super_mat[inst.ref_sd][None, :] * inst.ovlp_s[:inst.nproj, None]
+        # subtract super_ref * d_ovlp_s
+        expected -= super_ref * inst.d_ovlp_s
+        np.testing.assert_allclose(inst.d2_g_lambda_wfnparams[:inst.nproj], expected)
+    else:
+        # Should collapse to zeros in projected block
+        np.testing.assert_allclose(inst.d2_g_lambda_wfnparams[:inst.nproj], 0.0)
+
+    np.testing.assert_allclose(inst.d2_g_lambda_wfnparams[inst.nproj:], 0.0)
+
+
+# ---- gen_coeff_matrix ----
+@pytest.mark.parametrize("inorm", [True, False])
+def test_gen_coeff_matrix_efree_adjustment(inorm):
+    nproj, nactive, nequation = 4, 3, 6
+    ref_sd = 1
+    E = 1.25
+
+    inst = DummyEFree(
+        inorm=inorm, nproj=nproj, nactive=nactive, nequation=nequation,
+        ref_sd=ref_sd, energy_value=E
+    )
+
+    inst.d_ovlp_s = np.arange(nproj * nactive, dtype=float).reshape(nproj, nactive, order="F")
+
+    inst.gen_coeff_matrix()
+
+    expected = np.full((nequation, nactive), 100.0)
+    f_proj = 3.0 * inst.d_ovlp_s
+    ovlp_ref = inst.ovlp_s[ref_sd]
+
+    if inorm:
+        expected[:nproj] -= f_proj[ref_sd][None, :] * inst.ovlp_s[:nproj, None]
+    else:
+        expected[:nproj] -= (
+            (f_proj[ref_sd][None, :] - E * inst.d_ovlp_s[ref_sd][None, :])
+            * inst.ovlp_s[:nproj, None] / ovlp_ref
+        )
+
+    np.testing.assert_allclose(inst.c_matrix, expected)

--- a/tests/test_fanpt_container_energy_free.py
+++ b/tests/test_fanpt_container_energy_free.py
@@ -128,6 +128,15 @@ def test_der_g_lambda_efree_adjustment(inorm):
 # ---- der2_g_lambda_wfnparams ----
 @pytest.mark.parametrize("inorm", [True, False])
 def test_der2_g_lambda_wfnparams_efree(inorm):
+    """
+    super(): d2_g_lambda_wfnparams[:nproj] = 2 * d_ovlp_s
+
+    EFree:
+      if inorm=True:
+        subtract d_ref/dp_k * ovlp_s and d_ref * d_ovlp_s/dp_k
+      if inorm=False:
+        normalized correction cancels the projected block for this dummy setup
+    """
     inst = DummyEFree(inorm=inorm, nproj=4, nactive=3, nequation=6, ref_sd=2)
 
     # Deterministic d_ovlp grid
@@ -157,6 +166,17 @@ def test_der2_g_lambda_wfnparams_efree(inorm):
 # ---- gen_coeff_matrix ----
 @pytest.mark.parametrize("inorm", [True, False])
 def test_gen_coeff_matrix_efree_adjustment(inorm):
+    """
+    super(): c_matrix is initialized to 100 by the dummy parent.
+
+    EFree:
+      if inorm=True:
+        subtract f_ref,k * ovlp_s
+      if inorm=False:
+        subtract (f_ref,k - E * d_ovlp_ref,k) * ovlp_s / ovlp_ref
+
+    Rows beyond nproj are unchanged.
+    """
     nproj, nactive, nequation = 4, 3, 6
     ref_sd = 1
     E = 1.25

--- a/tests/test_fanpt_container_energy_param.py
+++ b/tests/test_fanpt_container_energy_param.py
@@ -1,0 +1,192 @@
+import numpy as np
+import pytest
+from fanpy.fanpt.containers.energy_param import FANPTContainerEParam
+
+
+# --- tiny helper ---
+def make_scaling_op(factor: float):
+    """Return an op(x, out=None) that multiplies by `factor`."""
+    def op(x, out=None):
+        if out is None:
+            return factor * x
+        out[...] = factor * x
+    return op
+
+
+class FakeFanCIObjective:
+    """Mock FanCI objective returning a fixed Jacobian."""
+    def __init__(self, ret: np.ndarray):
+        self._ret = ret
+        self.calls = 0
+        self.last_params = None
+
+    def compute_jacobian(self, params):
+        self.calls += 1
+        self.last_params = params
+        return self._ret
+
+
+# --- Lightweight test double: DOES NOT call super().__init__ ---
+class DummyEParam(FANPTContainerEParam):
+    def __init__(self, *,
+                 nequation=5,
+                 nproj=3,
+                 nactive=4,
+                 active_energy=True,
+                 energy_value=1.5):
+        # store read-onlys; expose via properties
+        self._nequation = int(nequation)
+        self._nproj     = int(nproj)
+        self._nactive   = int(nactive)
+
+        # flags & params (last element energy)
+        self.active_energy = bool(active_energy)
+        self.params = np.array([0.0] * (self._nactive - 1) + [float(energy_value)], dtype=float)
+
+        # operators
+        self.f_pot_ci_op = make_scaling_op(2.0)
+        self.ham_ci_op   = make_scaling_op(3.0)
+
+        # jacobian provider
+        self.fanci_objective = FakeFanCIObjective(
+            np.full((self._nequation, self._nactive), 42.0, dtype=float)
+        )
+
+        # overlaps / derivatives
+        self.ovlp_s = np.arange(self._nproj, dtype=float) + 1.0
+        self.d_ovlp_s = np.arange(self._nproj * self._nactive, dtype=float)\
+                            .reshape(self._nproj, self._nactive, order="F")
+        self.dd_ovlp_s = np.arange(self._nproj * self._nactive * self._nactive, dtype=float)\
+                            .reshape(self._nproj, self._nactive, self._nactive, order="F")
+
+    @property
+    def nequation(self): return self._nequation
+    @property
+    def nproj(self):     return self._nproj
+    @property
+    def nactive(self):   return self._nactive
+
+
+# ---------------- Tests (direct instantiation) ----------------
+
+def test_der_g_lambda_projects_only_first_nproj():
+    inst = DummyEParam()
+    inst.der_g_lambda()
+
+    assert inst.d_g_lambda.shape == (inst.nequation,)
+    np.testing.assert_allclose(inst.d_g_lambda[:inst.nproj], 2.0 * inst.ovlp_s)
+    np.testing.assert_allclose(inst.d_g_lambda[inst.nproj:], 0.0)
+
+
+@pytest.mark.parametrize("active_energy,ncols", [(False, 4), (True, 3)])
+def test_der2_g_lambda_wfnparams(active_energy, ncols):
+    inst = DummyEParam(nactive=4, active_energy=active_energy)
+    # shape (nproj, ncols) Fortran
+    inst.d_ovlp_s = np.arange(inst.nproj * ncols, dtype=float).reshape(
+        inst.nproj, ncols, order="F"
+    )
+
+    inst.der2_g_lambda_wfnparams()
+
+    assert inst.d2_g_lambda_wfnparams.shape == (inst.nequation, ncols)
+    np.testing.assert_allclose(inst.d2_g_lambda_wfnparams[:inst.nproj], 2.0 * inst.d_ovlp_s)
+    np.testing.assert_allclose(inst.d2_g_lambda_wfnparams[inst.nproj:], 0.0)
+
+
+def test_der2_g_e_wfnparams_active():
+    inst = DummyEParam(nactive=5, active_energy=True)
+    ncols = inst.nactive - 1
+    inst.d_ovlp_s = np.arange(inst.nproj * ncols, dtype=float).reshape(
+        inst.nproj, ncols, order="F"
+    )
+
+    inst.der2_g_e_wfnparams()
+
+    assert inst.d2_g_e_wfnparams.shape == (inst.nequation, ncols)
+    np.testing.assert_allclose(inst.d2_g_e_wfnparams[:inst.nproj], -inst.d_ovlp_s)
+    np.testing.assert_allclose(inst.d2_g_e_wfnparams[inst.nproj:], 0.0)
+
+
+def test_der2_g_e_wfnparams_inactive():
+    inst = DummyEParam(active_energy=False)
+    inst.der2_g_e_wfnparams()
+    assert inst.d2_g_e_wfnparams is None
+
+
+def test_gen_coeff_matrix_calls_fanci():
+    inst = DummyEParam()
+    inst.gen_coeff_matrix()
+    assert inst.fanci_objective.calls == 1
+    assert inst.c_matrix.shape == (inst.nequation, inst.nactive)
+    np.testing.assert_allclose(inst.c_matrix, 42.0)
+
+
+def test_der3_g_lambda_wfnparams2_inactive_energy():
+    nactive = 4
+    inst = DummyEParam(nactive=nactive, active_energy=False)
+    inst.dd_ovlp_s = np.arange(inst.nproj * nactive * nactive, dtype=float).reshape(
+        inst.nproj, nactive, nactive, order="F"
+    )
+
+    inst.der3_g_lambda_wfnparams2()
+
+    out = inst.d3_g_lambda_wfnparams2
+    assert out.shape == (inst.nequation, nactive, nactive)
+    np.testing.assert_allclose(out[:inst.nproj], 2.0 * inst.dd_ovlp_s)
+    np.testing.assert_allclose(out[inst.nproj:], 0.0)
+
+
+def test_der3_g_e_wfnparams2_active_energy():
+    nactive = 5
+    ncols = nactive - 1
+    inst = DummyEParam(nactive=nactive, active_energy=True)
+    inst.dd_ovlp_s = np.arange(inst.nproj * ncols * ncols, dtype=float).reshape(
+        inst.nproj, ncols, ncols, order="F"
+    )
+
+    inst.der3_g_e_wfnparams2()
+    out = inst.d3_g_e_wfnparams2
+
+    assert out.shape == (inst.nequation, ncols, ncols)
+    np.testing.assert_allclose(out[:inst.nproj], -inst.dd_ovlp_s)
+    np.testing.assert_allclose(out[inst.nproj:], 0.0)
+
+
+def test_der3_g_e_wfnparams2_inactive_energy():
+    inst = DummyEParam(active_energy=False)
+    inst.der3_g_e_wfnparams2()
+    assert inst.d3_g_e_wfnparams2 is None
+
+
+def test_der2_g_wfnparams2_active_energy():
+    nactive = 6
+    ncols = nactive - 1
+    E = 2.25
+    inst = DummyEParam(nactive=nactive, active_energy=True, energy_value=E)
+
+    dd = np.arange(inst.nproj * ncols * ncols, dtype=float).reshape(
+        inst.nproj, ncols, ncols, order="F"
+    )
+    inst.dd_ovlp_s = dd.copy()
+
+    inst.der2_g_wfnparams2()
+    out = inst.d2_g_wfnparams2
+
+    assert out.shape == (inst.nequation, ncols, ncols)
+
+    expected = (3.0 - E) * dd  # ham op scales by 3; then minus E term in method
+    np.testing.assert_allclose(out[:inst.nproj], expected)
+    np.testing.assert_allclose(out[inst.nproj:], 0.0)
+
+    # current impl modifies dd_ovlp_s in-place (as in your test)
+    assert not np.array_equal(inst.dd_ovlp_s, dd), "dd_ovlp_s was modified in-place."
+
+
+@pytest.mark.skip(reason="By design: der2_g_wfnparams2 is only used with active_energy=True.")
+def test_der2_g_wfnparams2_inactive_energy_bug():
+    inst = DummyEParam(active_energy=False)
+    inst.dd_ovlp_s = np.arange(inst.nproj * inst.nactive * inst.nactive, dtype=float).reshape(
+        inst.nproj, inst.nactive, inst.nactive, order="F"
+    )
+    inst.der2_g_wfnparams2()
+    assert hasattr(inst, "d2_g_wfnparams2")

--- a/tests/test_fanpt_container_energy_param.py
+++ b/tests/test_fanpt_container_energy_param.py
@@ -1,21 +1,39 @@
+"""Tests for fanpy.fanpt.containers.energy_param.FANPTContainerEParam."""
+
 import numpy as np
 import pytest
+
 from fanpy.fanpt.containers.energy_param import FANPTContainerEParam
 
 
-# --- tiny helper ---
-def make_scaling_op(factor: float):
-    """Return an op(x, out=None) that multiplies by `factor`."""
+def make_scaling_op(factor):
+    """Return an operator that scales its input by a constant factor."""
+
     def op(x, out=None):
         if out is None:
             return factor * x
+
         out[...] = factor * x
+        return None
+
     return op
+
+
+def copy_upper_triangle_to_lower(tensor):
+    """Return a copy with tensor[:, i, j] mirrored into tensor[:, j, i]."""
+    sym_tensor = tensor.copy()
+
+    for i in range(sym_tensor.shape[1]):
+        for j in range(i + 1, sym_tensor.shape[2]):
+            sym_tensor[:, j, i] = sym_tensor[:, i, j]
+
+    return sym_tensor
 
 
 class FakeFanCIObjective:
     """Mock FanCI objective returning a fixed Jacobian."""
-    def __init__(self, ret: np.ndarray):
+
+    def __init__(self, ret):
         self._ret = ret
         self.calls = 0
         self.last_params = None
@@ -26,96 +44,124 @@ class FakeFanCIObjective:
         return self._ret
 
 
-# --- Lightweight test double: DOES NOT call super().__init__ ---
 class DummyEParam(FANPTContainerEParam):
-    def __init__(self, *,
-                 nequation=5,
-                 nproj=3,
-                 nactive=4,
-                 active_energy=True,
-                 energy_value=1.5):
-        # store read-onlys; expose via properties
+    """Lightweight test double for FANPTContainerEParam.
+
+    This intentionally does not call super().__init__ because these tests target
+    individual derivative-building methods directly.
+    """
+
+    def __init__(
+        self,
+        *,
+        nequation=5,
+        nproj=3,
+        nactive=4,
+        active_energy=True,
+        energy_value=1.5,
+    ):
         self._nequation = int(nequation)
-        self._nproj     = int(nproj)
-        self._nactive   = int(nactive)
+        self._nproj = int(nproj)
+        self._nactive = int(nactive)
 
-        # flags & params (last element energy)
         self.active_energy = bool(active_energy)
-        self.params = np.array([0.0] * (self._nactive - 1) + [float(energy_value)], dtype=float)
+        self.params = np.array(
+            [0.0] * (self._nactive - 1) + [float(energy_value)],
+            dtype=float,
+        )
 
-        # operators
         self.f_pot_ci_op = make_scaling_op(2.0)
-        self.ham_ci_op   = make_scaling_op(3.0)
+        self.ham_ci_op = make_scaling_op(3.0)
 
-        # jacobian provider
         self.fanci_objective = FakeFanCIObjective(
             np.full((self._nequation, self._nactive), 42.0, dtype=float)
         )
 
-        # overlaps / derivatives
         self.ovlp_s = np.arange(self._nproj, dtype=float) + 1.0
-        self.d_ovlp_s = np.arange(self._nproj * self._nactive, dtype=float)\
-                            .reshape(self._nproj, self._nactive, order="F")
-        self.dd_ovlp_s = np.arange(self._nproj * self._nactive * self._nactive, dtype=float)\
-                            .reshape(self._nproj, self._nactive, self._nactive, order="F")
+        self.d_ovlp_s = np.arange(
+            self._nproj * self._nactive,
+            dtype=float,
+        ).reshape(self._nproj, self._nactive, order="F")
+
+        self.dd_ovlp_s = np.arange(
+            self._nproj * self._nactive * self._nactive,
+            dtype=float,
+        ).reshape(self._nproj, self._nactive, self._nactive, order="F")
 
     @property
-    def nequation(self): return self._nequation
-    @property
-    def nproj(self):     return self._nproj
-    @property
-    def nactive(self):   return self._nactive
+    def nequation(self):
+        return self._nequation
 
+    @property
+    def nproj(self):
+        return self._nproj
 
-# ---------------- Tests (direct instantiation) ----------------
+    @property
+    def nactive(self):
+        return self._nactive
+
 
 def test_der_g_lambda_projects_only_first_nproj():
     inst = DummyEParam()
+
     inst.der_g_lambda()
 
     assert inst.d_g_lambda.shape == (inst.nequation,)
-    np.testing.assert_allclose(inst.d_g_lambda[:inst.nproj], 2.0 * inst.ovlp_s)
-    np.testing.assert_allclose(inst.d_g_lambda[inst.nproj:], 0.0)
+    np.testing.assert_allclose(inst.d_g_lambda[: inst.nproj], 2.0 * inst.ovlp_s)
+    np.testing.assert_allclose(inst.d_g_lambda[inst.nproj :], 0.0)
 
 
 @pytest.mark.parametrize("active_energy,ncols", [(False, 4), (True, 3)])
 def test_der2_g_lambda_wfnparams(active_energy, ncols):
     inst = DummyEParam(nactive=4, active_energy=active_energy)
-    # shape (nproj, ncols) Fortran
     inst.d_ovlp_s = np.arange(inst.nproj * ncols, dtype=float).reshape(
-        inst.nproj, ncols, order="F"
+        inst.nproj,
+        ncols,
+        order="F",
     )
 
     inst.der2_g_lambda_wfnparams()
 
     assert inst.d2_g_lambda_wfnparams.shape == (inst.nequation, ncols)
-    np.testing.assert_allclose(inst.d2_g_lambda_wfnparams[:inst.nproj], 2.0 * inst.d_ovlp_s)
-    np.testing.assert_allclose(inst.d2_g_lambda_wfnparams[inst.nproj:], 0.0)
+    np.testing.assert_allclose(
+        inst.d2_g_lambda_wfnparams[: inst.nproj],
+        2.0 * inst.d_ovlp_s,
+    )
+    np.testing.assert_allclose(inst.d2_g_lambda_wfnparams[inst.nproj :], 0.0)
 
 
 def test_der2_g_e_wfnparams_active():
     inst = DummyEParam(nactive=5, active_energy=True)
     ncols = inst.nactive - 1
     inst.d_ovlp_s = np.arange(inst.nproj * ncols, dtype=float).reshape(
-        inst.nproj, ncols, order="F"
+        inst.nproj,
+        ncols,
+        order="F",
     )
 
     inst.der2_g_e_wfnparams()
 
     assert inst.d2_g_e_wfnparams.shape == (inst.nequation, ncols)
-    np.testing.assert_allclose(inst.d2_g_e_wfnparams[:inst.nproj], -inst.d_ovlp_s)
-    np.testing.assert_allclose(inst.d2_g_e_wfnparams[inst.nproj:], 0.0)
+    np.testing.assert_allclose(
+        inst.d2_g_e_wfnparams[: inst.nproj],
+        -inst.d_ovlp_s,
+    )
+    np.testing.assert_allclose(inst.d2_g_e_wfnparams[inst.nproj :], 0.0)
 
 
 def test_der2_g_e_wfnparams_inactive():
     inst = DummyEParam(active_energy=False)
+
     inst.der2_g_e_wfnparams()
+
     assert inst.d2_g_e_wfnparams is None
 
 
 def test_gen_coeff_matrix_calls_fanci():
     inst = DummyEParam()
+
     inst.gen_coeff_matrix()
+
     assert inst.fanci_objective.calls == 1
     assert inst.c_matrix.shape == (inst.nequation, inst.nactive)
     np.testing.assert_allclose(inst.c_matrix, 42.0)
@@ -124,69 +170,93 @@ def test_gen_coeff_matrix_calls_fanci():
 def test_der3_g_lambda_wfnparams2_inactive_energy():
     nactive = 4
     inst = DummyEParam(nactive=nactive, active_energy=False)
-    inst.dd_ovlp_s = np.arange(inst.nproj * nactive * nactive, dtype=float).reshape(
-        inst.nproj, nactive, nactive, order="F"
+
+    dd = np.arange(inst.nproj * nactive * nactive, dtype=float).reshape(
+        inst.nproj,
+        nactive,
+        nactive,
+        order="F",
     )
+    inst.dd_ovlp_s = dd.copy()
 
     inst.der3_g_lambda_wfnparams2()
 
+    expected = 2.0 * copy_upper_triangle_to_lower(dd)
+
     out = inst.d3_g_lambda_wfnparams2
     assert out.shape == (inst.nequation, nactive, nactive)
-    np.testing.assert_allclose(out[:inst.nproj], 2.0 * inst.dd_ovlp_s)
-    np.testing.assert_allclose(out[inst.nproj:], 0.0)
+    np.testing.assert_allclose(out[: inst.nproj], expected)
+    np.testing.assert_allclose(out[inst.nproj :], 0.0)
 
 
 def test_der3_g_e_wfnparams2_active_energy():
     nactive = 5
     ncols = nactive - 1
     inst = DummyEParam(nactive=nactive, active_energy=True)
+
     inst.dd_ovlp_s = np.arange(inst.nproj * ncols * ncols, dtype=float).reshape(
-        inst.nproj, ncols, ncols, order="F"
+        inst.nproj,
+        ncols,
+        ncols,
+        order="F",
     )
 
     inst.der3_g_e_wfnparams2()
-    out = inst.d3_g_e_wfnparams2
 
+    out = inst.d3_g_e_wfnparams2
     assert out.shape == (inst.nequation, ncols, ncols)
-    np.testing.assert_allclose(out[:inst.nproj], -inst.dd_ovlp_s)
-    np.testing.assert_allclose(out[inst.nproj:], 0.0)
+    np.testing.assert_allclose(out[: inst.nproj], -inst.dd_ovlp_s)
+    np.testing.assert_allclose(out[inst.nproj :], 0.0)
 
 
 def test_der3_g_e_wfnparams2_inactive_energy():
     inst = DummyEParam(active_energy=False)
+
     inst.der3_g_e_wfnparams2()
+
     assert inst.d3_g_e_wfnparams2 is None
 
 
 def test_der2_g_wfnparams2_active_energy():
     nactive = 6
     ncols = nactive - 1
-    E = 2.25
-    inst = DummyEParam(nactive=nactive, active_energy=True, energy_value=E)
+    energy = 2.25
+
+    inst = DummyEParam(
+        nactive=nactive,
+        active_energy=True,
+        energy_value=energy,
+    )
 
     dd = np.arange(inst.nproj * ncols * ncols, dtype=float).reshape(
-        inst.nproj, ncols, ncols, order="F"
+        inst.nproj,
+        ncols,
+        ncols,
+        order="F",
     )
     inst.dd_ovlp_s = dd.copy()
 
     inst.der2_g_wfnparams2()
+
+    expected = (3.0 - energy) * copy_upper_triangle_to_lower(dd)
+
     out = inst.d2_g_wfnparams2
-
     assert out.shape == (inst.nequation, ncols, ncols)
+    np.testing.assert_allclose(out[: inst.nproj], expected)
+    np.testing.assert_allclose(out[inst.nproj :], 0.0)
 
-    expected = (3.0 - E) * dd  # ham op scales by 3; then minus E term in method
-    np.testing.assert_allclose(out[:inst.nproj], expected)
-    np.testing.assert_allclose(out[inst.nproj:], 0.0)
-
-    # current impl modifies dd_ovlp_s in-place (as in your test)
-    assert not np.array_equal(inst.dd_ovlp_s, dd), "dd_ovlp_s was modified in-place."
+    # The method should not mutate the stored double-overlap derivatives.
+    np.testing.assert_allclose(inst.dd_ovlp_s, dd)
 
 
 @pytest.mark.skip(reason="By design: der2_g_wfnparams2 is only used with active_energy=True.")
 def test_der2_g_wfnparams2_inactive_energy_bug():
     inst = DummyEParam(active_energy=False)
-    inst.dd_ovlp_s = np.arange(inst.nproj * inst.nactive * inst.nactive, dtype=float).reshape(
-        inst.nproj, inst.nactive, inst.nactive, order="F"
-    )
+    inst.dd_ovlp_s = np.arange(
+        inst.nproj * inst.nactive * inst.nactive,
+        dtype=float,
+    ).reshape(inst.nproj, inst.nactive, inst.nactive, order="F")
+
     inst.der2_g_wfnparams2()
+
     assert hasattr(inst, "d2_g_wfnparams2")

--- a/tests/test_fanpt_container_updater.py
+++ b/tests/test_fanpt_container_updater.py
@@ -1,0 +1,561 @@
+import numpy as np
+import pytest
+from types import SimpleNamespace
+from fanpy.fanpt.containers.base import FANPTContainer
+
+# ---- Basic fakes ----
+
+class FakeObjective:
+    def __init__(self, nproj=3, energy_active=True):
+        self.mask = np.array([1, 1, 1 if energy_active else 0])
+        self.nproj = nproj
+        self.wfn = object()
+
+    def compute_overlap(self, wfn_params, space):
+        # Return predictable overlap: [1,2,3,...,nproj]
+        return np.arange(1, self.nproj + 1, dtype=float)
+
+
+from fanpy.fanpt.containers.base import FANPTContainer
+
+class DummyContainer(FANPTContainer):
+    """Simpler mock container for tests."""
+    def __init__(self, nactive=4, nequation=3, nproj=3, energy_active=True, l=0.2, inorm=False, ref_sd=0, energy=-1.0):
+        self.fanci_objective = FakeObjective(nproj, energy_active)
+
+        # Store privately since FANPTContainer defines read-only properties
+        self._nactive = nactive
+        self._nequation = nequation
+        self._nproj = nproj
+
+        self.l = l
+        self.inorm = inorm
+        self.ref_sd = ref_sd
+        self.energy = energy
+        self.active_energy = energy_active
+        self.wfn_params = np.zeros(nactive - 1)
+        self.c_matrix = np.eye(nequation, nactive)
+        self.constant_terms = np.zeros((nequation, 1))
+        self.d2_g_lambda_wfnparams = np.ones((nequation, nactive - 1))
+        self.d_g_lambda = np.arange(nequation, dtype=float)
+        self.ham0 = "H0"
+        self.ham1 = "H1"
+
+    # ---- Override property getters ----
+    @property
+    def nactive(self):
+        return self._nactive
+
+    @property
+    def nequation(self):
+        return self._nequation
+
+    @property
+    def nproj(self):
+        return self._nproj
+
+    # ---- Required abstract methods ----
+    def der_g_lambda(self):
+        pass
+
+    def der2_g_lambda_wfnparams(self):
+        pass
+
+    def gen_coeff_matrix(self):
+        pass
+
+
+
+class FakeSparseOp:
+    def __init__(self, ham, wfn, nproj, symmetric=False):
+        self.nproj = nproj
+
+    def __call__(self, vec, out):
+        out[:] = 2 * np.asarray(vec, dtype=float)
+
+
+def make_pyci():
+    return SimpleNamespace(sparse_op=FakeSparseOp, c_double=float)
+
+
+# ---- Import target classes ----
+
+def import_updater():
+    import fanpy.fanpt.containers.base as base_mod
+    from fanpy.fanpt.containers.updater import FANPTUpdater as Updater
+    return base_mod, Updater
+
+
+# ---- Tests ----
+
+def test_basic_init_and_final_l(monkeypatch):
+    base_mod, Updater = import_updater()
+    cont = DummyContainer(l=0.2)
+    import fanpy.fanpt.containers.updater as upd
+
+    monkeypatch.setattr(upd, "pyci", make_pyci())
+    monkeypatch.setattr(upd, "linear_comb_ham", lambda *a, **k: {})
+    monkeypatch.setattr(upd, "FANPTConstantTerms", lambda *a, **k: SimpleNamespace(constant_terms=np.zeros(4)))
+    monkeypatch.setattr(upd,"FANPTConstantTerms",lambda *a, **k: SimpleNamespace(constant_terms=np.zeros(cont.c_matrix.shape[0])),)
+
+    # Bad inputs
+    with pytest.raises(TypeError):
+        Updater(cont, final_order=1, final_l=1, solver=None)
+    with pytest.raises(ValueError):
+        Updater(cont, final_order=1, final_l=0.1, solver=None)
+    with pytest.raises(ValueError):
+        Updater(cont, final_order=1, final_l=1.1, solver=None)
+
+    # Valid
+    ok = Updater(cont, final_order=1, final_l=0.8, solver=None)
+    assert isinstance(ok, Updater)
+
+
+def test_resum_path(monkeypatch):
+    base_mod, Updater = import_updater()
+    cont = DummyContainer(nactive=4, nequation=4, energy_active=False, l=0.1)
+    cont.c_matrix = np.eye(4)
+    cont.d2_g_lambda_wfnparams = np.eye(4)
+    cont.d_g_lambda = np.arange(1, 5)
+
+    import fanpy.fanpt.containers.updater as upd
+    monkeypatch.setattr(upd, "pyci", make_pyci())
+    monkeypatch.setattr(upd, "linear_comb_ham", lambda *a, **k: {})
+    monkeypatch.setattr(upd, "FANPTConstantTerms", lambda **kw: SimpleNamespace(constant_terms=np.zeros(4)))
+    monkeypatch.setattr(upd, "FANPTConstantTerms", lambda *a, **k: SimpleNamespace(constant_terms=np.zeros(4)))
+
+    up = Updater(cont, final_order=2, final_l=0.6, solver=None, resum=True)
+    assert up.resum
+    assert hasattr(up, "resum_correction")
+
+
+def test_non_resum_path(monkeypatch):
+    base_mod, Updater = import_updater()
+    cont = DummyContainer(nactive=5, nequation=3, l=0.2)
+
+    rng = np.random.default_rng(0)
+    cont.c_matrix = rng.normal(size=(3, 5))
+
+    def fake_ct(*, fanpt_container, order, previous_responses):
+        # length must match rows of c_matrix (nequation)
+        return SimpleNamespace(constant_terms=np.ones(fanpt_container.c_matrix.shape[0]) * order)
+
+
+    import fanpy.fanpt.containers.updater as upd
+    monkeypatch.setattr(upd, "pyci", make_pyci())
+    monkeypatch.setattr(upd, "linear_comb_ham", lambda *a, **k: {})
+    monkeypatch.setattr(upd, "FANPTConstantTerms", fake_ct)
+    monkeypatch.setattr(upd, "FANPTConstantTerms", fake_ct)
+    up = Updater(cont, final_order=2, final_l=0.8, solver=None, resum=False)
+    assert up.responses.shape[0] == 2
+    assert np.all(np.isfinite(up.responses))
+
+
+def test_fanpt_e_formula(monkeypatch):
+    base_mod, Updater = import_updater()
+    cont = DummyContainer(nactive=5, nequation=4, l=0.1, energy=-5.0)
+
+    import fanpy.fanpt.containers.updater as upd
+    monkeypatch.setattr(upd, "pyci", make_pyci())
+    monkeypatch.setattr(upd, "linear_comb_ham", lambda *a, **k: {})
+    monkeypatch.setattr(upd, "FANPTConstantTerms", lambda *a, **k: SimpleNamespace(constant_terms=np.zeros(5)))
+    monkeypatch.setattr(upd,"FANPTConstantTerms",lambda *a, **k: SimpleNamespace(constant_terms=np.zeros(cont.c_matrix.shape[0])),)
+
+    up = Updater(cont, final_order=2, final_l=0.6, solver=None)
+    up.responses = np.zeros((2, cont.nactive))
+    up.responses[0, -1] = 1.5
+    up.responses[1, -1] = 0.5
+
+    up.fanpt_e_response()
+    expected = -5.0 + (0.5 * 1.5) + (0.5**2 / 2 * 0.5)
+    assert up.fanpt_e == pytest.approx(expected)
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/tests/test_fanpt_container_updater.py
+++ b/tests/test_fanpt_container_updater.py
@@ -1,29 +1,43 @@
+"""Tests for fanpy.fanpt.containers.updater.FANPTUpdater."""
+
+from types import SimpleNamespace
+
 import numpy as np
 import pytest
-from types import SimpleNamespace
+
 from fanpy.fanpt.containers.base import FANPTContainer
 
-# ---- Basic fakes ----
 
 class FakeObjective:
+    """Minimal FanCI objective used by the updater tests."""
+
     def __init__(self, nproj=3, energy_active=True):
-        self.mask = np.array([1, 1, 1 if energy_active else 0])
+        self.mask = np.array([True, True, bool(energy_active)])
         self.nproj = nproj
         self.wfn = object()
 
     def compute_overlap(self, wfn_params, space):
-        # Return predictable overlap: [1,2,3,...,nproj]
+        """Return deterministic overlaps."""
+        del wfn_params, space
         return np.arange(1, self.nproj + 1, dtype=float)
 
 
-from fanpy.fanpt.containers.base import FANPTContainer
-
 class DummyContainer(FANPTContainer):
-    """Simpler mock container for tests."""
-    def __init__(self, nactive=4, nequation=3, nproj=3, energy_active=True, l=0.2, inorm=False, ref_sd=0, energy=-1.0):
-        self.fanci_objective = FakeObjective(nproj, energy_active)
+    """Minimal FANPTContainer-like object for updater tests."""
 
-        # Store privately since FANPTContainer defines read-only properties
+    def __init__(
+        self,
+        nactive=4,
+        nequation=3,
+        nproj=3,
+        energy_active=True,
+        l=0.2,
+        inorm=False,
+        ref_sd=0,
+        energy=-1.0,
+    ):
+        self.fanci_objective = FakeObjective(nproj=nproj, energy_active=energy_active)
+
         self._nactive = nactive
         self._nequation = nequation
         self._nproj = nproj
@@ -33,15 +47,16 @@ class DummyContainer(FANPTContainer):
         self.ref_sd = ref_sd
         self.energy = energy
         self.active_energy = energy_active
+
         self.wfn_params = np.zeros(nactive - 1)
         self.c_matrix = np.eye(nequation, nactive)
         self.constant_terms = np.zeros((nequation, 1))
         self.d2_g_lambda_wfnparams = np.ones((nequation, nactive - 1))
         self.d_g_lambda = np.arange(nequation, dtype=float)
+
         self.ham0 = "H0"
         self.ham1 = "H1"
 
-    # ---- Override property getters ----
     @property
     def nactive(self):
         return self._nactive
@@ -54,7 +69,6 @@ class DummyContainer(FANPTContainer):
     def nproj(self):
         return self._nproj
 
-    # ---- Required abstract methods ----
     def der_g_lambda(self):
         pass
 
@@ -65,497 +79,163 @@ class DummyContainer(FANPTContainer):
         pass
 
 
-
 class FakeSparseOp:
+    """Minimal pyci sparse operator replacement."""
+
     def __init__(self, ham, wfn, nproj, symmetric=False):
+        del ham, wfn, symmetric
         self.nproj = nproj
 
-    def __call__(self, vec, out):
-        out[:] = 2 * np.asarray(vec, dtype=float)
+    def __call__(self, vector, out):
+        out[:] = 2.0 * np.asarray(vector, dtype=float)
 
 
 def make_pyci():
+    """Return a minimal pyci-like namespace."""
     return SimpleNamespace(sparse_op=FakeSparseOp, c_double=float)
 
 
-# ---- Import target classes ----
-
 def import_updater():
-    import fanpy.fanpt.containers.base as base_mod
-    from fanpy.fanpt.containers.updater import FANPTUpdater as Updater
-    return base_mod, Updater
+    """Import the updater class and module."""
+    import fanpy.fanpt.containers.updater as updater_module
+    from fanpy.fanpt.containers.updater import FANPTUpdater
+
+    return updater_module, FANPTUpdater
 
 
-# ---- Tests ----
+def patch_updater_dependencies(monkeypatch, updater_module, constant_terms_factory=None):
+    """Patch external updater dependencies with deterministic fakes."""
+    monkeypatch.setattr(updater_module, "pyci", make_pyci())
+    monkeypatch.setattr(updater_module, "linear_comb_ham", lambda *args, **kwargs: {})
 
-def test_basic_init_and_final_l(monkeypatch):
-    base_mod, Updater = import_updater()
-    cont = DummyContainer(l=0.2)
-    import fanpy.fanpt.containers.updater as upd
+    if constant_terms_factory is None:
 
-    monkeypatch.setattr(upd, "pyci", make_pyci())
-    monkeypatch.setattr(upd, "linear_comb_ham", lambda *a, **k: {})
-    monkeypatch.setattr(upd, "FANPTConstantTerms", lambda *a, **k: SimpleNamespace(constant_terms=np.zeros(4)))
-    monkeypatch.setattr(upd,"FANPTConstantTerms",lambda *a, **k: SimpleNamespace(constant_terms=np.zeros(cont.c_matrix.shape[0])),)
+        def constant_terms_factory(*args, **kwargs):
+            fanpt_container = kwargs["fanpt_container"]
+            return SimpleNamespace(
+                constant_terms=np.zeros(fanpt_container.c_matrix.shape[0])
+            )
 
-    # Bad inputs
+    monkeypatch.setattr(updater_module, "FANPTConstantTerms", constant_terms_factory)
+
+
+def make_constant_terms(value=0.0):
+    """Return a fake FANPTConstantTerms constructor."""
+
+    def fake_constant_terms(*args, **kwargs):
+        del args
+
+        fanpt_container = kwargs["fanpt_container"]
+        return SimpleNamespace(
+            constant_terms=np.full(fanpt_container.c_matrix.shape[0], value)
+        )
+
+    return fake_constant_terms
+
+
+def test_basic_init_and_final_l_validation(monkeypatch):
+    """Updater validates final_order and final_l before valid initialization."""
+    updater_module, Updater = import_updater()
+    container = DummyContainer(l=0.2)
+
+    patch_updater_dependencies(monkeypatch, updater_module)
+
     with pytest.raises(TypeError):
-        Updater(cont, final_order=1, final_l=1, solver=None)
-    with pytest.raises(ValueError):
-        Updater(cont, final_order=1, final_l=0.1, solver=None)
-    with pytest.raises(ValueError):
-        Updater(cont, final_order=1, final_l=1.1, solver=None)
+        Updater(container, final_order=1, final_l=1, solver=None)
 
-    # Valid
-    ok = Updater(cont, final_order=1, final_l=0.8, solver=None)
-    assert isinstance(ok, Updater)
+    with pytest.raises(ValueError):
+        Updater(container, final_order=1, final_l=0.1, solver=None)
+
+    with pytest.raises(ValueError):
+        Updater(container, final_order=1, final_l=1.1, solver=None)
+
+    updater = Updater(container, final_order=1, final_l=0.8, solver=None)
+    assert isinstance(updater, Updater)
 
 
 def test_resum_path(monkeypatch):
-    base_mod, Updater = import_updater()
-    cont = DummyContainer(nactive=4, nequation=4, energy_active=False, l=0.1)
-    cont.c_matrix = np.eye(4)
-    cont.d2_g_lambda_wfnparams = np.eye(4)
-    cont.d_g_lambda = np.arange(1, 5)
+    """Updater builds resummation correction when resum=True."""
+    updater_module, Updater = import_updater()
 
-    import fanpy.fanpt.containers.updater as upd
-    monkeypatch.setattr(upd, "pyci", make_pyci())
-    monkeypatch.setattr(upd, "linear_comb_ham", lambda *a, **k: {})
-    monkeypatch.setattr(upd, "FANPTConstantTerms", lambda **kw: SimpleNamespace(constant_terms=np.zeros(4)))
-    monkeypatch.setattr(upd, "FANPTConstantTerms", lambda *a, **k: SimpleNamespace(constant_terms=np.zeros(4)))
+    container = DummyContainer(
+        nactive=4,
+        nequation=4,
+        energy_active=False,
+        l=0.1,
+    )
+    container.c_matrix = np.eye(4)
+    container.d2_g_lambda_wfnparams = np.eye(4)
+    container.d_g_lambda = np.arange(1, 5, dtype=float)
 
-    up = Updater(cont, final_order=2, final_l=0.6, solver=None, resum=True)
-    assert up.resum
-    assert hasattr(up, "resum_correction")
+    patch_updater_dependencies(monkeypatch, updater_module)
+
+    updater = Updater(
+        container,
+        final_order=2,
+        final_l=0.6,
+        solver=None,
+        resum=True,
+    )
+
+    assert updater.resum
+    assert hasattr(updater, "resum_correction")
 
 
 def test_non_resum_path(monkeypatch):
-    base_mod, Updater = import_updater()
-    cont = DummyContainer(nactive=5, nequation=3, l=0.2)
+    """Updater computes finite response vectors in the non-resummation path."""
+    updater_module, Updater = import_updater()
 
+    container = DummyContainer(nactive=5, nequation=3, l=0.2)
     rng = np.random.default_rng(0)
-    cont.c_matrix = rng.normal(size=(3, 5))
+    container.c_matrix = rng.normal(size=(3, 5))
 
-    def fake_ct(*, fanpt_container, order, previous_responses):
-        # length must match rows of c_matrix (nequation)
-        return SimpleNamespace(constant_terms=np.ones(fanpt_container.c_matrix.shape[0]) * order)
+    def fake_constant_terms(*args, **kwargs):
+        del args
 
+        fanpt_container = kwargs["fanpt_container"]
+        order = kwargs["order"]
+        return SimpleNamespace(
+            constant_terms=np.full(fanpt_container.c_matrix.shape[0], order)
+        )
 
-    import fanpy.fanpt.containers.updater as upd
-    monkeypatch.setattr(upd, "pyci", make_pyci())
-    monkeypatch.setattr(upd, "linear_comb_ham", lambda *a, **k: {})
-    monkeypatch.setattr(upd, "FANPTConstantTerms", fake_ct)
-    monkeypatch.setattr(upd, "FANPTConstantTerms", fake_ct)
-    up = Updater(cont, final_order=2, final_l=0.8, solver=None, resum=False)
-    assert up.responses.shape[0] == 2
-    assert np.all(np.isfinite(up.responses))
+    patch_updater_dependencies(
+        monkeypatch,
+        updater_module,
+        constant_terms_factory=fake_constant_terms,
+    )
+
+    updater = Updater(
+        container,
+        final_order=2,
+        final_l=0.8,
+        solver=None,
+        resum=False,
+    )
+
+    assert updater.responses.shape == (2, container.nactive)
+    assert np.all(np.isfinite(updater.responses))
 
 
 def test_fanpt_e_formula(monkeypatch):
-    base_mod, Updater = import_updater()
-    cont = DummyContainer(nactive=5, nequation=4, l=0.1, energy=-5.0)
-
-    import fanpy.fanpt.containers.updater as upd
-    monkeypatch.setattr(upd, "pyci", make_pyci())
-    monkeypatch.setattr(upd, "linear_comb_ham", lambda *a, **k: {})
-    monkeypatch.setattr(upd, "FANPTConstantTerms", lambda *a, **k: SimpleNamespace(constant_terms=np.zeros(5)))
-    monkeypatch.setattr(upd,"FANPTConstantTerms",lambda *a, **k: SimpleNamespace(constant_terms=np.zeros(cont.c_matrix.shape[0])),)
-
-    up = Updater(cont, final_order=2, final_l=0.6, solver=None)
-    up.responses = np.zeros((2, cont.nactive))
-    up.responses[0, -1] = 1.5
-    up.responses[1, -1] = 0.5
-
-    up.fanpt_e_response()
-    expected = -5.0 + (0.5 * 1.5) + (0.5**2 / 2 * 0.5)
-    assert up.fanpt_e == pytest.approx(expected)
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+    """fanpt_e_response uses the Taylor correction from active-energy responses."""
+    updater_module, Updater = import_updater()
+
+    container = DummyContainer(
+        nactive=5,
+        nequation=4,
+        l=0.1,
+        energy=-5.0,
+    )
+
+    patch_updater_dependencies(monkeypatch, updater_module)
+
+    updater = Updater(container, final_order=2, final_l=0.6, solver=None)
+    updater.responses = np.zeros((2, container.nactive))
+    updater.responses[0, -1] = 1.5
+    updater.responses[1, -1] = 0.5
+
+    updater.fanpt_e_response()
+
+    dlambda = 0.5
+    expected = -5.0 + dlambda * 1.5 + (dlambda**2 / 2.0) * 0.5
+    assert updater.fanpt_e == pytest.approx(expected)

--- a/tests/test_fanpt_container_updater.py
+++ b/tests/test_fanpt_container_updater.py
@@ -180,7 +180,14 @@ def test_resum_path(monkeypatch):
     assert updater.resum
     assert hasattr(updater, "resum_correction")
 
+def fake_constant_terms(*args, **kwargs):
+    del args
 
+    fanpt_container = kwargs["fanpt_container"]
+    order = kwargs["order"]
+    return SimpleNamespace(
+        constant_terms=np.full(fanpt_container.c_matrix.shape[0], order)
+    )
 def test_non_resum_path(monkeypatch):
     """Updater computes finite response vectors in the non-resummation path."""
     updater_module, Updater = import_updater()
@@ -189,14 +196,6 @@ def test_non_resum_path(monkeypatch):
     rng = np.random.default_rng(0)
     container.c_matrix = rng.normal(size=(3, 5))
 
-    def fake_constant_terms(*args, **kwargs):
-        del args
-
-        fanpt_container = kwargs["fanpt_container"]
-        order = kwargs["order"]
-        return SimpleNamespace(
-            constant_terms=np.full(fanpt_container.c_matrix.shape[0], order)
-        )
 
     patch_updater_dependencies(
         monkeypatch,

--- a/tests/test_fanpt_fanpt.py
+++ b/tests/test_fanpt_fanpt.py
@@ -1,0 +1,286 @@
+# test_fanpt_fanpt.py  — Refactored to use a context manager (Option B)
+import numpy as np
+import types
+import pytest
+from contextlib import ExitStack
+from unittest.mock import patch
+
+from fanpy.fanpt.fanpt import FANPT
+import fanpy.fanpt.fanpt as mod
+
+
+#
+# ---------- Tiny fakes ----------
+#
+
+class FakeHam:
+    """Mock representation of a molecular Hamiltonian."""
+    def __init__(self, ecore=0.0, one_mo=None, two_mo=None):
+        self.ecore = ecore
+        self.one_mo = np.array(one_mo) if one_mo is not None else np.zeros((2, 2))
+        self.two_mo = np.array(two_mo) if two_mo is not None else np.zeros((2, 2, 2, 2))
+
+
+class FakeObjective:
+    """Mock objective class simulating FanCI's projected Schrödinger objective."""
+    def __init__(self, *, nequation=3, nactive=3, constraints=None, last_mask=False, ham=None, fill="full"):
+        self.nequation = nequation
+        self.nactive = nactive
+        # mask: True = active; last index corresponds to energy
+        self.mask = np.zeros(nactive, dtype=bool)
+        self.mask[-1] = last_mask
+        self.constraints = list(constraints or [])
+        self.ham = ham or FakeHam(0.0, np.eye(2), np.zeros((2, 2, 2, 2)))
+        self.fill = fill
+        # required by FANPT: .fanpy_objective.refwfn used when ref_sd is None
+        self.fanpy_objective = types.SimpleNamespace(refwfn=0)
+
+        # counters for freeze/unfreeze/constraint removal
+        self.frozen_calls = 0
+        self.unfrozen_calls = 0
+        self.removed_constraints = []
+
+    def freeze_parameter(self, idx):
+        assert idx == -1
+        self.frozen_calls += 1
+        self.mask[idx] = False
+
+    def unfreeze_parameter(self, idx):
+        assert idx == -1
+        self.unfrozen_calls += 1
+        self.mask[idx] = True
+
+    def remove_constraint(self, s):
+        self.removed_constraints.append(s)
+        try:
+            self.constraints.remove(s)
+        except ValueError:
+            pass
+
+    def optimize(self, params, **kwargs):
+        # deterministic fake: return a result with `x` of length = number of active params
+        active_count = int(self.mask.sum())
+        x = np.arange(active_count, dtype=float)
+        class Result(dict):
+            def __init__(self, x): super().__init__(); self.x = x
+        return Result(x)
+
+
+class FakePYCI:
+    """Mock PyCI interface class for FANPT testing."""
+    def __init__(self, objective, energy_nuc, legacy_fanci=True):
+        self.objective = objective
+        self.energy_nuc = energy_nuc
+        self.legacy_fanci = legacy_fanci
+        self.update_calls = []
+
+    def update_objective(self, ham):
+        self.update_calls.append(ham)
+
+
+class DummyContainer:
+    """Mock FANPT container (EParam/EFree) used in tests."""
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs  # record inputs for assertions
+
+
+class DummyUpdater:
+    """Mock FANPTUpdater for unit tests."""
+    def __init__(self, fanpt_container, final_order, final_l, solver, resum):
+        nactive = fanpt_container.kwargs["params"].size - 1
+        self.new_wfn_params = np.ones(nactive) * 7.0
+        self.new_energy = 11.5
+        self.new_ham = FakeHam(ecore=99.0, one_mo=np.eye(2), two_mo=np.zeros((2, 2, 2, 2)))
+
+
+#
+# ---------- Context-manager patching environment (Option B) ----------
+#
+
+def _fake_reduce_to_fock(two_mo):
+    """Return a sentinel so tests can assert this was used."""
+    return np.full_like(two_mo, 123.0)
+
+class CtxEnv:
+    """Context manager that patches FANPT's dependencies to fakes."""
+    def __init__(self, fake_objective=None):
+        self.stack = ExitStack()
+        self.ham_calls = []
+        self.fake_objective = fake_objective or FakeObjective()
+        self.fake_projected = None  # set in __enter__
+
+    def __enter__(self):
+        # Patch reduce_to_fock in fanpt module
+        self.stack.enter_context(patch.object(mod, "reduce_to_fock", _fake_reduce_to_fock))
+
+        # Patch pyci.hamiltonian inside fanpt module and record constructor calls
+        def _ham_ctor(ecore, one_mo, two_mo):
+            self.ham_calls.append((ecore, np.array(one_mo), np.array(two_mo)))
+            return FakeHam(ecore, one_mo, two_mo)
+        self.stack.enter_context(patch.object(mod.pyci, "hamiltonian", _ham_ctor))
+
+        # Patch PYCI constructor to return our FakePYCI holding self.fake_objective
+        def _fake_PYCI(fanpy_objective, energy_nuc, legacy_fanci=True):
+            return FakePYCI(self.fake_objective, energy_nuc, legacy_fanci=legacy_fanci)
+        self.stack.enter_context(patch.object(mod.fanpy.interface.pyci, "PYCI", _fake_PYCI))
+
+        # Patch container classes + updater
+        self.stack.enter_context(patch.object(mod, "FANPTContainerEParam", DummyContainer))
+        self.stack.enter_context(patch.object(mod, "FANPTContainerEFree",  DummyContainer))
+        self.stack.enter_context(patch.object(mod, "FANPTUpdater",         DummyUpdater))
+
+        # Patch ProjectedSchrodinger and create a fake instance
+        class _FakeProjectedSchrodinger: pass
+        self.stack.enter_context(patch.object(mod, "ProjectedSchrodinger", _FakeProjectedSchrodinger))
+        self.fake_projected = _FakeProjectedSchrodinger()
+
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.stack.close()
+
+
+#
+# ---------- Tests ----------
+#
+
+def test_init_selects_eparam_and_unfreezes_energy():
+    """energy_active=True → use EParam, unfreeze energy if last mask is False, build ham0 via reduce_to_fock."""
+    fake_obj = FakeObjective(nequation=4, nactive=3, constraints=[], last_mask=False, ham=FakeHam(
+        ecore=0.5, one_mo=np.eye(2), two_mo=np.zeros((2, 2, 2, 2))
+    ))
+
+    with CtxEnv(fake_objective=fake_obj) as env:
+        fanpt = FANPT(
+            fanpy_objective=env.fake_projected,
+            energy_nuc=1.234,
+            legacy_fanci=False,
+            energy_active=True,
+            ref_sd=0,
+            final_order=1,
+            steps=1,
+        )
+
+        # container class chosen
+        assert fanpt.fanpt_container_class is DummyContainer
+        # energy unfreezing happened (last mask was False initially)
+        assert fake_obj.unfrozen_calls == 1
+
+        # ham0 built via pyci.hamiltonian with reduced two-electron integrals
+        assert len(env.ham_calls) == 1
+        ecore, one_mo, two_mo = env.ham_calls[0]
+        assert np.all(two_mo == 123.0)  # reduce_to_fock sentinel
+        assert fanpt.ham1 is fake_obj.ham
+        assert isinstance(fanpt.ham0, FakeHam)
+
+
+def test_init_selects_efree_and_freezes_energy_when_active():
+    """energy_active=False → use EFree, freeze energy if mask[-1] is True."""
+    # last_mask=True triggers freeze in EFree branch
+    fake_obj = FakeObjective(nequation=4, nactive=3, constraints=[], last_mask=True, ham=FakeHam())
+
+    with CtxEnv(fake_objective=fake_obj) as env:
+        fanpt = FANPT(
+            fanpy_objective=env.fake_projected,
+            energy_nuc=2.0,
+            energy_active=False,
+            ref_sd=0,
+        )
+
+        assert fanpt.fanpt_container_class is DummyContainer
+        assert fake_obj.frozen_calls == 1
+
+
+def test_init_inorm_detection_and_norm_det_assignment():
+    """Detects normalization constraint and sets inorm/norm_det accordingly."""
+    ref_sd = 2
+    norm_str = f"<\\psi_{{{ref_sd}}}|\\Psi> - v_{{{ref_sd}}}"
+    fake_obj = FakeObjective(
+        nequation=4, nactive=3, constraints=[norm_str], last_mask=False,
+        ham=FakeHam(0.0, np.eye(2), np.zeros((2, 2, 2, 2)))
+    )
+
+    with CtxEnv(fake_objective=fake_obj) as env:
+        fanpt = FANPT(
+            fanpy_objective=env.fake_projected,
+            energy_nuc=0.0,
+            energy_active=True,
+            ref_sd=ref_sd,
+        )
+        assert fanpt.inorm is True
+        assert fanpt.norm_det == [(ref_sd, 1.0)]
+
+
+def test_init_resum_requires_inactive_energy():
+    """resum=True with energy_active=True should error."""
+    fake_obj = FakeObjective(nequation=4, nactive=3, constraints=[], last_mask=False, ham=FakeHam())
+
+    with CtxEnv(fake_objective=fake_obj) as env:
+        with pytest.raises(ValueError, match="energy parameter must be inactive"):
+            FANPT(
+                fanpy_objective=env.fake_projected,
+                energy_nuc=0.0,
+                energy_active=True,
+                resum=True,
+            )
+
+
+def test_init_resum_branch_normalizes_or_removes_constraint():
+    """
+    resum=True & energy_active=False:
+      - if not inorm and nequation == nactive → norm_det is set
+      - if inorm and (nequation - 1) == nactive → constraint removed, inorm=False
+    """
+    # Case 1: not inorm, nequation == nactive
+    ham1 = FakeHam(0.0, np.eye(2), np.zeros((2, 2, 2, 2)))
+    ref_sd = 0
+    obj1 = FakeObjective(nequation=4, nactive=4, constraints=[], last_mask=False, ham=ham1)
+
+    with CtxEnv(fake_objective=obj1) as env1:
+        fanpt1 = FANPT(
+            fanpy_objective=env1.fake_projected,
+            energy_nuc=0.0,
+            energy_active=False,
+            resum=True,
+            ref_sd=ref_sd,
+        )
+        assert fanpt1.norm_det == [(ref_sd, 1.0)]
+        assert fanpt1.inorm is False
+
+    # Case 2: inorm, nequation - 1 == nactive, and constraint present for ref_sd=0
+    norm_str = f"<\\psi_{{{ref_sd}}}|\\Psi> - v_{{{ref_sd}}}"
+    obj2 = FakeObjective(nequation=5, nactive=4, constraints=[norm_str], last_mask=False, ham=ham1)
+
+    with CtxEnv(fake_objective=obj2) as env2:
+        fanpt2 = FANPT(
+            fanpy_objective=env2.fake_projected,
+            energy_nuc=0.0,
+            energy_active=False,
+            resum=True,
+            ref_sd=ref_sd,
+        )
+        assert norm_str in obj2.removed_constraints
+        assert fanpt2.inorm is False
+
+
+def test_optimize_toggles_freeze_when_energy_inactive():
+    """
+    energy_active=False:
+    - unfreeze before each FanCI solve, then freeze after,
+    - both at the initial solve and inside the lambda loop.
+    """
+    obj = FakeObjective(nequation=4, nactive=3, constraints=[], last_mask=False, ham=FakeHam())
+
+    with CtxEnv(fake_objective=obj) as env:
+        fanpt = FANPT(
+            fanpy_objective=env.fake_projected,
+            energy_nuc=0.0,
+            energy_active=False,
+            steps=1,
+        )
+
+        fanpt.optimize(guess_params=np.array([0.0, 0.0]), guess_energy=0.0)
+
+        # Initial solve: unfreeze → freeze; Loop solve: unfreeze → freeze
+        assert obj.unfrozen_calls >= 2
+        assert obj.frozen_calls   >= 2

--- a/tests/test_fanpt_fanpt.py
+++ b/tests/test_fanpt_fanpt.py
@@ -1,73 +1,115 @@
-# test_fanpt_fanpt.py  — Refactored to use a context manager (Option B)
-import numpy as np
-import types
-import pytest
+"""Tests for fanpy.fanpt.fanpt.FANPT."""
+
 from contextlib import ExitStack
 from unittest.mock import patch
+import types
+
+import numpy as np
+import pytest
 
 from fanpy.fanpt.fanpt import FANPT
-import fanpy.fanpt.fanpt as mod
+import fanpy.fanpt.fanpt as fanpt_module
 
 
-#
-# ---------- Tiny fakes ----------
-#
+N_SPINORB = 2
+FOCK_SENTINEL = 123.0
+DUMMY_WFN_VALUE = 7.0
+DUMMY_ENERGY = 11.5
+DUMMY_ECORE = 99.0
+
+
+def make_two_mo():
+    """Return a zero two-electron integral tensor."""
+    return np.zeros((N_SPINORB, N_SPINORB, N_SPINORB, N_SPINORB))
+
+
+def make_one_mo():
+    """Return a small identity one-electron integral matrix."""
+    return np.eye(N_SPINORB)
+
+
+def make_norm_constraint(ref_sd):
+    """Return the normalization constraint string used by FanCI."""
+    return f"<\\psi_{{{ref_sd}}}|\\Psi> - v_{{{ref_sd}}}"
+
 
 class FakeHam:
-    """Mock representation of a molecular Hamiltonian."""
+    """Minimal Hamiltonian object used by FANPT tests."""
+
     def __init__(self, ecore=0.0, one_mo=None, two_mo=None):
         self.ecore = ecore
-        self.one_mo = np.array(one_mo) if one_mo is not None else np.zeros((2, 2))
-        self.two_mo = np.array(two_mo) if two_mo is not None else np.zeros((2, 2, 2, 2))
+        self.one_mo = np.array(one_mo) if one_mo is not None else np.zeros((N_SPINORB, N_SPINORB))
+        self.two_mo = np.array(two_mo) if two_mo is not None else make_two_mo()
+
+
+class FakeOptimizeResult(dict):
+    """Minimal optimization result with scipy-like `.x` attribute."""
+
+    def __init__(self, x):
+        super().__init__()
+        self.x = x
 
 
 class FakeObjective:
-    """Mock objective class simulating FanCI's projected Schrödinger objective."""
-    def __init__(self, *, nequation=3, nactive=3, constraints=None, last_mask=False, ham=None, fill="full"):
+    """Minimal projected Schrödinger objective used by FANPT."""
+
+    def __init__(
+        self,
+        *,
+        nequation=3,
+        nactive=3,
+        constraints=None,
+        last_mask=False,
+        ham=None,
+        fill="full",
+    ):
         self.nequation = nequation
         self.nactive = nactive
-        # mask: True = active; last index corresponds to energy
+        self.constraints = list(constraints or [])
+        self.ham = ham or FakeHam(0.0, make_one_mo(), make_two_mo())
+        self.fill = fill
+
+        # FanCI convention: True means active. Last parameter is the energy.
         self.mask = np.zeros(nactive, dtype=bool)
         self.mask[-1] = last_mask
-        self.constraints = list(constraints or [])
-        self.ham = ham or FakeHam(0.0, np.eye(2), np.zeros((2, 2, 2, 2)))
-        self.fill = fill
-        # required by FANPT: .fanpy_objective.refwfn used when ref_sd is None
+
+        # Required by FANPT when ref_sd is not explicitly provided.
         self.fanpy_objective = types.SimpleNamespace(refwfn=0)
 
-        # counters for freeze/unfreeze/constraint removal
-        self.frozen_calls = 0
-        self.unfrozen_calls = 0
+        self.freeze_calls = 0
+        self.unfreeze_calls = 0
         self.removed_constraints = []
 
-    def freeze_parameter(self, idx):
-        assert idx == -1
-        self.frozen_calls += 1
-        self.mask[idx] = False
+    def freeze_parameter(self, index):
+        """Freeze the energy parameter."""
+        assert index == -1
+        self.freeze_calls += 1
+        self.mask[index] = False
 
-    def unfreeze_parameter(self, idx):
-        assert idx == -1
-        self.unfrozen_calls += 1
-        self.mask[idx] = True
+    def unfreeze_parameter(self, index):
+        """Unfreeze the energy parameter."""
+        assert index == -1
+        self.unfreeze_calls += 1
+        self.mask[index] = True
 
-    def remove_constraint(self, s):
-        self.removed_constraints.append(s)
-        try:
-            self.constraints.remove(s)
-        except ValueError:
-            pass
+    def remove_constraint(self, constraint):
+        """Remove a constraint if present."""
+        self.removed_constraints.append(constraint)
+
+        if constraint in self.constraints:
+            self.constraints.remove(constraint)
 
     def optimize(self, params, **kwargs):
-        # deterministic fake: return a result with `x` of length = number of active params
+        """Return deterministic active-parameter values."""
+        del params, kwargs
+
         active_count = int(self.mask.sum())
-        x = np.arange(active_count, dtype=float)
-        class Result(dict):
-            def __init__(self, x): super().__init__(); self.x = x
-        return Result(x)
+        return FakeOptimizeResult(np.arange(active_count, dtype=float))
 
 
 class FakePYCI:
-    """Mock PyCI interface class for FANPT testing."""
+    """Minimal PYCI interface wrapper."""
+
     def __init__(self, objective, energy_nuc, legacy_fanci=True):
         self.objective = objective
         self.energy_nuc = energy_nuc
@@ -75,82 +117,117 @@ class FakePYCI:
         self.update_calls = []
 
     def update_objective(self, ham):
+        """Record Hamiltonian updates."""
         self.update_calls.append(ham)
 
 
 class DummyContainer:
-    """Mock FANPT container (EParam/EFree) used in tests."""
+    """Minimal FANPT container replacement."""
+
     def __init__(self, **kwargs):
-        self.kwargs = kwargs  # record inputs for assertions
+        self.kwargs = kwargs
 
 
 class DummyUpdater:
-    """Mock FANPTUpdater for unit tests."""
-    def __init__(self, fanpt_container, final_order, final_l, solver, resum):
-        nactive = fanpt_container.kwargs["params"].size - 1
-        self.new_wfn_params = np.ones(nactive) * 7.0
-        self.new_energy = 11.5
-        self.new_ham = FakeHam(ecore=99.0, one_mo=np.eye(2), two_mo=np.zeros((2, 2, 2, 2)))
+    """Minimal FANPTUpdater replacement."""
+
+    def __init__(
+        self,
+        fanpt_container,
+        final_order,
+        final_l,
+        solver,
+        resum,
+        quasi_approximation_order=None,
+        **kwargs,
+    ):
+        del final_order, final_l, solver, resum, quasi_approximation_order, kwargs
+
+        nactive_wfn_params = fanpt_container.kwargs["params"].size - 1
+        self.new_wfn_params = np.full(nactive_wfn_params, DUMMY_WFN_VALUE)
+        self.new_energy = DUMMY_ENERGY
+        self.new_ham = FakeHam(DUMMY_ECORE, make_one_mo(), make_two_mo())
 
 
-#
-# ---------- Context-manager patching environment (Option B) ----------
-#
+def fake_reduce_to_fock(two_mo):
+    """Return a sentinel tensor so tests can verify reduce_to_fock was used."""
+    return np.full_like(two_mo, FOCK_SENTINEL)
 
-def _fake_reduce_to_fock(two_mo):
-    """Return a sentinel so tests can assert this was used."""
-    return np.full_like(two_mo, 123.0)
 
-class CtxEnv:
-    """Context manager that patches FANPT's dependencies to fakes."""
-    def __init__(self, fake_objective=None):
-        self.stack = ExitStack()
+class PatchedFANPTEnvironment:
+    """Patch FANPT dependencies with lightweight fakes."""
+
+    def __init__(self, objective=None):
+        self.objective = objective or FakeObjective()
         self.ham_calls = []
-        self.fake_objective = fake_objective or FakeObjective()
-        self.fake_projected = None  # set in __enter__
+        self.fake_projected = None
+        self._stack = ExitStack()
 
     def __enter__(self):
-        # Patch reduce_to_fock in fanpt module
-        self.stack.enter_context(patch.object(mod, "reduce_to_fock", _fake_reduce_to_fock))
-
-        # Patch pyci.hamiltonian inside fanpt module and record constructor calls
-        def _ham_ctor(ecore, one_mo, two_mo):
-            self.ham_calls.append((ecore, np.array(one_mo), np.array(two_mo)))
-            return FakeHam(ecore, one_mo, two_mo)
-        self.stack.enter_context(patch.object(mod.pyci, "hamiltonian", _ham_ctor))
-
-        # Patch PYCI constructor to return our FakePYCI holding self.fake_objective
-        def _fake_PYCI(fanpy_objective, energy_nuc, legacy_fanci=True):
-            return FakePYCI(self.fake_objective, energy_nuc, legacy_fanci=legacy_fanci)
-        self.stack.enter_context(patch.object(mod.fanpy.interface.pyci, "PYCI", _fake_PYCI))
-
-        # Patch container classes + updater
-        self.stack.enter_context(patch.object(mod, "FANPTContainerEParam", DummyContainer))
-        self.stack.enter_context(patch.object(mod, "FANPTContainerEFree",  DummyContainer))
-        self.stack.enter_context(patch.object(mod, "FANPTUpdater",         DummyUpdater))
-
-        # Patch ProjectedSchrodinger and create a fake instance
-        class _FakeProjectedSchrodinger: pass
-        self.stack.enter_context(patch.object(mod, "ProjectedSchrodinger", _FakeProjectedSchrodinger))
-        self.fake_projected = _FakeProjectedSchrodinger()
-
+        self._patch_reduce_to_fock()
+        self._patch_hamiltonian_constructor()
+        self._patch_pyci_interface()
+        self._patch_fanpt_components()
+        self._patch_projected_schrodinger()
         return self
 
-    def __exit__(self, exc_type, exc, tb):
-        self.stack.close()
+    def __exit__(self, exc_type, exc, traceback):
+        self._stack.close()
 
+    def _patch_reduce_to_fock(self):
+        self._stack.enter_context(
+            patch.object(fanpt_module, "reduce_to_fock", fake_reduce_to_fock)
+        )
 
-#
-# ---------- Tests ----------
-#
+    def _patch_hamiltonian_constructor(self):
+        def fake_hamiltonian(ecore, one_mo, two_mo):
+            self.ham_calls.append((ecore, np.array(one_mo), np.array(two_mo)))
+            return FakeHam(ecore, one_mo, two_mo)
+
+        self._stack.enter_context(
+            patch.object(fanpt_module.pyci, "hamiltonian", fake_hamiltonian)
+        )
+
+    def _patch_pyci_interface(self):
+        def fake_pyci(fanpy_objective, energy_nuc, legacy_fanci=True):
+            del fanpy_objective
+            return FakePYCI(self.objective, energy_nuc, legacy_fanci=legacy_fanci)
+
+        self._stack.enter_context(
+            patch.object(fanpt_module.fanpy.interface.pyci, "PYCI", fake_pyci)
+        )
+
+    def _patch_fanpt_components(self):
+        patches = [
+            ("FANPTContainerEParam", DummyContainer),
+            ("FANPTContainerEFree", DummyContainer),
+            ("FANPTUpdater", DummyUpdater),
+        ]
+
+        for name, replacement in patches:
+            self._stack.enter_context(patch.object(fanpt_module, name, replacement))
+
+    def _patch_projected_schrodinger(self):
+        class FakeProjectedSchrodinger:
+            pass
+
+        self._stack.enter_context(
+            patch.object(fanpt_module, "ProjectedSchrodinger", FakeProjectedSchrodinger)
+        )
+        self.fake_projected = FakeProjectedSchrodinger()
+
 
 def test_init_selects_eparam_and_unfreezes_energy():
-    """energy_active=True → use EParam, unfreeze energy if last mask is False, build ham0 via reduce_to_fock."""
-    fake_obj = FakeObjective(nequation=4, nactive=3, constraints=[], last_mask=False, ham=FakeHam(
-        ecore=0.5, one_mo=np.eye(2), two_mo=np.zeros((2, 2, 2, 2))
-    ))
+    """energy_active=True uses EParam and unfreezes inactive energy."""
+    objective = FakeObjective(
+        nequation=4,
+        nactive=3,
+        constraints=[],
+        last_mask=False,
+        ham=FakeHam(0.5, make_one_mo(), make_two_mo()),
+    )
 
-    with CtxEnv(fake_objective=fake_obj) as env:
+    with PatchedFANPTEnvironment(objective) as env:
         fanpt = FANPT(
             fanpy_objective=env.fake_projected,
             energy_nuc=1.234,
@@ -161,25 +238,28 @@ def test_init_selects_eparam_and_unfreezes_energy():
             steps=1,
         )
 
-        # container class chosen
-        assert fanpt.fanpt_container_class is DummyContainer
-        # energy unfreezing happened (last mask was False initially)
-        assert fake_obj.unfrozen_calls == 1
+    assert fanpt.fanpt_container_class is DummyContainer
+    assert objective.unfreeze_calls == 1
 
-        # ham0 built via pyci.hamiltonian with reduced two-electron integrals
-        assert len(env.ham_calls) == 1
-        ecore, one_mo, two_mo = env.ham_calls[0]
-        assert np.all(two_mo == 123.0)  # reduce_to_fock sentinel
-        assert fanpt.ham1 is fake_obj.ham
-        assert isinstance(fanpt.ham0, FakeHam)
+    assert len(env.ham_calls) == 1
+    _, _, two_mo = env.ham_calls[0]
+    assert np.all(two_mo == FOCK_SENTINEL)
+
+    assert fanpt.ham1 is objective.ham
+    assert isinstance(fanpt.ham0, FakeHam)
 
 
 def test_init_selects_efree_and_freezes_energy_when_active():
-    """energy_active=False → use EFree, freeze energy if mask[-1] is True."""
-    # last_mask=True triggers freeze in EFree branch
-    fake_obj = FakeObjective(nequation=4, nactive=3, constraints=[], last_mask=True, ham=FakeHam())
+    """energy_active=False uses EFree and freezes active energy."""
+    objective = FakeObjective(
+        nequation=4,
+        nactive=3,
+        constraints=[],
+        last_mask=True,
+        ham=FakeHam(),
+    )
 
-    with CtxEnv(fake_objective=fake_obj) as env:
+    with PatchedFANPTEnvironment(objective) as env:
         fanpt = FANPT(
             fanpy_objective=env.fake_projected,
             energy_nuc=2.0,
@@ -187,35 +267,46 @@ def test_init_selects_efree_and_freezes_energy_when_active():
             ref_sd=0,
         )
 
-        assert fanpt.fanpt_container_class is DummyContainer
-        assert fake_obj.frozen_calls == 1
+    assert fanpt.fanpt_container_class is DummyContainer
+    assert objective.freeze_calls == 1
 
 
 def test_init_inorm_detection_and_norm_det_assignment():
-    """Detects normalization constraint and sets inorm/norm_det accordingly."""
+    """FANPT detects the normalization constraint and sets norm_det."""
     ref_sd = 2
-    norm_str = f"<\\psi_{{{ref_sd}}}|\\Psi> - v_{{{ref_sd}}}"
-    fake_obj = FakeObjective(
-        nequation=4, nactive=3, constraints=[norm_str], last_mask=False,
-        ham=FakeHam(0.0, np.eye(2), np.zeros((2, 2, 2, 2)))
+    norm_constraint = make_norm_constraint(ref_sd)
+
+    objective = FakeObjective(
+        nequation=4,
+        nactive=3,
+        constraints=[norm_constraint],
+        last_mask=False,
+        ham=FakeHam(0.0, make_one_mo(), make_two_mo()),
     )
 
-    with CtxEnv(fake_objective=fake_obj) as env:
+    with PatchedFANPTEnvironment(objective) as env:
         fanpt = FANPT(
             fanpy_objective=env.fake_projected,
             energy_nuc=0.0,
             energy_active=True,
             ref_sd=ref_sd,
         )
-        assert fanpt.inorm is True
-        assert fanpt.norm_det == [(ref_sd, 1.0)]
+
+    assert fanpt.inorm is True
+    assert fanpt.norm_det == [(ref_sd, 1.0)]
 
 
 def test_init_resum_requires_inactive_energy():
-    """resum=True with energy_active=True should error."""
-    fake_obj = FakeObjective(nequation=4, nactive=3, constraints=[], last_mask=False, ham=FakeHam())
+    """resum=True requires energy_active=False."""
+    objective = FakeObjective(
+        nequation=4,
+        nactive=3,
+        constraints=[],
+        last_mask=False,
+        ham=FakeHam(),
+    )
 
-    with CtxEnv(fake_objective=fake_obj) as env:
+    with PatchedFANPTEnvironment(objective) as env:
         with pytest.raises(ValueError, match="energy parameter must be inactive"):
             FANPT(
                 fanpy_objective=env.fake_projected,
@@ -225,53 +316,67 @@ def test_init_resum_requires_inactive_energy():
             )
 
 
-def test_init_resum_branch_normalizes_or_removes_constraint():
-    """
-    resum=True & energy_active=False:
-      - if not inorm and nequation == nactive → norm_det is set
-      - if inorm and (nequation - 1) == nactive → constraint removed, inorm=False
-    """
-    # Case 1: not inorm, nequation == nactive
-    ham1 = FakeHam(0.0, np.eye(2), np.zeros((2, 2, 2, 2)))
+def test_init_resum_sets_norm_det_when_no_constraint_and_square_system():
+    """resum=True sets norm_det when no explicit normalization constraint exists."""
     ref_sd = 0
-    obj1 = FakeObjective(nequation=4, nactive=4, constraints=[], last_mask=False, ham=ham1)
+    objective = FakeObjective(
+        nequation=4,
+        nactive=4,
+        constraints=[],
+        last_mask=False,
+        ham=FakeHam(0.0, make_one_mo(), make_two_mo()),
+    )
 
-    with CtxEnv(fake_objective=obj1) as env1:
-        fanpt1 = FANPT(
-            fanpy_objective=env1.fake_projected,
+    with PatchedFANPTEnvironment(objective) as env:
+        fanpt = FANPT(
+            fanpy_objective=env.fake_projected,
             energy_nuc=0.0,
             energy_active=False,
             resum=True,
             ref_sd=ref_sd,
         )
-        assert fanpt1.norm_det == [(ref_sd, 1.0)]
-        assert fanpt1.inorm is False
 
-    # Case 2: inorm, nequation - 1 == nactive, and constraint present for ref_sd=0
-    norm_str = f"<\\psi_{{{ref_sd}}}|\\Psi> - v_{{{ref_sd}}}"
-    obj2 = FakeObjective(nequation=5, nactive=4, constraints=[norm_str], last_mask=False, ham=ham1)
+    assert fanpt.norm_det == [(ref_sd, 1.0)]
+    assert fanpt.inorm is False
 
-    with CtxEnv(fake_objective=obj2) as env2:
-        fanpt2 = FANPT(
-            fanpy_objective=env2.fake_projected,
+
+def test_init_resum_removes_norm_constraint_when_overdetermined_by_one():
+    """resum=True removes explicit normalization when nequation - 1 == nactive."""
+    ref_sd = 0
+    norm_constraint = make_norm_constraint(ref_sd)
+
+    objective = FakeObjective(
+        nequation=5,
+        nactive=4,
+        constraints=[norm_constraint],
+        last_mask=False,
+        ham=FakeHam(0.0, make_one_mo(), make_two_mo()),
+    )
+
+    with PatchedFANPTEnvironment(objective) as env:
+        fanpt = FANPT(
+            fanpy_objective=env.fake_projected,
             energy_nuc=0.0,
             energy_active=False,
             resum=True,
             ref_sd=ref_sd,
         )
-        assert norm_str in obj2.removed_constraints
-        assert fanpt2.inorm is False
+
+    assert norm_constraint in objective.removed_constraints
+    assert fanpt.inorm is False
 
 
 def test_optimize_toggles_freeze_when_energy_inactive():
-    """
-    energy_active=False:
-    - unfreeze before each FanCI solve, then freeze after,
-    - both at the initial solve and inside the lambda loop.
-    """
-    obj = FakeObjective(nequation=4, nactive=3, constraints=[], last_mask=False, ham=FakeHam())
+    """energy_active=False temporarily unfreezes energy during FanCI solves."""
+    objective = FakeObjective(
+        nequation=4,
+        nactive=3,
+        constraints=[],
+        last_mask=False,
+        ham=FakeHam(),
+    )
 
-    with CtxEnv(fake_objective=obj) as env:
+    with PatchedFANPTEnvironment(objective) as env:
         fanpt = FANPT(
             fanpy_objective=env.fake_projected,
             energy_nuc=0.0,
@@ -279,8 +384,10 @@ def test_optimize_toggles_freeze_when_energy_inactive():
             steps=1,
         )
 
-        fanpt.optimize(guess_params=np.array([0.0, 0.0]), guess_energy=0.0)
+        fanpt.optimize(
+            guess_params=np.array([0.0, 0.0]),
+            guess_energy=0.0,
+        )
 
-        # Initial solve: unfreeze → freeze; Loop solve: unfreeze → freeze
-        assert obj.unfrozen_calls >= 2
-        assert obj.frozen_calls   >= 2
+    assert objective.unfreeze_calls >= 2
+    assert objective.freeze_calls >= 2

--- a/tests/test_fanpt_fanpt.py
+++ b/tests/test_fanpt_fanpt.py
@@ -7,7 +7,6 @@ import types
 import numpy as np
 import pytest
 
-from fanpy.fanpt.fanpt import FANPT
 import fanpy.fanpt.fanpt as fanpt_module
 
 
@@ -228,7 +227,7 @@ def test_init_selects_eparam_and_unfreezes_energy():
     )
 
     with PatchedFANPTEnvironment(objective) as env:
-        fanpt = FANPT(
+        fanpt = fanpt_module.FANPT(
             fanpy_objective=env.fake_projected,
             energy_nuc=1.234,
             legacy_fanci=False,
@@ -260,7 +259,7 @@ def test_init_selects_efree_and_freezes_energy_when_active():
     )
 
     with PatchedFANPTEnvironment(objective) as env:
-        fanpt = FANPT(
+        fanpt = fanpt_module.FANPT(
             fanpy_objective=env.fake_projected,
             energy_nuc=2.0,
             energy_active=False,
@@ -285,7 +284,7 @@ def test_init_inorm_detection_and_norm_det_assignment():
     )
 
     with PatchedFANPTEnvironment(objective) as env:
-        fanpt = FANPT(
+        fanpt = fanpt_module.FANPT(
             fanpy_objective=env.fake_projected,
             energy_nuc=0.0,
             energy_active=True,
@@ -308,7 +307,7 @@ def test_init_resum_requires_inactive_energy():
 
     with PatchedFANPTEnvironment(objective) as env:
         with pytest.raises(ValueError, match="energy parameter must be inactive"):
-            FANPT(
+            fanpt_module.FANPT(
                 fanpy_objective=env.fake_projected,
                 energy_nuc=0.0,
                 energy_active=True,
@@ -328,7 +327,7 @@ def test_init_resum_sets_norm_det_when_no_constraint_and_square_system():
     )
 
     with PatchedFANPTEnvironment(objective) as env:
-        fanpt = FANPT(
+        fanpt = fanpt_module.FANPT(
             fanpy_objective=env.fake_projected,
             energy_nuc=0.0,
             energy_active=False,
@@ -354,7 +353,7 @@ def test_init_resum_removes_norm_constraint_when_overdetermined_by_one():
     )
 
     with PatchedFANPTEnvironment(objective) as env:
-        fanpt = FANPT(
+        fanpt = fanpt_module.FANPT(
             fanpy_objective=env.fake_projected,
             energy_nuc=0.0,
             energy_active=False,
@@ -377,7 +376,7 @@ def test_optimize_toggles_freeze_when_energy_inactive():
     )
 
     with PatchedFANPTEnvironment(objective) as env:
-        fanpt = FANPT(
+        fanpt = fanpt_module.FANPT(
             fanpy_objective=env.fake_projected,
             energy_nuc=0.0,
             energy_active=False,


### PR DESCRIPTION
## Description

This PR updates and expands the FANPT test suite.

The existing `tests/test_fanpt.py` tests have been updated to use the newer PyCI/FanCI interface instead of the older `convert_to_fanci` workflow. The refactor now constructs the projected Schrödinger objective through `ProjectedSchrodinger`, builds the PyCI interface with `legacy_fanci=False`, and evaluates overlaps/objectives through the updated interface.

In addition, this PR adds several new unit test files for the FANPT container and updater components:

* `test_fanpt_container_base.py`
* `test_fanpt_container_constant_terms.py`
* `test_fanpt_container_energy_free.py`
* `test_fanpt_container_energy_param.py`
* `test_fanpt_container_updater.py`
* `test_fanpt_fanpt.py`

These tests use lightweight mock objects and monkeypatching to isolate FANPT logic from the full PyCI/FanCI backend where possible. The new tests cover container initialization behavior, derivative generation, constant-term construction, active-energy and energy-free branches, updater behavior, and high-level FANPT workflow logic.

## Main Changes

* Updated outdated FANPT tests to use the new PyCI interface.
* Removed dependence on the older `convert_to_fanci` path in the affected tests.
* Added unit tests for FANPT base container behavior.
* Added tests for FANPT constant-term generation.
* Added tests for energy-parameter and energy-free FANPT containers.
* Added tests for FANPT updater behavior.
* Added high-level tests for the FANPT driver logic using mocked dependencies.

## Motivation

The FANPT tests were outdated relative to the current PyCI/FanCI interface. This PR brings the tests closer to the current code structure and adds more focused coverage for the FANPT container and updater modules. The added tests should make future refactoring safer by checking the main derivative, constant-term, and update pathways independently.

## Notes

Some tests use simplified mock objects rather than full molecular calculations. This is intentional: the goal is to test FANPT control flow and algebraic behavior without requiring the full backend setup for every unit test.
