### PR TITLE
fix: constant_terms.py qao=3 issue

### DIFF
--- a/fanpy/fanpt/containers/constant_terms.py
+++ b/fanpy/fanpt/containers/constant_terms.py
@@ -226,7 +226,7 @@ class FANPTConstantTerms:
                             * np.einsum(
                                 "mkl,k,l->m",
                                 self.fanpt_container.d3_g_e_wfnparams2,
-                                self.previous_responses[1][:-1],
+                                self.previous_responses[0][:-1],
                                 self.previous_responses[0][:-1],
                             )
                         )


### PR DESCRIPTION
This PR fixes the third-order QAO3 active-energy constant-term generation in `gen_constant_terms`.

Previously, the `d3_g_e_wfnparams2` contribution for `order == 3` was contracted with the second-order and first-order wavefunction responses, corresponding to `G_Epp * p2 * p1 * E1`. This was incorrect. The third-order FANPT expression requires this term to be contracted with two first-order wavefunction responses, corresponding to `G_Epp * p1 * p1 * E1`.

The fix replaces the incorrect `previous_responses[1][:-1]` response vector with `previous_responses[0][:-1]` in the `d3_g_e_wfnparams2` contraction.
